### PR TITLE
Simplify testData file paths in TestDataPluginSettings

### DIFF
--- a/.idea/kotlinTestDataPluginTestDataPaths.xml
+++ b/.idea/kotlinTestDataPluginTestDataPaths.xml
@@ -3,9 +3,7 @@
     <component name="TestDataPluginSettings">
         <option name="testDataFiles">
             <array>
-                <option value="$PROJECT_DIR$/compiler-tests/src/test/data/box"/>
-                <option value="$PROJECT_DIR$/compiler-tests/src/test/data/diagnostic"/>
-                <option value="$PROJECT_DIR$/compiler-tests/src/test/data/dump/fir"/>
+                <option value="$PROJECT_DIR$/compiler-tests/src/test/data"/>
             </array>
         </option>
     </component>


### PR DESCRIPTION
By making the testData path in TestDataPluginSettings less specific, we can avoid having to update TestDataPluginSettings whenever new testData folders are added in the future.

This approach is also [used in Kotlin](https://github.com/JetBrains/kotlin/blob/a783f6594518b99a4478e2e5d6c7e10da72c9b34/.idea/kotlinTestDataPluginTestDataPaths.xml#L80), and everything works fine.

<img src="https://github.com/user-attachments/assets/8c45133e-a716-41f7-938e-1edfd38a6155" width="80%" />


