### PR TITLE
Fix a function typo in dagger interop

### DIFF
--- a/interop-dagger/api/interop-dagger.api
+++ b/interop-dagger/api/interop-dagger.api
@@ -1,9 +1,9 @@
 public final class dev/zacsweers/metro/interop/dagger/DaggerInteropKt {
+	public static final fun asDaggerLazy (Lkotlin/Lazy;)Ldagger/Lazy;
 	public static final fun asDaggerMembersInjector (Ldev/zacsweers/metro/MembersInjector;)Ldagger/MembersInjector;
 	public static final fun asJakartaProvider (Ldev/zacsweers/metro/Provider;)Ljakarta/inject/Provider;
 	public static final fun asJavaxProvider (Ldev/zacsweers/metro/Provider;)Ljavax/inject/Provider;
 	public static final fun asKotlinLazy (Ldagger/Lazy;)Lkotlin/Lazy;
-	public static final fun asKotlinLazy (Lkotlin/Lazy;)Ldagger/Lazy;
 	public static final fun asMetroMembersInjector (Ldagger/MembersInjector;)Ldev/zacsweers/metro/MembersInjector;
 	public static final fun asMetroProvider (Ljakarta/inject/Provider;)Ldev/zacsweers/metro/Provider;
 	public static final fun asMetroProvider (Ljavax/inject/Provider;)Ldev/zacsweers/metro/Provider;

--- a/interop-dagger/src/main/kotlin/dev/zacsweers/metro/interop/dagger/daggerInterop.kt
+++ b/interop-dagger/src/main/kotlin/dev/zacsweers/metro/interop/dagger/daggerInterop.kt
@@ -57,8 +57,8 @@ public fun <T : Any> MetroProvider<T>.asJakartaProvider(): JakartaProvider<T> =
  *
  * @return A [dagger.Lazy] that delegates its invocation to the source [Lazy].
  */
-public fun <T : Any> Lazy<T>.asKotlinLazy(): dagger.Lazy<T> =
-  dagger.Lazy<T> { this@asKotlinLazy.value }
+public fun <T : Any> Lazy<T>.asDaggerLazy(): dagger.Lazy<T> =
+  dagger.Lazy<T> { this@asDaggerLazy.value }
 
 /**
  * Converts a Metro [MetroMembersInjector] into a Dagger [DaggerMembersInjector].


### PR DESCRIPTION
Spotted a typo when going through the dagger interop.

We plan to experiment Metro in our main BandLab Android app, we're currently using Dagger + Anvil KSP. We will see if we can adopt smoothly by keeping our custom KSP code gen, and provide some issues, contributions, and meaningful benchmarks. Thanks a lot for this framework 👍 