### PR TITLE
Add interop support for Anvil's ContributesMultibinding annotation

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ClassIds.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ClassIds.kt
@@ -15,6 +15,7 @@ public class ClassIds(
   customBindsAnnotations: Set<ClassId> = emptySet(),
   customContributesToAnnotations: Set<ClassId> = emptySet(),
   customContributesBindingAnnotations: Set<ClassId> = emptySet(),
+  internal val customContributesIntoSetAnnotations: Set<ClassId> = emptySet(),
   customElementsIntoSetAnnotations: Set<ClassId> = emptySet(),
   customGraphAnnotations: Set<ClassId> = emptySet(),
   customGraphFactoryAnnotations: Set<ClassId> = emptySet(),
@@ -102,7 +103,8 @@ public class ClassIds(
     contributesToAnnotations +
       contributesBindingAnnotations +
       contributesIntoSetAnnotations +
-      contributesIntoMapAnnotations
+      contributesIntoMapAnnotations +
+      customContributesIntoSetAnnotations
 
   internal val providerTypes = setOf(Symbols.ClassIds.metroProvider) + customProviderClasses
   internal val lazyTypes = setOf(Symbols.ClassIds.lazy) + customLazyClasses

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroCompilerPluginRegistrar.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroCompilerPluginRegistrar.kt
@@ -34,6 +34,7 @@ public class MetroCompilerPluginRegistrar : CompilerPluginRegistrar() {
         customBindsAnnotations = options.customBindsAnnotations,
         customContributesToAnnotations = options.customContributesToAnnotations,
         customContributesBindingAnnotations = options.customContributesBindingAnnotations,
+        customContributesIntoSetAnnotations = options.customContributesIntoSetAnnotations,
         customElementsIntoSetAnnotations = options.customElementsIntoSetAnnotations,
         customGraphAnnotations = options.customGraphAnnotations,
         customGraphFactoryAnnotations = options.customGraphFactoryAnnotations,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
@@ -228,6 +228,17 @@ internal enum class MetroOption(val raw: RawMetroOption<*>) {
       valueMapper = { it.splitToSequence(':').mapToSet { ClassId.fromString(it, false) } },
     )
   ),
+  CUSTOM_CONTRIBUTES_INTO_SET(
+    RawMetroOption(
+      name = "custom-contributes-into-set",
+      defaultValue = emptySet(),
+      valueDescription = "ContributesIntoSet annotations",
+      description = "ContributesIntoSet annotations",
+      required = false,
+      allowMultipleOccurrences = false,
+      valueMapper = { it.splitToSequence(':').mapToSet { ClassId.fromString(it, false) } },
+    )
+  ),
   CUSTOM_ELEMENTS_INTO_SET(
     RawMetroOption(
       name = "custom-elements-into-set",
@@ -389,6 +400,8 @@ public data class MetroOptions(
     MetroOption.CUSTOM_CONTRIBUTES_TO.raw.defaultValue.expectAs(),
   val customContributesBindingAnnotations: Set<ClassId> =
     MetroOption.CUSTOM_CONTRIBUTES_BINDING.raw.defaultValue.expectAs(),
+  val customContributesIntoSetAnnotations: Set<ClassId> =
+    MetroOption.CUSTOM_CONTRIBUTES_INTO_SET.raw.defaultValue.expectAs(),
   val customElementsIntoSetAnnotations: Set<ClassId> =
     MetroOption.CUSTOM_ELEMENTS_INTO_SET.raw.defaultValue.expectAs(),
   val customGraphAnnotations: Set<ClassId> = MetroOption.CUSTOM_GRAPH.raw.defaultValue.expectAs(),
@@ -434,6 +447,7 @@ public data class MetroOptions(
       val customProvidesAnnotations = mutableSetOf<ClassId>()
       val customQualifierAnnotations = mutableSetOf<ClassId>()
       val customScopeAnnotations = mutableSetOf<ClassId>()
+      val customContributesIntoSetAnnotations = mutableSetOf<ClassId>()
 
       for (entry in MetroOption.entries) {
         when (entry) {
@@ -509,6 +523,8 @@ public data class MetroOptions(
           MetroOption.CUSTOM_QUALIFIER ->
             customQualifierAnnotations.addAll(configuration.getAsSet(entry))
           MetroOption.CUSTOM_SCOPE -> customScopeAnnotations.addAll(configuration.getAsSet(entry))
+          MetroOption.CUSTOM_CONTRIBUTES_INTO_SET ->
+            customContributesIntoSetAnnotations.addAll(configuration.getAsSet(entry))
         }
       }
 
@@ -538,6 +554,7 @@ public data class MetroOptions(
           customProvidesAnnotations = customProvidesAnnotations,
           customQualifierAnnotations = customQualifierAnnotations,
           customScopeAnnotations = customScopeAnnotations,
+          customContributesIntoSetAnnotations = customContributesIntoSetAnnotations,
         )
 
       return options

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionsFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionsFirGenerator.kt
@@ -129,6 +129,18 @@ internal class ContributionsFirGenerator(session: FirSession) :
               listOf(buildIntoMapAnnotation(), buildBindsAnnotation())
             }
         }
+        in session.classIds.customContributesIntoSetAnnotations -> {
+          contributions +=
+            if (contributingSymbol.mapKeyAnnotation(session) != null) {
+              Contribution.ContributesIntoMapBinding(contributingSymbol, annotation) {
+                listOf(buildIntoMapAnnotation(), buildBindsAnnotation())
+              }
+            } else {
+              Contribution.ContributesIntoSetBinding(contributingSymbol, annotation) {
+                listOf(buildIntoSetAnnotation(), buildBindsAnnotation())
+              }
+            }
+        }
       }
     }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
@@ -188,6 +188,13 @@ abstract class MetroCompilerTest {
                 if (customScopeAnnotations.isEmpty()) continue
                 processor.option(entry.raw.cliOption, customScopeAnnotations.joinToString(":"))
               }
+              MetroOption.CUSTOM_CONTRIBUTES_INTO_SET -> {
+                if (customContributesIntoSetAnnotations.isEmpty()) continue
+                processor.option(
+                  entry.raw.cliOption,
+                  customContributesIntoSetAnnotations.joinToString(":"),
+                )
+              }
             }
           yield(option)
         }

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -40,6 +40,7 @@ public abstract class dev/zacsweers/metro/gradle/MetroPluginExtension$InteropHan
 	public final fun getAssistedInject ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getBinds ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getContributesBinding ()Lorg/gradle/api/provider/SetProperty;
+	public final fun getContributesIntoSet ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getContributesTo ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getElementsIntoSet ()Lorg/gradle/api/provider/SetProperty;
 	public abstract fun getEnableDaggerRuntimeInterop ()Lorg/gradle/api/provider/Property;

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
@@ -112,6 +112,11 @@ public class MetroGradleSubplugin : KotlinCompilerPluginSupportPlugin {
               .takeUnless { it.isEmpty() }
               ?.let { SubpluginOption("custom-contributes-binding", value = it.joinToString(":")) }
               ?.let(::add)
+          contributesIntoSet
+              .getOrElse(emptySet())
+              .takeUnless { it.isEmpty() }
+              ?.let { SubpluginOption("custom-contributes-into-set", value = it.joinToString(":")) }
+              ?.let(::add)
           elementsIntoSet
               .getOrElse(emptySet())
               .takeUnless { it.isEmpty() }

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
@@ -83,6 +83,7 @@ public abstract class MetroPluginExtension @Inject constructor(objects: ObjectFa
     public val binds: SetProperty<String> = objects.setProperty(String::class.java)
     public val contributesTo: SetProperty<String> = objects.setProperty(String::class.java)
     public val contributesBinding: SetProperty<String> = objects.setProperty(String::class.java)
+    public val contributesIntoSet: SetProperty<String> = objects.setProperty(String::class.java)
     public val elementsIntoSet: SetProperty<String> = objects.setProperty(String::class.java)
     public val graph: SetProperty<String> = objects.setProperty(String::class.java)
     public val graphFactory: SetProperty<String> = objects.setProperty(String::class.java)
@@ -168,6 +169,7 @@ public abstract class MetroPluginExtension @Inject constructor(objects: ObjectFa
         graphFactory.add("com/squareup/anvil/annotations/MergeComponent.Factory")
         contributesTo.add("com/squareup/anvil/annotations/ContributesTo")
         contributesBinding.add("com/squareup/anvil/annotations/ContributesBinding")
+        contributesIntoSet.add("com/squareup/anvil/annotations/ContributesMultibinding")
       }
       if (includeKotlinInjectAnvil) {
         graph.add("software/amazon/lastmile/kotlin/inject/anvil/MergeComponent")


### PR DESCRIPTION
This change adds interop support for dagger anvil's `@ContributeMultibinding` annotation. Annotated classes will behave the same as `@ContributesIntoSet`, UNLESS it is also annotated with `@MapKey`, in which case it will behave as `@ContributesIntoMap`.