### PR TITLE
Provide LatticeClassIds via FirSession extension property

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/LatticeFirBuiltIns.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/LatticeFirBuiltIns.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.zacsweers.lattice.fir
+
+import dev.zacsweers.lattice.LatticeClassIds
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.extensions.FirExtensionSessionComponent
+
+internal class LatticeFirBuiltIns(session: FirSession, val latticeClassIds: LatticeClassIds) :
+  FirExtensionSessionComponent(session) {
+  companion object {
+    fun getFactory(latticeClassIds: LatticeClassIds) = Factory { session ->
+      LatticeFirBuiltIns(session, latticeClassIds)
+    }
+  }
+}
+
+internal val FirSession.latticeFirBuiltIns: LatticeFirBuiltIns by
+  FirSession.sessionComponentAccessor()
+internal val FirSession.latticeClassIds: LatticeClassIds
+  get() = latticeFirBuiltIns.latticeClassIds

--- a/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/LatticeFirExtensionRegistrar.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/LatticeFirExtensionRegistrar.kt
@@ -30,31 +30,18 @@ import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 internal class LatticeFirExtensionRegistrar(private val latticeClassIds: LatticeClassIds) :
   FirExtensionRegistrar() {
   override fun ExtensionRegistrarContext.configurePlugin() {
-    +LatticeFirCheckers.getFactory(latticeClassIds)
+    +LatticeFirBuiltIns.getFactory(latticeClassIds)
+    +::LatticeFirCheckers
   }
 }
 
-internal class LatticeFirCheckers(
-  session: FirSession,
-  private val latticeClassIds: LatticeClassIds,
-) : FirAdditionalCheckersExtension(session) {
-  companion object {
-    fun getFactory(latticeClassIds: LatticeClassIds) = Factory { session ->
-      LatticeFirCheckers(session, latticeClassIds)
-    }
-  }
-
+internal class LatticeFirCheckers(session: FirSession) : FirAdditionalCheckersExtension(session) {
   override val declarationCheckers: DeclarationCheckers =
     object : DeclarationCheckers() {
       override val classCheckers: Set<FirClassChecker>
-        get() =
-          setOf(
-            InjectConstructorChecker(session, latticeClassIds),
-            AssistedInjectChecker(session, latticeClassIds),
-            ComponentCreatorChecker(session, latticeClassIds),
-          )
+        get() = setOf(InjectConstructorChecker, AssistedInjectChecker, ComponentCreatorChecker)
 
       override val callableDeclarationCheckers: Set<FirCallableDeclarationChecker>
-        get() = setOf(ProvidesChecker(session, latticeClassIds))
+        get() = setOf(ProvidesChecker)
     }
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/checkers/AssistedInjectChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/checkers/AssistedInjectChecker.kt
@@ -23,6 +23,7 @@ import dev.zacsweers.lattice.fir.annotationsIn
 import dev.zacsweers.lattice.fir.checkers.AssistedInjectChecker.FirAssistedParameterKey.Companion.toAssistedParameterKey
 import dev.zacsweers.lattice.fir.findInjectConstructor
 import dev.zacsweers.lattice.fir.isAnnotatedWithAny
+import dev.zacsweers.lattice.fir.latticeClassIds
 import dev.zacsweers.lattice.fir.singleAbstractFunction
 import dev.zacsweers.lattice.fir.validateFactoryClass
 import dev.zacsweers.lattice.mapToSetWithDupes
@@ -38,12 +39,11 @@ import org.jetbrains.kotlin.fir.declarations.getStringArgument
 import org.jetbrains.kotlin.fir.resolve.firClassLike
 import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 
-internal class AssistedInjectChecker(
-  private val session: FirSession,
-  private val latticeClassIds: LatticeClassIds,
-) : FirClassChecker(MppCheckerKind.Common) {
+internal object AssistedInjectChecker : FirClassChecker(MppCheckerKind.Common) {
   override fun check(declaration: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
     val source = declaration.source ?: return
+    val session = context.session
+    val latticeClassIds = session.latticeClassIds
 
     // Check if this is an assisted factory
     val isAssistedFactory =

--- a/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/checkers/ComponentCreatorChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/checkers/ComponentCreatorChecker.kt
@@ -15,28 +15,21 @@
  */
 package dev.zacsweers.lattice.fir.checkers
 
-import dev.zacsweers.lattice.LatticeClassIds
-import dev.zacsweers.lattice.fir.FirLatticeErrors
-import dev.zacsweers.lattice.fir.FirTypeKey
-import dev.zacsweers.lattice.fir.annotationsIn
-import dev.zacsweers.lattice.fir.isAnnotatedWithAny
-import dev.zacsweers.lattice.fir.singleAbstractFunction
-import dev.zacsweers.lattice.fir.validateFactoryClass
+import dev.zacsweers.lattice.fir.*
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
-import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.resolve.firClassLike
 
-internal class ComponentCreatorChecker(
-  private val session: FirSession,
-  private val latticeClassIds: LatticeClassIds,
-) : FirClassChecker(MppCheckerKind.Common) {
+internal object ComponentCreatorChecker : FirClassChecker(MppCheckerKind.Common) {
   override fun check(declaration: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
     declaration.source ?: return
+    val session = context.session
+    val latticeClassIds = session.latticeClassIds
+
     val componentFactoryAnnotation =
       declaration.annotationsIn(session, latticeClassIds.componentFactoryAnnotations).toList()
 

--- a/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/checkers/InjectConstructorChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/checkers/InjectConstructorChecker.kt
@@ -15,27 +15,21 @@
  */
 package dev.zacsweers.lattice.fir.checkers
 
-import dev.zacsweers.lattice.LatticeClassIds
-import dev.zacsweers.lattice.fir.FirLatticeErrors
-import dev.zacsweers.lattice.fir.annotationsIn
-import dev.zacsweers.lattice.fir.findInjectConstructor
-import dev.zacsweers.lattice.fir.validateInjectedClass
-import dev.zacsweers.lattice.fir.validateVisibility
+import dev.zacsweers.lattice.fir.*
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
-import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.primaryConstructorIfAny
 
-internal class InjectConstructorChecker(
-  private val session: FirSession,
-  private val latticeClassIds: LatticeClassIds,
-) : FirClassChecker(MppCheckerKind.Common) {
+internal object InjectConstructorChecker : FirClassChecker(MppCheckerKind.Common) {
   override fun check(declaration: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
     declaration.source ?: return
+    val session = context.session
+    val latticeClassIds = session.latticeClassIds
+
     val classInjectAnnotation =
       declaration.annotationsIn(session, latticeClassIds.injectAnnotations).toList()
 

--- a/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/checkers/ProvidesChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/lattice/fir/checkers/ProvidesChecker.kt
@@ -15,14 +15,13 @@
  */
 package dev.zacsweers.lattice.fir.checkers
 
-import dev.zacsweers.lattice.LatticeClassIds
 import dev.zacsweers.lattice.fir.FirLatticeErrors
 import dev.zacsweers.lattice.fir.FirTypeKey
 import dev.zacsweers.lattice.fir.isAnnotatedWithAny
+import dev.zacsweers.lattice.fir.latticeClassIds
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
-import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirCallableDeclarationChecker
@@ -38,16 +37,15 @@ import org.jetbrains.kotlin.fir.types.renderReadableWithFqNames
 //  some of this changes if we reuse this for `@Binds`
 //  What about future Kotlin versions where you can have different get signatures
 //  Make visibility error configurable? ERROR/WARN/NONE
-internal class ProvidesChecker(
-  private val session: FirSession,
-  private val latticeClassIds: LatticeClassIds,
-) : FirCallableDeclarationChecker(MppCheckerKind.Common) {
+internal object ProvidesChecker : FirCallableDeclarationChecker(MppCheckerKind.Common) {
   override fun check(
     declaration: FirCallableDeclaration,
     context: CheckerContext,
     reporter: DiagnosticReporter,
   ) {
     val source = declaration.source ?: return
+    val session = context.session
+    val latticeClassIds = session.latticeClassIds
 
     if (!declaration.isAnnotatedWithAny(session, latticeClassIds.providesAnnotations)) {
       return


### PR DESCRIPTION
A little FIR extension cleanup before I start in on an `FirStatusTransformerExtension` implementation.