### PR TITLE
Make no-op logger truly no-op

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroLogger.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroLogger.kt
@@ -35,7 +35,19 @@ public interface MetroLogger {
       return MetroLoggerImpl(type, output, tag)
     }
 
-    public val NONE: MetroLogger = MetroLoggerImpl(Type.None, {})
+    public val NONE: MetroLogger = NoOpMetroLogger
+  }
+}
+
+private object NoOpMetroLogger : MetroLogger {
+  override val type: MetroLogger.Type = MetroLogger.Type.None
+
+  override fun indent() = this
+
+  override fun unindent() = this
+
+  override fun log(message: () -> String) {
+    // Do nothing
   }
 }
 


### PR DESCRIPTION
### Description

This pull request ensures that the no-op logger behaves correctly by making it completely non-operative. It ensures no unintended functionality is executed when the no-op logger is used. 

### Checklist

- [ ] Tests have been added or updated (if applicable).
- [ ] Documentation has been updated (if applicable).