### PR TITLE
Fix wrapper type string formatting in FirContextualTypeKey

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirContextualTypeKey.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirContextualTypeKey.kt
@@ -41,7 +41,7 @@ internal class FirContextualTypeKey(
       when {
         isWrappedInProvider -> "Provider"
         isWrappedInLazy -> "Lazy"
-        isLazyWrappedInProvider -> "Provider<Lazy<"
+        isLazyWrappedInProvider -> "Provider<Lazy"
         else -> null
       }
     if (wrapperType != null) {


### PR DESCRIPTION
Fixes an issue with extra "<" like `Provider<Lazy<<T>>` when isLazyWrappedInProvider type.