### PR TITLE
Move Anvil tests to Kotlin test infrastructure

### DIFF
--- a/compiler-tests/build.gradle.kts
+++ b/compiler-tests/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
   java
 }
 
-val metroRuntimeClasspath: Configuration by configurations.creating
+val metroRuntimeClasspath: Configuration by configurations.creating { isTransitive = false }
+val anvilRuntimeClasspath: Configuration by configurations.creating { isTransitive = false }
 
 dependencies {
   testImplementation(project(":compiler"))
@@ -15,6 +16,8 @@ dependencies {
   testImplementation(libs.kotlin.compiler)
 
   metroRuntimeClasspath(project(":runtime"))
+  anvilRuntimeClasspath(libs.anvil.annotations)
+  anvilRuntimeClasspath(libs.anvil.annotations.optional)
 
   // Dependencies required to run the internal test framework.
   testRuntimeOnly(libs.kotlin.reflect)
@@ -47,6 +50,7 @@ tasks.withType<Test> {
   useJUnitPlatform()
 
   systemProperty("metroRuntime.classpath", metroRuntimeClasspath.asPath)
+  systemProperty("anvilRuntime.classpath", anvilRuntimeClasspath.asPath)
 
   // Properties required to run the internal test framework.
   systemProperty("idea.ignore.disabled.plugins", "true")

--- a/compiler-tests/src/test/data/box/aggregation/ContributesMultibindingInteropAnnotationsAddBindingToSetOrMapWithMapKey.kt
+++ b/compiler-tests/src/test/data/box/aggregation/ContributesMultibindingInteropAnnotationsAddBindingToSetOrMapWithMapKey.kt
@@ -1,0 +1,32 @@
+// WITH_ANVIL
+
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlin.test.*
+
+interface ContributedInterface
+interface SecondInterface
+
+@ContributesMultibinding(AppScope::class, boundType = ContributedInterface::class)
+@Inject class Impl : ContributedInterface, SecondInterface
+
+@MapKey annotation class MyKey(val key: Int)
+
+@MyKey(1)
+@ContributesMultibinding(AppScope::class, boundType = SecondInterface::class)
+@Inject class MapImpl : ContributedInterface, SecondInterface
+
+@DependencyGraph(scope = AppScope::class)
+interface ExampleGraph {
+  val contributedSet: Set<ContributedInterface>
+  val contributedMap: Map<Int, SecondInterface>
+}
+
+fun box(): String {
+  val graph = createGraph<ExampleGraph>()
+  val contributedSet = graph.contributedSet
+  assertEquals(contributedSet.single()::class.qualifiedName, "Impl")
+  val contributedMap = graph.contributedMap
+  assertEquals(contributedMap.keys.single(), 1)
+  assertEquals(contributedMap.values.single()::class.qualifiedName, "MapImpl")
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/aggregation/RepeatedContributesBindingAnvilInteropWorksForBoundTypeAndIgnoreQualifier.kt
+++ b/compiler-tests/src/test/data/box/aggregation/RepeatedContributesBindingAnvilInteropWorksForBoundTypeAndIgnoreQualifier.kt
@@ -1,0 +1,30 @@
+// WITH_ANVIL
+
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlin.test.*
+
+interface ContributedInterface
+interface SecondInterface
+
+@SingleIn(AppScope::class)
+@ForScope(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = SecondInterface::class)
+@ContributesBinding(AppScope::class, boundType = ContributedInterface::class, ignoreQualifier = true)
+@Inject
+class Impl : ContributedInterface, SecondInterface
+
+@DependencyGraph(scope = AppScope::class)
+interface ExampleGraph {
+  val contributedInterface: ContributedInterface
+  @ForScope(AppScope::class) val secondInterface: SecondInterface
+}
+
+fun box(): String {
+  val graph = createGraph<ExampleGraph>()
+  val contributedInterface = graph.contributedInterface
+  assertNotNull(contributedInterface)
+  assertEquals(contributedInterface::class.qualifiedName, "Impl")
+  val secondInterface = graph.secondInterface
+  assertEquals<Any>(contributedInterface, secondInterface)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -23,6 +23,28 @@ public class BoxTestGenerated extends AbstractBoxTest {
   }
 
   @Nested
+  @TestMetadata("compiler-tests/src/test/data/box/aggregation")
+  @TestDataPath("$PROJECT_ROOT")
+  public class Aggregation {
+    @Test
+    public void testAllFilesPresentInAggregation() {
+      KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler-tests/src/test/data/box/aggregation"), Pattern.compile("^(.+)\\.kt$"), null, TargetBackend.JVM_IR, true);
+    }
+
+    @Test
+    @TestMetadata("ContributesMultibindingInteropAnnotationsAddBindingToSetOrMapWithMapKey.kt")
+    public void testContributesMultibindingInteropAnnotationsAddBindingToSetOrMapWithMapKey() {
+      runTest("compiler-tests/src/test/data/box/aggregation/ContributesMultibindingInteropAnnotationsAddBindingToSetOrMapWithMapKey.kt");
+    }
+
+    @Test
+    @TestMetadata("RepeatedContributesBindingAnvilInteropWorksForBoundTypeAndIgnoreQualifier.kt")
+    public void testRepeatedContributesBindingAnvilInteropWorksForBoundTypeAndIgnoreQualifier() {
+      runTest("compiler-tests/src/test/data/box/aggregation/RepeatedContributesBindingAnvilInteropWorksForBoundTypeAndIgnoreQualifier.kt");
+    }
+  }
+
+  @Nested
   @TestMetadata("compiler-tests/src/test/data/box/member")
   @TestDataPath("$PROJECT_ROOT")
   public class Member {

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroDirectives.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroDirectives.kt
@@ -8,4 +8,7 @@ object MetroDirectives : SimpleDirectivesContainer() {
   val GENERATE_ASSISTED_FACTORIES by directive("Enable assisted factories generation.")
   val PUBLIC_PROVIDER_SEVERITY by
     enumDirective<MetroOptions.DiagnosticSeverity>("Enable assisted factories generation.")
+
+  // Dependency directives.
+  val WITH_ANVIL by directive("Add Anvil as dependency and configure custom annotations.")
 }

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/RuntimeTestServices.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/RuntimeTestServices.kt
@@ -14,7 +14,7 @@ private val metroRuntimeClasspath =
   System.getProperty("metroRuntime.classpath")?.split(File.pathSeparator)?.map(::File)
     ?: error("Unable to get a valid classpath from 'metroRuntime.classpath' property")
 
-class RuntimeEnvironmentConfigurator(testServices: TestServices) :
+class MetroRuntimeEnvironmentConfigurator(testServices: TestServices) :
   EnvironmentConfigurator(testServices) {
   override fun configureCompilerConfiguration(
     configuration: CompilerConfiguration,

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/interop/AnvilRuntimeTestServices.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/interop/AnvilRuntimeTestServices.kt
@@ -1,0 +1,46 @@
+// Copyright (C) 2025 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.compiler.interop
+
+import dev.zacsweers.metro.compiler.MetroDirectives
+import java.io.File
+import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
+import org.jetbrains.kotlin.test.services.RuntimeClasspathProvider
+import org.jetbrains.kotlin.test.services.TestServices
+
+private val anvilRuntimeClasspath =
+  System.getProperty("anvilRuntime.classpath")?.split(File.pathSeparator)?.map(::File)
+    ?: error("Unable to get a valid classpath from 'anvilRuntime.classpath' property")
+
+fun TestConfigurationBuilder.configureAnvilAnnotations() {
+  useConfigurators(::AnvilRuntimeEnvironmentConfigurator)
+  useCustomRuntimeClasspathProviders(::AnvilRuntimeClassPathProvider)
+}
+
+class AnvilRuntimeEnvironmentConfigurator(testServices: TestServices) :
+  EnvironmentConfigurator(testServices) {
+  override fun configureCompilerConfiguration(
+    configuration: CompilerConfiguration,
+    module: TestModule,
+  ) {
+    if (MetroDirectives.WITH_ANVIL in module.directives) {
+      for (file in anvilRuntimeClasspath) {
+        configuration.addJvmClasspathRoot(file)
+      }
+    }
+  }
+}
+
+class AnvilRuntimeClassPathProvider(testServices: TestServices) :
+  RuntimeClasspathProvider(testServices) {
+  override fun runtimeClassPaths(module: TestModule): List<File> {
+    return when (MetroDirectives.WITH_ANVIL in module.directives) {
+      true -> anvilRuntimeClasspath
+      false -> emptyList()
+    }
+  }
+}

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ClassIds.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ClassIds.kt
@@ -28,6 +28,32 @@ public class ClassIds(
   customQualifierAnnotations: Set<ClassId> = emptySet(),
   customScopeAnnotations: Set<ClassId> = emptySet(),
 ) {
+  public companion object {
+    public fun fromOptions(options: MetroOptions): ClassIds =
+      ClassIds(
+        customProviderClasses = options.customProviderTypes,
+        customLazyClasses = options.customLazyTypes,
+        customAssistedAnnotations = options.customAssistedAnnotations,
+        customAssistedFactoryAnnotations = options.customAssistedFactoryAnnotations,
+        customAssistedInjectAnnotations = options.customAssistedInjectAnnotations,
+        customBindsAnnotations = options.customBindsAnnotations,
+        customContributesToAnnotations = options.customContributesToAnnotations,
+        customContributesBindingAnnotations = options.customContributesBindingAnnotations,
+        customContributesIntoSetAnnotations = options.customContributesIntoSetAnnotations,
+        customElementsIntoSetAnnotations = options.customElementsIntoSetAnnotations,
+        customGraphAnnotations = options.customGraphAnnotations,
+        customGraphFactoryAnnotations = options.customGraphFactoryAnnotations,
+        customInjectAnnotations = options.customInjectAnnotations,
+        customIntoMapAnnotations = options.customIntoMapAnnotations,
+        customIntoSetAnnotations = options.customIntoSetAnnotations,
+        customMapKeyAnnotations = options.customMapKeyAnnotations,
+        customMultibindsAnnotations = options.customMultibindsAnnotations,
+        customProvidesAnnotations = options.customProvidesAnnotations,
+        customQualifierAnnotations = options.customQualifierAnnotations,
+        customScopeAnnotations = options.customScopeAnnotations,
+      )
+  }
+
   private fun FqName.classIdOf(simpleName: String): ClassId {
     return classIdOf(Name.identifier(simpleName))
   }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroCompilerPluginRegistrar.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroCompilerPluginRegistrar.kt
@@ -24,29 +24,7 @@ public class MetroCompilerPluginRegistrar : CompilerPluginRegistrar() {
 
     if (!options.enabled) return
 
-    val classIds =
-      ClassIds(
-        customProviderClasses = options.customProviderTypes,
-        customLazyClasses = options.customLazyTypes,
-        customAssistedAnnotations = options.customAssistedAnnotations,
-        customAssistedFactoryAnnotations = options.customAssistedFactoryAnnotations,
-        customAssistedInjectAnnotations = options.customAssistedInjectAnnotations,
-        customBindsAnnotations = options.customBindsAnnotations,
-        customContributesToAnnotations = options.customContributesToAnnotations,
-        customContributesBindingAnnotations = options.customContributesBindingAnnotations,
-        customContributesIntoSetAnnotations = options.customContributesIntoSetAnnotations,
-        customElementsIntoSetAnnotations = options.customElementsIntoSetAnnotations,
-        customGraphAnnotations = options.customGraphAnnotations,
-        customGraphFactoryAnnotations = options.customGraphFactoryAnnotations,
-        customInjectAnnotations = options.customInjectAnnotations,
-        customIntoMapAnnotations = options.customIntoMapAnnotations,
-        customIntoSetAnnotations = options.customIntoSetAnnotations,
-        customMapKeyAnnotations = options.customMapKeyAnnotations,
-        customMultibindsAnnotations = options.customMultibindsAnnotations,
-        customProvidesAnnotations = options.customProvidesAnnotations,
-        customQualifierAnnotations = options.customQualifierAnnotations,
-        customScopeAnnotations = options.customScopeAnnotations,
-      )
+    val classIds = ClassIds.fromOptions(options)
 
     if (options.debug) {
       configuration.messageCollector.report(


### PR DESCRIPTION
I saw #276 and thought I would show how to use external dependencies within the Kotlin test infrastructure. Here I'm loading the Anvil annotations if the new `WITH_ANVIL` directive is added. This adds the required jar files to the compile and runtime classpaths and adds annotations to the configuration. A similar pattern could be repeated for all other libraries you what to test interop with.