### PR TITLE
Safe copy all parameter annotations from constructor args when generating factories (fixes #235)

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/builders.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/builders.kt
@@ -116,38 +116,37 @@ internal fun FirExtension.copyParameters(
     val originalFir = original.symbol.fir as FirValueParameter
     functionBuilder.valueParameters +=
       buildValueParameterCopy(originalFir) {
-        name = original.name
-        origin = Keys.ValueParameter.origin
-        symbol = FirValueParameterSymbol(original.symbol.name)
-        containingDeclarationSymbol = functionBuilder.symbol
-        parameterInit(original)
-        if (!copyParameterDefaults) {
-          if (originalFir.symbol.hasDefaultValue) {
-            defaultValue = buildFunctionCall {
-              this.coneTypeOrNull = session.builtinTypes.nothingType.coneType
-              this.calleeReference = buildResolvedNamedReference {
-                this.resolvedSymbol = session.metroFirBuiltIns.errorFunctionSymbol
-                this.name = session.metroFirBuiltIns.errorFunctionSymbol.name
+          name = original.name
+          origin = Keys.ValueParameter.origin
+          symbol = FirValueParameterSymbol(original.symbol.name)
+          containingDeclarationSymbol = functionBuilder.symbol
+          parameterInit(original)
+          if (!copyParameterDefaults) {
+            if (originalFir.symbol.hasDefaultValue) {
+              defaultValue = buildFunctionCall {
+                this.coneTypeOrNull = session.builtinTypes.nothingType.coneType
+                this.calleeReference = buildResolvedNamedReference {
+                  this.resolvedSymbol = session.metroFirBuiltIns.errorFunctionSymbol
+                  this.name = session.metroFirBuiltIns.errorFunctionSymbol.name
+                }
+                argumentList =
+                  buildResolvedArgumentList(
+                    buildArgumentList {
+                      this.arguments +=
+                        buildLiteralExpression(
+                          source = null,
+                          kind = ConstantValueKind.String,
+                          value = "Replaced in IR",
+                          setType = true,
+                        )
+                    },
+                    LinkedHashMap(),
+                  )
               }
-              argumentList =
-                buildResolvedArgumentList(
-                  buildArgumentList {
-                    this.arguments +=
-                      buildLiteralExpression(
-                        source = null,
-                        kind = ConstantValueKind.String,
-                        value = "Replaced in IR",
-                        setType = true,
-                      )
-                  },
-                  LinkedHashMap(),
-                )
             }
           }
         }
-      }.apply {
-        replaceAnnotationsSafe(original.symbol.annotations)
-      }
+        .apply { replaceAnnotationsSafe(original.symbol.annotations) }
   }
 }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/builders.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/builders.kt
@@ -145,6 +145,8 @@ internal fun FirExtension.copyParameters(
             }
           }
         }
+      }.apply {
+        replaceAnnotationsSafe(original.symbol.annotations)
       }
   }
 }

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/ForScope.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/ForScope.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
   AnnotationTarget.PROPERTY,
   AnnotationTarget.PROPERTY_GETTER,
   AnnotationTarget.VALUE_PARAMETER,
+  AnnotationTarget.TYPE,
 )
 @Qualifier
 public annotation class ForScope(val scope: KClass<*>)


### PR DESCRIPTION
This helps ensure that more complex use-cases like parameters annotated with `@ForScope` or annotations with class arguments are resolved in time for some compiler validation checks.

fixes https://github.com/ZacSweers/metro/issues/235