### PR TITLE
Prevent duplicate bindings when using multiple Contributes* annotations

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionsFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionsFirGenerator.kt
@@ -225,18 +225,11 @@ internal class ContributionsFirGenerator(session: FirSession) :
     if (!owner.hasOrigin(Keys.MetroContributionClassDeclaration)) return emptyList()
     val origin = owner.getContainingClassSymbol() as? FirClassSymbol<*> ?: return emptyList()
     val contributions = findContributions(origin) ?: return emptyList()
-    val properties =
-      contributions.mapNotNull { contribution ->
-        when (contribution) {
-          is Contribution.ContributesBinding,
-          is Contribution.ContributesIntoSetBinding,
-          is Contribution.ContributesIntoMapBinding -> {
-            buildBindingProperty(owner, contribution)
-          }
-          is Contribution.ContributesTo -> null
-        }
-      }
-    return properties
+
+    return contributions
+      .filterIsInstance<Contribution.BindingContribution>()
+      .filter { it.callableName == callableId.callableName.identifier }
+      .map { contribution -> buildBindingProperty(owner, contribution) }
   }
 
   private fun buildBindingProperty(


### PR DESCRIPTION
The underlying issue was that generateProperties is called once for each contribution type present and findContributions matches all contributions for the type. This resulted in duplicate properties being generated, now filter the results of findContributions using the callableId.

Fixes: https://github.com/ZacSweers/metro/issues/261