### PR TITLE
Add validation for @Provides methods found in objects

### DIFF
--- a/compiler-tests/src/test/data/diagnostic/provides/ProvidesCannotLiveInObjects.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/provides/ProvidesCannotLiveInObjects.fir.diag.txt
@@ -1,0 +1,1 @@
+/ProvidesCannotLiveInObjects.kt:(104,117): error: @Provides declarations must be within an interface, class, or companion object. `provideString` appears to be defined directly within a (non-companion) object.

--- a/compiler-tests/src/test/data/diagnostic/provides/ProvidesCannotLiveInObjects.kt
+++ b/compiler-tests/src/test/data/diagnostic/provides/ProvidesCannotLiveInObjects.kt
@@ -1,0 +1,5 @@
+// RENDER_DIAGNOSTICS_FULL_TEXT
+
+object InvalidContainer {
+  @Provides fun <!PROVIDES_ERROR!>provideString<!>(): String = "Hello"
+}

--- a/compiler-tests/src/test/data/diagnostic/provides/ProvidesFunctionsCannotBeTopLevel.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/provides/ProvidesFunctionsCannotBeTopLevel.fir.diag.txt
@@ -1,1 +1,1 @@
-/ProvidesFunctionsCannotBeTopLevel.kt:(150,160): error: @Provides/@Binds declarations must be within a class/object/interface
+/ProvidesFunctionsCannotBeTopLevel.kt:(150,160): error: @Provides/@Binds declarations must be within an interface, class, or companion object. If you're seeing this, `provideInt` is likely defined as a top-level method which isn't supported.

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/DiagnosticTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/DiagnosticTestGenerated.java
@@ -127,6 +127,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
     }
 
     @Test
+    @TestMetadata("ProvidesCannotLiveInObjects.kt")
+    public void testProvidesCannotLiveInObjects() {
+      runTest("compiler-tests/src/test/data/diagnostic/provides/ProvidesCannotLiveInObjects.kt");
+    }
+
+    @Test
     @TestMetadata("ProvidesFunctionsCannotBeTopLevel.kt")
     public void testProvidesFunctionsCannotBeTopLevel() {
       runTest("compiler-tests/src/test/data/diagnostic/provides/ProvidesFunctionsCannotBeTopLevel.kt");


### PR DESCRIPTION
Currently this is not supported and `@Provides` must live within a class, interface, or companion object. Previously, when migrating from Dagger+Anvil, non-contributed `@Modules` defined as objects result in a `NullPointerException` in IR for the `ProvidesTransformer`:

```
> Task :some:module:compileDebugKotlin FAILED
e: java.lang.NullPointerException
        at dev.zacsweers.metro.compiler.ir.transformers.ProvidesTransformer.getOrLookupFactoryClass(ProvidesTransformer.kt:276)
        at dev.zacsweers.metro.compiler.ir.transformers.ProvidesTransformer.visitFunction(ProvidesTransformer.kt:147)
        at dev.zacsweers.metro.compiler.ir.transformers.ProvidesTransformer.visitClass(ProvidesTransformer.kt:97)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitClass(DependencyGraphTransformer.kt:234)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitClass(DependencyGraphTransformer.kt:130)
```

 These changes make it so we catch the situation earlier and present an explicit error message pointing to the class+method in question.

Also update the error message for top-level `@Provides`/`@Binds` functions to be more explicit.