### PR TITLE
Start preparing MetroMetadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
   alias(libs.plugins.spotless)
   alias(libs.plugins.binaryCompatibilityValidator)
   alias(libs.plugins.poko) apply false
+  alias(libs.plugins.wire) apply false
 }
 
 apiValidation {

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -43,15 +43,9 @@ tasks.test { maxParallelForks = Runtime.getRuntime().availableProcessors() * 2 }
 
 wire { kotlin {} }
 
-val shade: Configuration = configurations.maybeCreate("compileShaded")
-
-configurations.getByName("compileOnly").extendsFrom(shade)
-
 val shadowJar =
   tasks.shadowJar.apply {
     configure {
-      archiveClassifier.set("")
-      configurations = listOf(shade)
       relocate("com.squareup.wire", "dev.zacsweers.metro.compiler.shaded.com.squareup.wire")
     }
   }
@@ -66,7 +60,7 @@ dependencies {
   compileOnly(libs.kotlin.stdlib)
   implementation(libs.autoService)
   implementation(libs.picnic) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
-  shade(libs.wire.runtime) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
+  shadow(libs.wire.runtime) { exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib") }
   ksp(libs.autoService.ksp)
 
   testImplementation(project(":runtime"))

--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.ksp)
   alias(libs.plugins.poko)
   alias(libs.plugins.buildConfig)
+  alias(libs.plugins.wire)
 }
 
 kotlin {
@@ -39,11 +40,14 @@ buildConfig {
 
 tasks.test { maxParallelForks = Runtime.getRuntime().availableProcessors() * 2 }
 
+wire { kotlin {} }
+
 dependencies {
   compileOnly(libs.kotlin.compilerEmbeddable)
   compileOnly(libs.kotlin.stdlib)
   implementation(libs.autoService)
   implementation(libs.picnic)
+  implementation(libs.wire.runtime)
   ksp(libs.autoService.ksp)
 
   testImplementation(project(":runtime"))

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/Symbols.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/Symbols.kt
@@ -98,6 +98,7 @@ internal class Symbols(
     val instance = Name.identifier("instance")
     val injectMembers = Name.identifier(StringNames.INJECT_MEMBERS)
     val invoke = Name.identifier(StringNames.INVOKE)
+    val isExtendable = "isExtendable".asName()
     val metroFactory = Name.identifier(StringNames.METRO_FACTORY)
     val metroContribution = Name.identifier("$\$MetroContribution")
     val metroGraph = Name.identifier("$\$MetroGraph")

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/BindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/BindingGraph.kt
@@ -24,6 +24,9 @@ internal class BindingGraph(private val metroContext: IrMetroContext) {
   // TODO eventually add inject() targets too from member injection
   private val accessors = mutableMapOf<ContextualTypeKey, BindingStack.Entry>()
 
+  // Thin immutable view over the internal bindings
+  fun bindingsSnapshot(): Map<TypeKey, Binding> = bindings
+
   fun addAccessor(key: ContextualTypeKey, entry: BindingStack.Entry) {
     accessors[key] = entry
   }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/BindingStack.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/BindingStack.kt
@@ -10,7 +10,7 @@ import dev.zacsweers.metro.compiler.ir.BindingStack.Entry
 import dev.zacsweers.metro.compiler.withoutLineBreaks
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
-import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrOverridableDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrProperty
@@ -38,7 +38,7 @@ internal interface BindingStack {
     val contextKey: ContextualTypeKey,
     val usage: String?,
     val graphContext: String?,
-    val declaration: IrDeclaration?,
+    val declaration: IrDeclarationWithName?,
     val displayTypeKey: TypeKey = contextKey.typeKey,
     /**
      * Indicates this entry is informational only and not an actual functional binding that should
@@ -103,7 +103,7 @@ internal interface BindingStack {
        */
       fun contributedToMultibinding(
         contextKey: ContextualTypeKey,
-        declaration: IrDeclaration?,
+        declaration: IrDeclarationWithName?,
       ): Entry =
         Entry(
           contextKey = contextKey,
@@ -133,7 +133,7 @@ internal interface BindingStack {
         contextKey: ContextualTypeKey,
         function: IrFunction,
         param: IrValueParameter? = null,
-        declaration: IrDeclaration? = param,
+        declaration: IrDeclarationWithName? = param,
         displayTypeKey: TypeKey = contextKey.typeKey,
         isSynthetic: Boolean = false,
       ): Entry {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/DependencyGraphNode.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/DependencyGraphNode.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 // Represents an object graph's structure and relationships
 internal data class DependencyGraphNode(
   val sourceGraph: IrClass,
+  val isExtendable: Boolean,
   val dependencies: Map<TypeKey, DependencyGraphNode>,
   val scopes: Set<IrAnnotation>,
   val providerFunctions: List<Pair<TypeKey, MetroSimpleFunction>>,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrMetroContext.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrMetroContext.kt
@@ -8,6 +8,7 @@ import dev.zacsweers.metro.compiler.MetroOptions
 import dev.zacsweers.metro.compiler.Symbols
 import dev.zacsweers.metro.compiler.ir.parameters.wrapInProvider
 import dev.zacsweers.metro.compiler.mapToSet
+import kotlin.system.measureTimeMillis
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
@@ -167,4 +168,9 @@ internal interface IrMetroContext {
       }
     }
   }
+}
+
+internal inline fun IrMetroContext.timedComputation(name: String, block: () -> Unit) {
+  val result = measureTimeMillis(block)
+  log("$name took ${result}ms")
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -85,6 +85,7 @@ import org.jetbrains.kotlin.ir.util.fileOrNull
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.getSimpleFunction
+import org.jetbrains.kotlin.ir.util.getValueArgument
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.isFakeOverriddenFromAny
 import org.jetbrains.kotlin.ir.util.isObject
@@ -629,6 +630,9 @@ internal fun IrClass.implementsAny(
 
 internal fun IrConstructorCall.getSingleConstBooleanArgumentOrNull(): Boolean? =
   (getValueArgument(0) as IrConst?)?.value as Boolean?
+
+internal fun IrConstructorCall.getConstBooleanArgumentOrNull(name: Name): Boolean? =
+  (getValueArgument(name) as IrConst?)?.value as Boolean?
 
 internal fun Collection<IrElement?>.joinToKotlinLike(separator: String = "\n"): String {
   return joinToString(separator = separator) { it?.dumpKotlinLike() ?: "<null element>" }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
@@ -28,6 +28,7 @@ import dev.zacsweers.metro.compiler.ir.createIrBuilder
 import dev.zacsweers.metro.compiler.ir.doubleCheck
 import dev.zacsweers.metro.compiler.ir.finalizeFakeOverride
 import dev.zacsweers.metro.compiler.ir.getAllSuperTypes
+import dev.zacsweers.metro.compiler.ir.getConstBooleanArgumentOrNull
 import dev.zacsweers.metro.compiler.ir.getSingleConstBooleanArgumentOrNull
 import dev.zacsweers.metro.compiler.ir.implements
 import dev.zacsweers.metro.compiler.ir.irExprBodySafe
@@ -52,9 +53,12 @@ import dev.zacsweers.metro.compiler.ir.singleAbstractFunction
 import dev.zacsweers.metro.compiler.ir.stubExpression
 import dev.zacsweers.metro.compiler.ir.stubExpressionBody
 import dev.zacsweers.metro.compiler.ir.thisReceiverOrFail
+import dev.zacsweers.metro.compiler.ir.timedComputation
 import dev.zacsweers.metro.compiler.ir.typeAsProviderArgument
 import dev.zacsweers.metro.compiler.ir.withEntry
 import dev.zacsweers.metro.compiler.letIf
+import dev.zacsweers.metro.compiler.proto.DependencyGraphProto
+import dev.zacsweers.metro.compiler.proto.MetroMetadata
 import kotlin.io.path.createDirectories
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.writeText
@@ -292,7 +296,8 @@ internal class DependencyGraphTransformer(
       val dependentNode =
         DependencyGraphNode(
           sourceGraph = graphDeclaration,
-          isExtendable = dependencyGraphAnno?.getBooleanConstArgument(i = 3) == true,
+          isExtendable =
+            dependencyGraphAnno?.getConstBooleanArgumentOrNull(Symbols.Names.isExtendable) == true,
           dependencies = emptyMap(),
           scopes = emptySet(),
           providerFunctions = emptyList(),
@@ -475,7 +480,8 @@ internal class DependencyGraphTransformer(
     val dependencyGraphNode =
       DependencyGraphNode(
         sourceGraph = graphDeclaration,
-        isExtendable = dependencyGraphAnno.getBooleanConstArgument(i = 3) == true,
+        isExtendable =
+          dependencyGraphAnno.getConstBooleanArgumentOrNull(Symbols.Names.isExtendable) == true,
         dependencies = graphDependencies,
         scopes = scopes,
         bindsFunctions = bindsFunctions,
@@ -863,8 +869,8 @@ internal class DependencyGraphTransformer(
     graphClass: IrClass,
     bindingGraph: BindingGraph,
     deferredTypes: Set<TypeKey>,
-  ): IrClass {
-    return graphClass.apply {
+  ) =
+    with(graphClass) {
       val ctor = primaryConstructor!!
 
       // Add fields for providers. May include both scoped and unscoped providers as well as bound
@@ -1108,7 +1114,53 @@ internal class DependencyGraphTransformer(
       }
 
       implementOverrides(node.accessors, node.bindsFunctions, node.injectors, baseGenerationContext)
+
+      if (node.isExtendable) {
+        timedComputation("Generating Metro metadata") {
+          // Finally, generate metadata
+          val metroMetadata =
+            MetroMetadata(
+              node.toProto(
+                bindingGraph = bindingGraph,
+                providerFields = providerFields.values.map { it.name.asString() }.sorted(),
+              )
+            )
+          val serialized = MetroMetadata.ADAPTER.encode(metroMetadata)
+          // TODO add to metadata
+          //  pluginContext.metadataDeclarationRegistrar.addCustomMetadataExtension(
+          //    graphClass,
+          //    PLUGIN_ID,
+          //    serialized
+          //  )
+        }
+      }
     }
+
+  private fun DependencyGraphNode.toProto(
+    bindingGraph: BindingGraph,
+    providerFields: List<String>,
+  ): DependencyGraphProto {
+    val providerFactoryClasses = mutableListOf<String>()
+    val bindsCallableIds = mutableListOf<String>()
+
+    for (binding in bindingGraph.bindingsSnapshot().values) {
+      if (binding is Binding.Provided) {
+        if (binding.aliasedType != null) {
+          bindsCallableIds += binding.providerFunction.name.asString()
+        } else {
+          providerFactoryClasses +=
+            providesTransformer.getOrGenerateFactoryClass(binding)!!.classIdOrFail.asString()
+        }
+      }
+    }
+
+    return DependencyGraphProto(
+      is_graph = true,
+      provider_field_names = providerFields,
+      provider_factory_classes = providerFactoryClasses.sorted(),
+      binds_callable_ids = bindsCallableIds.sorted(),
+      accessor_callable_ids = accessors.map { it.first.ir.name.asString() }.sorted(),
+    )
   }
 
   private fun implementOverrides(

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
@@ -292,6 +292,7 @@ internal class DependencyGraphTransformer(
       val dependentNode =
         DependencyGraphNode(
           sourceGraph = graphDeclaration,
+          isExtendable = dependencyGraphAnno?.getBooleanConstArgument(i = 3) == true,
           dependencies = emptyMap(),
           scopes = emptySet(),
           providerFunctions = emptyList(),
@@ -474,6 +475,7 @@ internal class DependencyGraphTransformer(
     val dependencyGraphNode =
       DependencyGraphNode(
         sourceGraph = graphDeclaration,
+        isExtendable = dependencyGraphAnno.getBooleanConstArgument(i = 3) == true,
         dependencies = graphDependencies,
         scopes = scopes,
         bindsFunctions = bindsFunctions,

--- a/compiler/src/main/proto/dev/zacsweers/metro/compiler/proto/metro_metadata.proto
+++ b/compiler/src/main/proto/dev/zacsweers/metro/compiler/proto/metro_metadata.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+package dev.zacsweers.metro.compiler.proto;
+
+option java_package = "dev.zacsweers.metro.compiler.proto";
+option java_multiple_files = true;
+
+message DependencyGraphProto {
+  // Required boolean "isGraph"
+  bool is_graph = 1;
+
+  // Required map of ClassIds (as strings) of provider factory classes
+  // If is_graph is true, this includes _all_ inherited classes' factories too
+  repeated string provider_factory_classes = 2;
+
+  // Set of provider field names (strings). Only present if is_graph is true
+  repeated string provider_field_names = 3;
+
+  // Set of binds callable IDs (strings)
+  repeated string binds_callable_ids = 4;
+
+  // Set of accessor callable IDs (strings)
+  repeated string accessor_callable_ids = 5;
+}
+
+message MetroMetadata {
+  // Optional DependencyGraphProto field
+  optional DependencyGraphProto dependency_graph = 1;
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }
 poko = { id = "dev.drewhamilton.poko", version = "0.18.2" }
-shadow = { id = "com.gradleup.shadow", version = "8.3.6" }
+shadow = { id = "com.gradleup.shadow", version = "9.0.0-beta10" }
 spotless = { id = "com.diffplug.spotless", version = "7.0.2" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }
 poko = { id = "dev.drewhamilton.poko", version = "0.18.2" }
+shadow = { id = "com.gradleup.shadow", version = "8.3.6" }
 spotless = { id = "com.diffplug.spotless", version = "7.0.2" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }
 
@@ -116,4 +117,4 @@ truth = { module = "com.google.truth:truth", version = "1.4.4" }
 kct = { module = "dev.zacsweers.kctfork:core", version.ref = "kct" }
 kct-ksp = { module = "dev.zacsweers.kctfork:ksp", version.ref = "kct" }
 
-wire-runtime = { module = "com.squareup.wire:wire-runtime", version.ref = "wire" }
+wire-runtime = { module = "com.squareup.wire:wire-runtime-jvm", version.ref = "wire" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@
 autoService = "1.1.1"
 anvil = "0.4.1"
 atomicfu = "0.27.0"
+wire = "5.3.1"
 dagger = "2.55"
 kct = "0.7.0"
 kotlin = "2.1.10"
@@ -47,6 +48,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }
 poko = { id = "dev.drewhamilton.poko", version = "0.18.2" }
 spotless = { id = "com.diffplug.spotless", version = "7.0.2" }
+wire = { id = "com.squareup.wire", version.ref = "wire" }
 
 [libraries]
 anvil-annotations = { module = "dev.zacsweers.anvil:annotations", version.ref = "anvil" }
@@ -113,3 +115,5 @@ junit = { module = "junit:junit", version = "4.13.2" }
 truth = { module = "com.google.truth:truth", version = "1.4.4" }
 kct = { module = "dev.zacsweers.kctfork:core", version.ref = "kct" }
 kct-ksp = { module = "dev.zacsweers.kctfork:ksp", version.ref = "kct" }
+
+wire-runtime = { module = "com.squareup.wire:wire-runtime", version.ref = "wire" }

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -57,6 +57,7 @@ public abstract interface annotation class dev/zacsweers/metro/ContributesTo$Con
 public abstract interface annotation class dev/zacsweers/metro/DependencyGraph : java/lang/annotation/Annotation {
 	public abstract fun additionalScopes ()[Ljava/lang/Class;
 	public abstract fun excludes ()[Ljava/lang/Class;
+	public abstract fun isExtendable ()Z
 	public abstract fun scope ()Ljava/lang/Class;
 }
 

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -75,12 +75,14 @@ open annotation class dev.zacsweers.metro/ContributesTo : kotlin/Annotation { //
 }
 
 open annotation class dev.zacsweers.metro/DependencyGraph : kotlin/Annotation { // dev.zacsweers.metro/DependencyGraph|null[0]
-    constructor <init>(kotlin.reflect/KClass<*> = ..., kotlin/Array<kotlin.reflect/KClass<*>> = ..., kotlin/Array<kotlin.reflect/KClass<*>> = ...) // dev.zacsweers.metro/DependencyGraph.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.Array<kotlin.reflect.KClass<*>>;kotlin.Array<kotlin.reflect.KClass<*>>){}[0]
+    constructor <init>(kotlin.reflect/KClass<*> = ..., kotlin/Array<kotlin.reflect/KClass<*>> = ..., kotlin/Array<kotlin.reflect/KClass<*>> = ..., kotlin/Boolean = ...) // dev.zacsweers.metro/DependencyGraph.<init>|<init>(kotlin.reflect.KClass<*>;kotlin.Array<kotlin.reflect.KClass<*>>;kotlin.Array<kotlin.reflect.KClass<*>>;kotlin.Boolean){}[0]
 
     final val additionalScopes // dev.zacsweers.metro/DependencyGraph.additionalScopes|{}additionalScopes[0]
         final fun <get-additionalScopes>(): kotlin/Array<kotlin.reflect/KClass<*>> // dev.zacsweers.metro/DependencyGraph.additionalScopes.<get-additionalScopes>|<get-additionalScopes>(){}[0]
     final val excludes // dev.zacsweers.metro/DependencyGraph.excludes|{}excludes[0]
         final fun <get-excludes>(): kotlin/Array<kotlin.reflect/KClass<*>> // dev.zacsweers.metro/DependencyGraph.excludes.<get-excludes>|<get-excludes>(){}[0]
+    final val isExtendable // dev.zacsweers.metro/DependencyGraph.isExtendable|{}isExtendable[0]
+        final fun <get-isExtendable>(): kotlin/Boolean // dev.zacsweers.metro/DependencyGraph.isExtendable.<get-isExtendable>|<get-isExtendable>(){}[0]
     final val scope // dev.zacsweers.metro/DependencyGraph.scope|{}scope[0]
         final fun <get-scope>(): kotlin.reflect/KClass<*> // dev.zacsweers.metro/DependencyGraph.scope.<get-scope>|<get-scope>(){}[0]
 

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/DependencyGraph.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/DependencyGraph.kt
@@ -94,12 +94,15 @@ import kotlin.reflect.KClass
  *
  * @property excludes Optional list of excluded contributing classes (requires a [scope] to be
  *   defined).
+ * @property isExtendable If enabled, marks this graph as available for extension and generates
+ *   extra metadata about this graph's available bindings for child graphs to read.
  */
 @Target(AnnotationTarget.CLASS)
 public annotation class DependencyGraph(
   val scope: KClass<*> = Nothing::class,
   val additionalScopes: Array<KClass<*>> = [],
   val excludes: Array<KClass<*>> = [],
+  val isExtendable: Boolean = false,
 ) {
   /**
    * Graph factories can be declared as a single nested declaration within the target graph to


### PR DESCRIPTION
This introduces custom metadata that we'll eventually use to support both graph extensions and private providers. This metadata will be serialized into kotlin's own metadata and readable in downstream compilations.