### PR TITLE
Rename BoundType -> binding

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
@@ -789,7 +789,7 @@ internal fun FirAnnotation.excludesArgument() =
   argumentAsOrNull<FirArrayLiteral>("excludes".asName(), index = 2)
 
 internal fun FirAnnotation.replacesArgument() =
-  argumentAsOrNull<FirArrayLiteral>("replaces".asName(), index = 1)
+  argumentAsOrNull<FirArrayLiteral>("replaces".asName(), index = 2)
 
 internal fun FirAnnotation.bindingArgument() = annotationArgument("binding".asName(), index = 1)
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
@@ -791,18 +791,18 @@ internal fun FirAnnotation.excludesArgument() =
 internal fun FirAnnotation.replacesArgument() =
   argumentAsOrNull<FirArrayLiteral>("replaces".asName(), index = 1)
 
-internal fun FirAnnotation.boundTypeArgument() = annotationArgument("boundType".asName(), index = 2)
+internal fun FirAnnotation.bindingArgument() = annotationArgument("binding".asName(), index = 1)
 
-internal fun FirAnnotation.resolvedBoundType(session: FirSession): FirTypeRef? {
-  // Return a BoundType defined using metro api's
-  boundTypeArgument()?.let { boundType ->
-    return boundType.typeArguments[0].expectAsOrNull<FirTypeProjectionWithVariance>()?.typeRef
+internal fun FirAnnotation.resolvedBindingArgument(session: FirSession): FirTypeRef? {
+  // Return a binding defined using Metro's API
+  bindingArgument()?.let { binding ->
+    return binding.typeArguments[0].expectAsOrNull<FirTypeProjectionWithVariance>()?.typeRef
   }
-  // Return a boundType defined using anvil KClass
-  return kClassBoundTypeArgument(session)
+  // Anvil interop - try a boundType defined using anvil KClass
+  return anvilKClassBoundTypeArgument(session)
 }
 
-internal fun FirAnnotation.kClassBoundTypeArgument(session: FirSession): FirTypeRef? {
+internal fun FirAnnotation.anvilKClassBoundTypeArgument(session: FirSession): FirTypeRef? {
   return getAnnotationKClassArgument("boundType".asName(), session)?.toFirResolvedTypeRef()
 }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AggregationTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AggregationTest.kt
@@ -227,7 +227,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesBinding(
             AppScope::class,
-            boundType = BoundType<ContributedInterface>()
+            binding<ContributedInterface>()
           )
           @Inject
           class Impl : ContributedInterface, AnotherInterface
@@ -257,11 +257,11 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesBinding(
             AppScope::class,
-            boundType = BoundType<ContributedInterface>()
+            binding<ContributedInterface>()
           )
           @ContributesBinding(
             AppScope::class,
-            boundType = BoundType<AnotherInterface>()
+            binding<AnotherInterface>()
           )
           @Inject
           class Impl : ContributedInterface, AnotherInterface
@@ -295,7 +295,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesBinding(
             AppScope::class,
-            boundType = BoundType<@Named("hello") ContributedInterface>()
+            binding<@Named("hello") ContributedInterface>()
           )
           @Inject
           class Impl : ContributedInterface, AnotherInterface
@@ -325,7 +325,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesBinding(
             AppScope::class,
-            boundType = BoundType<ContributedInterface<String>>()
+            binding<ContributedInterface<String>>()
           )
           @Inject
           class Impl : ContributedInterface<String>
@@ -355,7 +355,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesBinding(
             AppScope::class,
-            boundType = BoundType<@Named("named") ContributedInterface<String>>()
+            binding<@Named("named") ContributedInterface<String>>()
           )
           @Inject
           class Impl : ContributedInterface<String>
@@ -513,7 +513,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesIntoSet(
             AppScope::class,
-            boundType = BoundType<ContributedInterface>()
+            binding<ContributedInterface>()
           )
           @Inject
           class Impl : ContributedInterface, AnotherInterface
@@ -544,7 +544,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesIntoSet(
             AppScope::class,
-            boundType = BoundType<@Named("hello") ContributedInterface>()
+            binding<@Named("hello") ContributedInterface>()
           )
           @Inject
           class Impl : ContributedInterface, AnotherInterface
@@ -575,7 +575,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesIntoSet(
             AppScope::class,
-            boundType = BoundType<ContributedInterface<String>>()
+            binding<ContributedInterface<String>>()
           )
           @Inject
           class Impl : ContributedInterface<String>
@@ -606,7 +606,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesIntoSet(
             AppScope::class,
-            boundType = BoundType<@Named("named") ContributedInterface<String>>()
+            binding<@Named("named") ContributedInterface<String>>()
           )
           @Inject
           class Impl : ContributedInterface<String>
@@ -773,7 +773,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesIntoMap(
             AppScope::class,
-            boundType = BoundType<@ClassKey(Impl::class) ContributedInterface>()
+            binding<@ClassKey(Impl::class) ContributedInterface>()
           )
           @Inject
           class Impl : ContributedInterface, AnotherInterface
@@ -805,7 +805,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesIntoMap(
             AppScope::class,
-            boundType = BoundType<@ClassKey(Impl::class) @Named("hello") ContributedInterface>()
+            binding<@ClassKey(Impl::class) @Named("hello") ContributedInterface>()
           )
           @Inject
           class Impl : ContributedInterface, AnotherInterface
@@ -837,7 +837,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesIntoMap(
             AppScope::class,
-            boundType = BoundType<@ClassKey(Impl::class) ContributedInterface<String>>()
+            binding<@ClassKey(Impl::class) ContributedInterface<String>>()
           )
           @Inject
           class Impl : ContributedInterface<String>
@@ -869,7 +869,7 @@ class AggregationTest : MetroCompilerTest() {
 
           @ContributesIntoMap(
             AppScope::class,
-            boundType = BoundType<@ClassKey(Impl::class) @Named("named") ContributedInterface<String>>()
+            binding<@ClassKey(Impl::class) @Named("named") ContributedInterface<String>>()
           )
           @Inject
           class Impl : ContributedInterface<String>
@@ -961,8 +961,8 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<ContributedInterface>())
-          @ContributesBinding(AppScope::class, boundType = BoundType<ContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<ContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
 
@@ -990,8 +990,8 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<@Named("1") ContributedInterface>())
-          @ContributesBinding(AppScope::class, boundType = BoundType<@Named("1") ContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<@Named("1") ContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<@Named("1") ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
 
@@ -1019,8 +1019,8 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<@Named("1") ContributedInterface>())
-          @ContributesBinding(AppScope::class, boundType = BoundType<@Named("2") ContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<@Named("1") ContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<@Named("2") ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
 
@@ -1051,7 +1051,7 @@ class AggregationTest : MetroCompilerTest() {
           interface ContributedInterface
 
           @ContributesBinding(AppScope::class)
-          @ContributesBinding(AppScope::class, boundType = BoundType<@Named("2") ContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<@Named("2") ContributedInterface>())
           @Named("1")
           @Inject
           class Impl : ContributedInterface
@@ -1148,6 +1148,7 @@ class AggregationTest : MetroCompilerTest() {
     }
   }
 
+  // TODO loosen this restriction
   @Test
   fun `explicit bound types don't use class qualifier - ContributesBinding`() {
     compile(
@@ -1155,7 +1156,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<ContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<ContributedInterface>())
           @Named("1")
           @Inject
           class Impl : ContributedInterface
@@ -1188,7 +1189,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<ContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<ContributedInterface>())
           @ContributesBinding(AppScope::class)
           @Inject
           class Impl : ContributedInterface
@@ -1211,13 +1212,13 @@ class AggregationTest : MetroCompilerTest() {
   }
 
   @Test
-  fun `boundType as Nothing is an error - ContributesBinding`() {
+  fun `binding as Nothing is an error - ContributesBinding`() {
     compile(
       source(
         """
           interface ContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<Nothing>())
+          @ContributesBinding(AppScope::class, binding<Nothing>())
           @Inject
           class Impl : ContributedInterface
 
@@ -1229,19 +1230,19 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 Explicit bound types should not be `Nothing` or `Nothing?`."
+        "e: ContributedInterface.kt:9:46 Explicit bound types should not be `Nothing` or `Nothing?`."
       )
     }
   }
 
   @Test
-  fun `boundType can be Any - ContributesBinding`() {
+  fun `binding can be Any - ContributesBinding`() {
     compile(
       source(
         """
           interface ContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<Any>())
+          @ContributesBinding(AppScope::class, binding<Any>())
           @Inject
           class Impl : ContributedInterface
 
@@ -1254,13 +1255,13 @@ class AggregationTest : MetroCompilerTest() {
   }
 
   @Test
-  fun `boundType is not assignable - ContributesBinding`() {
+  fun `binding is not assignable - ContributesBinding`() {
     compile(
       source(
         """
           interface ContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<Unit>())
+          @ContributesBinding(AppScope::class, binding<Unit>())
           @Inject
           class Impl : ContributedInterface
 
@@ -1272,13 +1273,13 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 Class test.Impl does not implement explicit bound type kotlin.Unit"
+        "e: ContributedInterface.kt:9:46 Class test.Impl does not implement explicit bound type kotlin.Unit"
       )
     }
   }
 
   @Test
-  fun `boundType can be ancestor - ContributesBinding`() {
+  fun `binding can be ancestor - ContributesBinding`() {
     compile(
       source(
         """
@@ -1286,7 +1287,7 @@ class AggregationTest : MetroCompilerTest() {
 
           interface ContributedInterface : BaseContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<BaseContributedInterface>())
+          @ContributesBinding(AppScope::class, binding<BaseContributedInterface>())
           @Inject
           class Impl : ContributedInterface
 
@@ -1414,7 +1415,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesBinding(AppScope::class, boundType = BoundType<Impl>())
+          @ContributesBinding(AppScope::class, binding<Impl>())
           @Inject
           class Impl : ContributedInterface
 
@@ -1426,7 +1427,7 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
+        "e: ContributedInterface.kt:9:46 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
       )
     }
   }
@@ -1436,7 +1437,7 @@ class AggregationTest : MetroCompilerTest() {
     compile(
       source(
         """
-          @ContributesBinding(AppScope::class, boundType = BoundType<Impl>())
+          @ContributesBinding(AppScope::class, binding<Impl>())
           @Inject
           class Impl
 
@@ -1448,7 +1449,7 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: Impl.kt:7:60 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
+        "e: Impl.kt:7:46 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
       )
     }
   }
@@ -1486,8 +1487,8 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<ContributedInterface>())
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<ContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<ContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
         """
@@ -1512,8 +1513,8 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<@Named("1") ContributedInterface>())
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<@Named("1") ContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<@Named("1") ContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<@Named("1") ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
         """
@@ -1538,8 +1539,8 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<@Named("1") ContributedInterface>())
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<@Named("2") ContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<@Named("1") ContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<@Named("2") ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
 
@@ -1572,7 +1573,7 @@ class AggregationTest : MetroCompilerTest() {
           interface ContributedInterface
 
           @ContributesIntoSet(AppScope::class)
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<@Named("2") ContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<@Named("2") ContributedInterface>())
           @Named("1")
           @Inject
           class Impl : ContributedInterface
@@ -1633,7 +1634,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<ContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<ContributedInterface>())
           @Named("1")
           @Inject
           class Impl : ContributedInterface
@@ -1666,7 +1667,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<ContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<ContributedInterface>())
           @ContributesIntoSet(AppScope::class)
           @Inject
           class Impl : ContributedInterface
@@ -1686,13 +1687,13 @@ class AggregationTest : MetroCompilerTest() {
   }
 
   @Test
-  fun `boundType as Nothing is an error - ContributesIntoSet`() {
+  fun `binding as Nothing is an error - ContributesIntoSet`() {
     compile(
       source(
         """
           interface ContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<Nothing>())
+          @ContributesIntoSet(AppScope::class, binding<Nothing>())
           @Inject
           class Impl : ContributedInterface
         """
@@ -1701,19 +1702,19 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 Explicit bound types should not be `Nothing` or `Nothing?`."
+        "e: ContributedInterface.kt:9:46 Explicit bound types should not be `Nothing` or `Nothing?`."
       )
     }
   }
 
   @Test
-  fun `boundType can be Any - ContributesIntoSet`() {
+  fun `binding can be Any - ContributesIntoSet`() {
     compile(
       source(
         """
           interface ContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<Any>())
+          @ContributesIntoSet(AppScope::class, binding<Any>())
           @Inject
           class Impl : ContributedInterface
         """
@@ -1723,13 +1724,13 @@ class AggregationTest : MetroCompilerTest() {
   }
 
   @Test
-  fun `boundType is not assignable - ContributesIntoSet`() {
+  fun `binding is not assignable - ContributesIntoSet`() {
     compile(
       source(
         """
           interface ContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<Unit>())
+          @ContributesIntoSet(AppScope::class, binding<Unit>())
           @Inject
           class Impl : ContributedInterface
         """
@@ -1738,13 +1739,13 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 Class test.Impl does not implement explicit bound type kotlin.Unit"
+        "e: ContributedInterface.kt:9:46 Class test.Impl does not implement explicit bound type kotlin.Unit"
       )
     }
   }
 
   @Test
-  fun `boundType can be ancestor - ContributesIntoSet`() {
+  fun `binding can be ancestor - ContributesIntoSet`() {
     compile(
       source(
         """
@@ -1752,7 +1753,7 @@ class AggregationTest : MetroCompilerTest() {
 
           interface ContributedInterface : BaseContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<BaseContributedInterface>())
+          @ContributesIntoSet(AppScope::class, binding<BaseContributedInterface>())
           @Inject
           class Impl : ContributedInterface
 
@@ -1878,7 +1879,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<Impl>())
+          @ContributesIntoSet(AppScope::class, binding<Impl>())
           @Inject
           class Impl : ContributedInterface
         """
@@ -1887,7 +1888,7 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
+        "e: ContributedInterface.kt:9:46 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
       )
     }
   }
@@ -1897,7 +1898,7 @@ class AggregationTest : MetroCompilerTest() {
     compile(
       source(
         """
-          @ContributesIntoSet(AppScope::class, boundType = BoundType<Impl>())
+          @ContributesIntoSet(AppScope::class, binding<Impl>())
           @Inject
           class Impl
         """
@@ -1906,7 +1907,7 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: Impl.kt:7:60 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
+        "e: Impl.kt:7:46 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
       )
     }
   }
@@ -1945,8 +1946,8 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) ContributedInterface>())
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
         """
@@ -1971,8 +1972,8 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) @Named("1") ContributedInterface>())
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) @Named("1") ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) @Named("1") ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) @Named("1") ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
         """
@@ -1997,8 +1998,8 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) @Named("1") ContributedInterface>())
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) @Named("2") ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) @Named("1") ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) @Named("2") ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
 
@@ -2033,7 +2034,7 @@ class AggregationTest : MetroCompilerTest() {
           interface ContributedInterface
 
           @ContributesIntoMap(AppScope::class)
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) @Named("2") ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) @Named("2") ContributedInterface>())
           @Named("1")
           @ClassKey(Impl::class)
           @Inject
@@ -2099,7 +2100,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) ContributedInterface>())
           @Named("1")
           @Inject
           class Impl : ContributedInterface
@@ -2132,7 +2133,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<ContributedInterface>())
           @ClassKey(Impl::class) // Class key is ignored if bound is explicit
           @Inject
           class Impl : ContributedInterface
@@ -2149,7 +2150,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<ContributedInterface>())
           @Inject
           class Impl : ContributedInterface
         """
@@ -2158,7 +2159,7 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 `@ContributesIntoMap`-annotated class @test.Impl must declare a map key but doesn't. Add one on the explicit bound type or the class."
+        "e: ContributedInterface.kt:9:46 `@ContributesIntoMap`-annotated class @test.Impl must declare a map key but doesn't. Add one on the explicit bound type or the class."
       )
     }
   }
@@ -2191,7 +2192,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) ContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) ContributedInterface>())
           @ContributesIntoMap(AppScope::class)
           @ClassKey(Impl::class)
           @Inject
@@ -2212,13 +2213,13 @@ class AggregationTest : MetroCompilerTest() {
   }
 
   @Test
-  fun `boundType as Nothing is an error - ContributesIntoMap`() {
+  fun `binding as Nothing is an error - ContributesIntoMap`() {
     compile(
       source(
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<Nothing>())
+          @ContributesIntoMap(AppScope::class, binding<Nothing>())
           @ClassKey(Impl::class)
           @Inject
           class Impl : ContributedInterface
@@ -2228,19 +2229,19 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 Explicit bound types should not be `Nothing` or `Nothing?`."
+        "e: ContributedInterface.kt:9:46 Explicit bound types should not be `Nothing` or `Nothing?`."
       )
     }
   }
 
   @Test
-  fun `boundType can be Any - ContributesIntoMap`() {
+  fun `binding can be Any - ContributesIntoMap`() {
     compile(
       source(
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) Any>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) Any>())
           @ClassKey(Impl::class)
           @Inject
           class Impl : ContributedInterface
@@ -2251,13 +2252,13 @@ class AggregationTest : MetroCompilerTest() {
   }
 
   @Test
-  fun `boundType is not assignable - ContributesIntoMap`() {
+  fun `binding is not assignable - ContributesIntoMap`() {
     compile(
       source(
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<Unit>())
+          @ContributesIntoMap(AppScope::class, binding<Unit>())
           @ClassKey(Impl::class)
           @Inject
           class Impl : ContributedInterface
@@ -2267,13 +2268,13 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 Class test.Impl does not implement explicit bound type kotlin.Unit"
+        "e: ContributedInterface.kt:9:46 Class test.Impl does not implement explicit bound type kotlin.Unit"
       )
     }
   }
 
   @Test
-  fun `boundType can be ancestor - ContributesIntoMap`() {
+  fun `binding can be ancestor - ContributesIntoMap`() {
     compile(
       source(
         """
@@ -2281,7 +2282,7 @@ class AggregationTest : MetroCompilerTest() {
 
           interface ContributedInterface : BaseContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) BaseContributedInterface>())
+          @ContributesIntoMap(AppScope::class, binding<@ClassKey(Impl::class) BaseContributedInterface>())
           @Inject
           class Impl : ContributedInterface
 
@@ -2409,7 +2410,7 @@ class AggregationTest : MetroCompilerTest() {
         """
           interface ContributedInterface
 
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<Impl>())
+          @ContributesIntoMap(AppScope::class, binding<Impl>())
           @ClassKey(Impl::class)
           @Inject
           class Impl : ContributedInterface
@@ -2419,7 +2420,7 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: ContributedInterface.kt:9:60 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
+        "e: ContributedInterface.kt:9:46 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
       )
     }
   }
@@ -2429,7 +2430,7 @@ class AggregationTest : MetroCompilerTest() {
     compile(
       source(
         """
-          @ContributesIntoMap(AppScope::class, boundType = BoundType<Impl>())
+          @ContributesIntoMap(AppScope::class, binding<Impl>())
           @ClassKey(Impl::class)
           @Inject
           class Impl
@@ -2439,7 +2440,7 @@ class AggregationTest : MetroCompilerTest() {
       expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
       assertDiagnostics(
-        "e: Impl.kt:7:60 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
+        "e: Impl.kt:7:46 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
       )
     }
   }

--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -88,25 +88,28 @@ For simple cases where there is a single typertype, that type is implicitly used
 class CacheImpl(...) : Cache
 ```
 
-For classes with multiple supertypes or advanced cases where you want to bind an ancestor type, you can explicitly define this via `boundType` parameter.
+For classes with multiple supertypes or advanced cases where you want to bind an ancestor type, you can explicitly define this via `binding` parameter.
 
 ```kotlin
 @ContributesBinding(
   scope = AppScope::class,
-  boundType = BoundType<Cache>()
+  binding = binding<Cache>()
 )
 @Inject
 class CacheImpl(...) : Cache, AnotherType
 ```
 
+!!! tip
+    Whoa, is that a function call in an annotation argument? Nope! `binding` is just a decapitalized class in this case, intentionally designed for readability. It's an adjective in this context and the functional syntax better conveys that.
+
 Note that the bound type is defined as the type argument to `@ContributesBinding`. This allows for the bound type to be generic and is validated in FIR.
 
-Qualifier annotations can be specified on the `BoundType` type parameter and will take precedence over any qualifiers on the class itself.
+Qualifier annotations can be specified on the `binding` type parameter and will take precedence over any qualifiers on the class itself.
 
 ```kotlin
 @ContributesBinding(
   scope = AppScope::class,
-  boundType = BoundType<@Named("cache") Cache>()
+  binding = binding<@Named("cache") Cache>()
 )
 @Inject
 class CacheImpl(...) : Cache, AnotherType
@@ -117,11 +120,11 @@ This annotation is *repeatable* and can be used to contribute to multiple scopes
 ```kotlin
 @ContributesBinding(
   scope = AppScope::class,
-  boundType = BoundType<Cache>()
+  binding = binding<Cache>()
 )
 @ContributesBinding(
   scope = AppScope::class,
-  boundType = BoundType<AnotherType>()
+  binding = binding<AnotherType>()
 )
 @Inject
 class CacheImpl(...) : Cache, AnotherType
@@ -140,9 +143,9 @@ To contribute into a multibinding, use the `@ContributesIntoSet` or `@Contribute
 class CacheImpl(...) : Cache
 ```
 
-Same rules around qualifiers and `boundType()` apply in this scenario
+Same rules around qualifiers and `binding()` apply in this scenario
 
-To contribute into a Map multibinding, the map key annotation must be specified on the class or `BoundType` type argument.
+To contribute into a Map multibinding, the map key annotation must be specified on the class or `binding` type argument.
 
 ```kotlin
 // Will be contributed into a Map multibinding with @StringKey("Networking")
@@ -151,10 +154,10 @@ To contribute into a Map multibinding, the map key annotation must be specified 
 @Inject
 class CacheImpl(...) : Cache
 
-// Or if using BoundType
+// Or if using binding
 @ContributesIntoMap(
   scope = AppScope::class,
-  boundType = BoundType<@StringKey("Networking") Cache>()
+  binding = binding<@StringKey("Networking") Cache>()
 )
 @Inject
 class CacheImpl(...) : Cache

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -23,9 +23,9 @@
 #### …from Anvil
 
 * There is no `rank`.
-* `@ContributesBinding` uses a `BoundType` API to support generic bound types. See the [aggregation docs](aggregation.md) for more info.
+* `@ContributesBinding` uses a `binding` API to support generic bound types. See the [aggregation docs](aggregation.md) for more info.
 
 #### …from kotlin-inject-anvil
 
 * There is no need for `@CreateComponent` or `expect fun createComponent()` functions.
-* `@ContributesBinding` uses a `BoundType` API to support generic bound types. See the [aggregation docs](aggregation.md) for more info.
+* `@ContributesBinding` uses a `binding` API to support generic bound types. See the [aggregation docs](aggregation.md) for more info.

--- a/docs/interop.md
+++ b/docs/interop.md
@@ -51,7 +51,7 @@ metro {
 
 Similarly, `@ContributesBinding` is replaceable but there are not direct analogues for Anvil’s `@ContributesMultibinding` or kotlin-inject-anvil’s `@ContributesBinding(multibinding = …)` as these annotations are implemented as `@ContributesInto*` annotations in Metro.
 
-`boundType` in Metro uses a more flexible mechanism to support generics, but interop with Anvil's `boundType: KClass<*>` property is supported.
+`binding` in Metro uses a more flexible mechanism to support generics, but interop with Anvil's `boundType: KClass<*>` property is supported.
 
 ## Components
 

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -11,15 +11,12 @@ public abstract interface annotation class dev/zacsweers/metro/AssistedFactory :
 public abstract interface annotation class dev/zacsweers/metro/Binds : java/lang/annotation/Annotation {
 }
 
-public abstract interface annotation class dev/zacsweers/metro/BoundType : java/lang/annotation/Annotation {
-}
-
 public abstract interface annotation class dev/zacsweers/metro/ClassKey : java/lang/annotation/Annotation {
 	public abstract fun value ()Ljava/lang/Class;
 }
 
 public abstract interface annotation class dev/zacsweers/metro/ContributesBinding : java/lang/annotation/Annotation {
-	public abstract fun boundType ()Ldev/zacsweers/metro/BoundType;
+	public abstract fun binding ()Ldev/zacsweers/metro/binding;
 	public abstract fun replaces ()[Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;
 }
@@ -29,7 +26,7 @@ public abstract interface annotation class dev/zacsweers/metro/ContributesBindin
 }
 
 public abstract interface annotation class dev/zacsweers/metro/ContributesIntoMap : java/lang/annotation/Annotation {
-	public abstract fun boundType ()Ldev/zacsweers/metro/BoundType;
+	public abstract fun binding ()Ldev/zacsweers/metro/binding;
 	public abstract fun replaces ()[Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;
 }
@@ -39,7 +36,7 @@ public abstract interface annotation class dev/zacsweers/metro/ContributesIntoMa
 }
 
 public abstract interface annotation class dev/zacsweers/metro/ContributesIntoSet : java/lang/annotation/Annotation {
-	public abstract fun boundType ()Ldev/zacsweers/metro/BoundType;
+	public abstract fun binding ()Ldev/zacsweers/metro/binding;
 	public abstract fun replaces ()[Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;
 }
@@ -129,5 +126,8 @@ public abstract interface annotation class dev/zacsweers/metro/SingleIn$Containe
 
 public abstract interface annotation class dev/zacsweers/metro/StringKey : java/lang/annotation/Annotation {
 	public abstract fun value ()Ljava/lang/String;
+}
+
+public abstract interface annotation class dev/zacsweers/metro/binding : java/lang/annotation/Annotation {
 }
 

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -6,8 +6,8 @@
 // - Show declarations: true
 
 // Library unique name: <dev.zacsweers.metro:runtime>
-open annotation class <#A: kotlin/Any> dev.zacsweers.metro/BoundType : kotlin/Annotation { // dev.zacsweers.metro/BoundType|null[0]
-    constructor <init>() // dev.zacsweers.metro/BoundType.<init>|<init>(){}[0]
+open annotation class <#A: kotlin/Any> dev.zacsweers.metro/binding : kotlin/Annotation { // dev.zacsweers.metro/binding|null[0]
+    constructor <init>() // dev.zacsweers.metro/binding.<init>|<init>(){}[0]
 }
 
 open annotation class dev.zacsweers.metro/Assisted : kotlin/Annotation { // dev.zacsweers.metro/Assisted|null[0]
@@ -33,10 +33,10 @@ open annotation class dev.zacsweers.metro/ClassKey : kotlin/Annotation { // dev.
 }
 
 open annotation class dev.zacsweers.metro/ContributesBinding : kotlin/Annotation { // dev.zacsweers.metro/ContributesBinding|null[0]
-    constructor <init>(kotlin.reflect/KClass<*>, kotlin/Array<kotlin.reflect/KClass<*>> = ..., dev.zacsweers.metro/BoundType<*> = ...) // dev.zacsweers.metro/ContributesBinding.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.Array<kotlin.reflect.KClass<*>>;dev.zacsweers.metro.BoundType<*>){}[0]
+    constructor <init>(kotlin.reflect/KClass<*>, dev.zacsweers.metro/binding<*> = ..., kotlin/Array<kotlin.reflect/KClass<*>> = ...) // dev.zacsweers.metro/ContributesBinding.<init>|<init>(kotlin.reflect.KClass<*>;dev.zacsweers.metro.binding<*>;kotlin.Array<kotlin.reflect.KClass<*>>){}[0]
 
-    final val boundType // dev.zacsweers.metro/ContributesBinding.boundType|{}boundType[0]
-        final fun <get-boundType>(): dev.zacsweers.metro/BoundType<*> // dev.zacsweers.metro/ContributesBinding.boundType.<get-boundType>|<get-boundType>(){}[0]
+    final val binding // dev.zacsweers.metro/ContributesBinding.binding|{}binding[0]
+        final fun <get-binding>(): dev.zacsweers.metro/binding<*> // dev.zacsweers.metro/ContributesBinding.binding.<get-binding>|<get-binding>(){}[0]
     final val replaces // dev.zacsweers.metro/ContributesBinding.replaces|{}replaces[0]
         final fun <get-replaces>(): kotlin/Array<kotlin.reflect/KClass<*>> // dev.zacsweers.metro/ContributesBinding.replaces.<get-replaces>|<get-replaces>(){}[0]
     final val scope // dev.zacsweers.metro/ContributesBinding.scope|{}scope[0]
@@ -44,10 +44,10 @@ open annotation class dev.zacsweers.metro/ContributesBinding : kotlin/Annotation
 }
 
 open annotation class dev.zacsweers.metro/ContributesIntoMap : kotlin/Annotation { // dev.zacsweers.metro/ContributesIntoMap|null[0]
-    constructor <init>(kotlin.reflect/KClass<*>, kotlin/Array<kotlin.reflect/KClass<*>> = ..., dev.zacsweers.metro/BoundType<*> = ...) // dev.zacsweers.metro/ContributesIntoMap.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.Array<kotlin.reflect.KClass<*>>;dev.zacsweers.metro.BoundType<*>){}[0]
+    constructor <init>(kotlin.reflect/KClass<*>, dev.zacsweers.metro/binding<*> = ..., kotlin/Array<kotlin.reflect/KClass<*>> = ...) // dev.zacsweers.metro/ContributesIntoMap.<init>|<init>(kotlin.reflect.KClass<*>;dev.zacsweers.metro.binding<*>;kotlin.Array<kotlin.reflect.KClass<*>>){}[0]
 
-    final val boundType // dev.zacsweers.metro/ContributesIntoMap.boundType|{}boundType[0]
-        final fun <get-boundType>(): dev.zacsweers.metro/BoundType<*> // dev.zacsweers.metro/ContributesIntoMap.boundType.<get-boundType>|<get-boundType>(){}[0]
+    final val binding // dev.zacsweers.metro/ContributesIntoMap.binding|{}binding[0]
+        final fun <get-binding>(): dev.zacsweers.metro/binding<*> // dev.zacsweers.metro/ContributesIntoMap.binding.<get-binding>|<get-binding>(){}[0]
     final val replaces // dev.zacsweers.metro/ContributesIntoMap.replaces|{}replaces[0]
         final fun <get-replaces>(): kotlin/Array<kotlin.reflect/KClass<*>> // dev.zacsweers.metro/ContributesIntoMap.replaces.<get-replaces>|<get-replaces>(){}[0]
     final val scope // dev.zacsweers.metro/ContributesIntoMap.scope|{}scope[0]
@@ -55,10 +55,10 @@ open annotation class dev.zacsweers.metro/ContributesIntoMap : kotlin/Annotation
 }
 
 open annotation class dev.zacsweers.metro/ContributesIntoSet : kotlin/Annotation { // dev.zacsweers.metro/ContributesIntoSet|null[0]
-    constructor <init>(kotlin.reflect/KClass<*>, kotlin/Array<kotlin.reflect/KClass<*>> = ..., dev.zacsweers.metro/BoundType<*> = ...) // dev.zacsweers.metro/ContributesIntoSet.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.Array<kotlin.reflect.KClass<*>>;dev.zacsweers.metro.BoundType<*>){}[0]
+    constructor <init>(kotlin.reflect/KClass<*>, dev.zacsweers.metro/binding<*> = ..., kotlin/Array<kotlin.reflect/KClass<*>> = ...) // dev.zacsweers.metro/ContributesIntoSet.<init>|<init>(kotlin.reflect.KClass<*>;dev.zacsweers.metro.binding<*>;kotlin.Array<kotlin.reflect.KClass<*>>){}[0]
 
-    final val boundType // dev.zacsweers.metro/ContributesIntoSet.boundType|{}boundType[0]
-        final fun <get-boundType>(): dev.zacsweers.metro/BoundType<*> // dev.zacsweers.metro/ContributesIntoSet.boundType.<get-boundType>|<get-boundType>(){}[0]
+    final val binding // dev.zacsweers.metro/ContributesIntoSet.binding|{}binding[0]
+        final fun <get-binding>(): dev.zacsweers.metro/binding<*> // dev.zacsweers.metro/ContributesIntoSet.binding.<get-binding>|<get-binding>(){}[0]
     final val replaces // dev.zacsweers.metro/ContributesIntoSet.replaces|{}replaces[0]
         final fun <get-replaces>(): kotlin/Array<kotlin.reflect/KClass<*>> // dev.zacsweers.metro/ContributesIntoSet.replaces.<get-replaces>|<get-replaces>(){}[0]
     final val scope // dev.zacsweers.metro/ContributesIntoSet.scope|{}scope[0]

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/ContributesBinding.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/ContributesBinding.kt
@@ -6,8 +6,8 @@ import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.reflect.KClass
 
 /**
- * Contributes a binding of the annotated type to the given [scope] as a [boundType] (if specified)
- * or single declared supertype.
+ * Contributes a binding of the annotated type to the given [scope] as a [binding] (if specified) or
+ * single declared supertype.
  *
  * ```
  * // Implicit supertype is Base
@@ -16,11 +16,11 @@ import kotlin.reflect.KClass
  * class Impl : Base
  * ```
  *
- * Use [BoundType] to specify a specific bound type if an implicit one is not possible.
+ * Use [binding] to specify a specific bound type if an implicit one is not possible.
  *
  * ```
  * // Explicit supertype is Base
- * @ContributesBinding(AppScope::class, boundType = BoundType<Base>())
+ * @ContributesBinding(AppScope::class, binding = binding<Base>())
  * @Inject
  * class Impl : Base, AnotherBase
  * ```
@@ -35,15 +35,15 @@ import kotlin.reflect.KClass
  * [Binds] declaration.
  *
  * @property scope The scope this binding contributes to.
+ * @property binding The explicit bound type for this contribution, if not using the implicit
+ *   supertype.
  * @property replaces List of other contributing classes that this binding should replace in the
  *   scope.
- * @property boundType The explicit bound type for this contribution, if not using the implicit
- *   supertype.
  */
 @Target(CLASS)
 @Repeatable
 public annotation class ContributesBinding(
   val scope: KClass<*>,
+  val binding: binding<*> = binding<Nothing>(),
   val replaces: Array<KClass<*>> = [],
-  val boundType: BoundType<*> = BoundType<Nothing>(),
 )

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/ContributesIntoMap.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/ContributesIntoMap.kt
@@ -6,9 +6,9 @@ import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.reflect.KClass
 
 /**
- * Contributes an [IntoMap] binding of the annotated type to the given [scope] as a [boundType] (if
+ * Contributes an [IntoMap] binding of the annotated type to the given [scope] as a [binding] (if
  * specified) or single declared supertype. A [MapKey] _must_ be declared either on the annotated
- * class or on the [boundType].
+ * class or on the [binding].
  *
  * ```
  * // Implicit supertype is Base
@@ -18,21 +18,21 @@ import kotlin.reflect.KClass
  * class Impl : Base
  * ```
  *
- * Use [BoundType] to specify a specific bound type if an implicit one is not possible.
+ * Use [binding] to specify a specific bound type if an implicit one is not possible.
  *
  * ```
  * // Explicit supertype is Base
  * @ClassKey(Impl::class)
- * @ContributesIntoMap(AppScope::class, boundType = BoundType<Base>())
+ * @ContributesIntoMap(AppScope::class, binding = binding<Base>())
  * @Inject
  * class Impl : Base, AnotherBase
  * ```
  *
- * [BoundType]'s type argument can also be annotated with a [MapKey].
+ * [binding]'s type argument can also be annotated with a [MapKey].
  *
  * ```
  * // Explicit supertype is Base
- * @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) Base>())
+ * @ContributesIntoMap(AppScope::class, binding = binding<@ClassKey(Impl::class) Base>())
  * @Inject
  * class Impl : Base, AnotherBase
  * ```
@@ -47,15 +47,15 @@ import kotlin.reflect.KClass
  * [IntoMap] declaration.
  *
  * @property scope The scope this binding contributes to.
+ * @property binding The explicit bound type for this contribution, if not using the implicit
+ *   supertype.
  * @property replaces List of other contributing classes that this binding should replace in the
  *   scope.
- * @property boundType The explicit bound type for this contribution, if not using the implicit
- *   supertype.
  */
 @Target(CLASS)
 @Repeatable
 public annotation class ContributesIntoMap(
   val scope: KClass<*>,
+  val binding: binding<*> = binding<Nothing>(),
   val replaces: Array<KClass<*>> = [],
-  val boundType: BoundType<*> = BoundType<Nothing>(),
 )

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/ContributesIntoSet.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/ContributesIntoSet.kt
@@ -6,7 +6,7 @@ import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.reflect.KClass
 
 /**
- * Contributes an [IntoSet] binding of the annotated type to the given [scope] as a [boundType] (if
+ * Contributes an [IntoSet] binding of the annotated type to the given [scope] as a [binding] (if
  * specified) or single declared supertype.
  *
  * ```
@@ -16,12 +16,12 @@ import kotlin.reflect.KClass
  * class Impl : Base
  * ```
  *
- * Use [BoundType] to specify a specific bound type if an implicit one is not possible.
+ * Use [binding] to specify a specific bound type if an implicit one is not possible.
  *
  * ```
  * // Explicit supertype is Base
  * @ClassKey(Impl::class)
- * @ContributesIntoSet(AppScope::class, boundType = BoundType<Base>())
+ * @ContributesIntoSet(AppScope::class, binding = binding<Base>())
  * @Inject
  * class Impl : Base, AnotherBase
  * ```
@@ -36,15 +36,15 @@ import kotlin.reflect.KClass
  * [IntoSet] declaration.
  *
  * @property scope The scope this binding contributes to.
+ * @property binding The explicit bound type for this contribution, if not using the implicit
+ *   supertype.
  * @property replaces List of other contributing classes that this binding should replace in the
  *   scope.
- * @property boundType The explicit bound type for this contribution, if not using the implicit
- *   supertype.
  */
 @Target(CLASS)
 @Repeatable
 public annotation class ContributesIntoSet(
   val scope: KClass<*>,
+  val binding: binding<*> = binding<Nothing>(),
   val replaces: Array<KClass<*>> = [],
-  val boundType: BoundType<*> = BoundType<Nothing>(),
 )

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/binding.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/binding.kt
@@ -14,7 +14,7 @@ package dev.zacsweers.metro
  * supertype).
  *
  * ```kotlin
- * @ContributesBinding(AppScope::class, boundType = BoundType<Base>())
+ * @ContributesBinding(AppScope::class, binding = binding<Base>())
  * class Impl : Base, AnotherBase
  * ```
  *
@@ -23,13 +23,13 @@ package dev.zacsweers.metro
  * on the class, if any.
  *
  * ```kotlin
- * // Uses the qualifier on `boundType`
- * @ContributesBinding(AppScope::class, boundType = BoundType<@Named("qualified") Base>())
+ * // Uses the qualifier on `binding`
+ * @ContributesBinding(AppScope::class, binding = binding<@Named("qualified") Base>())
  * class Impl : Base, AnotherBase
  *
  * // Falls back to the class
  * @Named("qualified")
- * @ContributesBinding(AppScope::class, boundType = BoundType<Base>())
+ * @ContributesBinding(AppScope::class, binding = binding<Base>())
  * class Impl : Base, AnotherBase
  * ```
  *
@@ -37,8 +37,8 @@ package dev.zacsweers.metro
  * [MapKey]. If none is defined on [T], there _must_ be one on the annotated class to use.
  *
  * ```kotlin
- * @ContributesIntoMap(AppScope::class, boundType = BoundType<@ClassKey(Impl::class) Base>())
+ * @ContributesIntoMap(AppScope::class, binding = binding<@ClassKey(Impl::class) Base>())
  * class Impl : Base, AnotherBase
  * ```
  */
-public annotation class BoundType<@Suppress("unused") T : Any>
+@Suppress("ClassName") public annotation class binding<@Suppress("unused") T : Any>


### PR DESCRIPTION
After some discussion in slack, this reads better

```kotlin
@ContributesBinding(AppScope::class, binding<Parent>())
@Inject
class Subtype : Parent
```