### PR TITLE
Throws CliOptionProcessingException instead of IllegalStateException

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroCommandLineProcessor.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroCommandLineProcessor.kt
@@ -4,6 +4,7 @@ package dev.zacsweers.metro.compiler
 
 import com.google.auto.service.AutoService
 import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOptionProcessingException
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.config.CompilerConfiguration
 
@@ -21,7 +22,7 @@ public class MetroCommandLineProcessor : CommandLineProcessor {
     configuration: CompilerConfiguration,
   ) {
     when (val metroOption = MetroOption.entriesByOptionName[option.optionName]) {
-      null -> error("Unknown plugin option: ${option.optionName}")
+      null -> throw CliOptionProcessingException("Unknown plugin option: ${option.optionName}")
       else -> with(metroOption.raw) { configuration.put(value) }
     }
   }


### PR DESCRIPTION
If the compiler argument parsing fails in a Kotlin CLI, a [CliOptionProcessingException is thrown](https://github.com/JetBrains/kotlin/blob/928416c9c5fe0287ed38c11ce3e93051c76eb598/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/plugins/PluginsOptionsParser.kt#L63).

```kotlin
open class CliOptionProcessingException(
  message: String, 
  cause: Throwable? = null,
) : RuntimeException(message, cause)
```