### PR TITLE
Add ContributesBinding.rank interop support

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -96,4 +96,5 @@ dependencies {
   testImplementation(libs.coroutines.test)
   testImplementation(libs.dagger.compiler)
   testImplementation(libs.dagger.runtime)
+  testImplementation(libs.anvil.annotations)
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
@@ -369,6 +369,17 @@ internal enum class MetroOption(val raw: RawMetroOption<*>) {
       allowMultipleOccurrences = false,
       valueMapper = { it.splitToSequence(':').mapToSet { ClassId.fromString(it, false) } },
     )
+  ),
+  ENABLE_DAGGER_ANVIL_INTEROP(
+    RawMetroOption.boolean(
+      name = "enable-dagger-anvil-interop",
+      defaultValue = false,
+      valueDescription = "<true | false>",
+      description =
+        "Enable/disable interop with Dagger Anvil's additional functionality (currently for 'rank' support).",
+      required = false,
+      allowMultipleOccurrences = false,
+    )
   );
 
   companion object {
@@ -433,6 +444,8 @@ public data class MetroOptions(
   val customQualifierAnnotations: Set<ClassId> =
     MetroOption.CUSTOM_QUALIFIER.raw.defaultValue.expectAs(),
   val customScopeAnnotations: Set<ClassId> = MetroOption.CUSTOM_SCOPE.raw.defaultValue.expectAs(),
+  val enableDaggerAnvilInterop: Boolean =
+    MetroOption.ENABLE_DAGGER_ANVIL_INTEROP.raw.defaultValue.expectAs(),
 ) {
   internal companion object {
     fun load(configuration: CompilerConfiguration): MetroOptions {
@@ -540,6 +553,10 @@ public data class MetroOptions(
           MetroOption.CUSTOM_SCOPE -> customScopeAnnotations.addAll(configuration.getAsSet(entry))
           MetroOption.CUSTOM_CONTRIBUTES_INTO_SET ->
             customContributesIntoSetAnnotations.addAll(configuration.getAsSet(entry))
+
+          MetroOption.ENABLE_DAGGER_ANVIL_INTEROP -> {
+            options = options.copy(enableDaggerAnvilInterop = configuration.getAsBoolean(entry))
+          }
         }
       }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/AggregationChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/AggregationChecker.kt
@@ -11,6 +11,7 @@ import dev.zacsweers.metro.compiler.fir.findInjectConstructors
 import dev.zacsweers.metro.compiler.fir.isAnnotatedWithAny
 import dev.zacsweers.metro.compiler.fir.isOrImplements
 import dev.zacsweers.metro.compiler.fir.mapKeyAnnotation
+import dev.zacsweers.metro.compiler.fir.metroFirBuiltIns
 import dev.zacsweers.metro.compiler.fir.qualifierAnnotation
 import dev.zacsweers.metro.compiler.fir.rankArgument
 import dev.zacsweers.metro.compiler.fir.resolvedBindingArgument
@@ -290,13 +291,16 @@ internal object AggregationChecker : FirClassChecker(MppCheckerKind.Common) {
             context,
           )
           return false
-        } else if (annotation.rankArgument() != null) {
+        } else if (
+          session.metroFirBuiltIns.options.enableDaggerAnvilInterop &&
+            annotation.rankArgument() != null
+        ) {
           val errorMessage =
             """
               `@$kind`-annotated class ${declaration.symbol.classId.asSingleFqName()} sets a rank but doesn't declare its binding type.
               Bindings with non-default ranks must declare explicit binding types. This is because
               we're not able to resolve supertypes to get the implicit binding type when
-              processing ranked contributions. 
+              processing ranked contributions.
             """
               .trimIndent()
           reporter.reportOn(

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/AggregationChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/AggregationChecker.kt
@@ -12,6 +12,7 @@ import dev.zacsweers.metro.compiler.fir.isAnnotatedWithAny
 import dev.zacsweers.metro.compiler.fir.isOrImplements
 import dev.zacsweers.metro.compiler.fir.mapKeyAnnotation
 import dev.zacsweers.metro.compiler.fir.qualifierAnnotation
+import dev.zacsweers.metro.compiler.fir.rankArgument
 import dev.zacsweers.metro.compiler.fir.resolvedBindingArgument
 import dev.zacsweers.metro.compiler.fir.resolvedScopeClassId
 import dev.zacsweers.metro.compiler.unsafeLazy
@@ -286,6 +287,22 @@ internal object AggregationChecker : FirClassChecker(MppCheckerKind.Common) {
             annotation.source,
             FirMetroErrors.AGGREGATION_ERROR,
             "`@$kind`-annotated class @${classId.asSingleFqName()} doesn't declare an explicit `bindingType` but has multiple supertypes. You must define an explicit bound type in this scenario.",
+            context,
+          )
+          return false
+        } else if (annotation.rankArgument() != null) {
+          val errorMessage =
+            """
+              `@$kind`-annotated class ${declaration.symbol.classId.asSingleFqName()} sets a rank but doesn't declare its binding type.
+              Bindings with non-default ranks must declare explicit binding types. This is because
+              we're not able to resolve supertypes to get the implicit binding type when
+              processing ranked contributions. 
+            """
+              .trimIndent()
+          reporter.reportOn(
+            annotation.source,
+            FirMetroErrors.AGGREGATION_ERROR,
+            errorMessage,
             context,
           )
           return false

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -6,20 +6,21 @@ import dev.zacsweers.metro.compiler.ClassIds
 import dev.zacsweers.metro.compiler.Symbols
 import dev.zacsweers.metro.compiler.fir.annotationsIn
 import dev.zacsweers.metro.compiler.fir.classIds
+import dev.zacsweers.metro.compiler.fir.rankValue
 import dev.zacsweers.metro.compiler.fir.resolvedAdditionalScopesClassIds
+import dev.zacsweers.metro.compiler.fir.resolvedBindingArgument
 import dev.zacsweers.metro.compiler.fir.resolvedExcludedClassIds
 import dev.zacsweers.metro.compiler.fir.resolvedReplacedClassIds
 import dev.zacsweers.metro.compiler.fir.resolvedScopeClassId
 import dev.zacsweers.metro.compiler.fir.scopeArgument
 import java.util.TreeMap
-import kotlin.sequences.forEach
+import kotlin.collections.plusAssign
 import org.jetbrains.kotlin.fir.FirAnnotationContainer
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.getContainingClassSymbol
 import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.declarations.FirClassLikeDeclaration
-import org.jetbrains.kotlin.fir.declarations.utils.classId
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation
 import org.jetbrains.kotlin.fir.extensions.FirSupertypeGenerationExtension
 import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
@@ -28,11 +29,14 @@ import org.jetbrains.kotlin.fir.moduleData
 import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.resolve.toClassSymbol
 import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.ConeClassLikeType
 import org.jetbrains.kotlin.fir.types.ConeKotlinType
 import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.fir.types.classId
+import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.constructClassLikeType
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -215,6 +219,86 @@ internal class ContributedInterfaceSupertypeGenerator(
       // TODO warn?
     }
 
+    // TODO(j) should short-circuit if interop isn't enabled
+    val unmatchedRankReplacements = mutableSetOf<ClassId>()
+    val pendingRankReplacements = processRankBasedReplacements(contributions, typeResolver)
+
+    pendingRankReplacements.distinct().forEach { replacedClassId ->
+      val removed = contributions.remove(replacedClassId)
+      if (removed != null) {
+        unmatchedRankReplacements += replacedClassId
+      }
+    }
+
+    if (unmatchedRankReplacements.isNotEmpty()) {
+      // TODO we could report all rank based replacements here
+    }
+
     return contributions.values.toList()
   }
+
+  /**
+   * This is an imperfect solution to provide `rank` interop for users migrating from Dagger-Anvil.
+   * We're not able to get 1:1 parity due to some type restrictions but it should be enough to make
+   * the migration much more feasible in large projects that have a lot of ranked bindings.
+   *
+   * There are two important limitations to note here:
+   * 1. Ranked bindings and bindings that get outranked must both explicitly declare their binding
+   *    type in order for us to actually compare them, because supertypes are not resolvable here.
+   *    The user will end up getting a duplicate binding error if the outranked binding is using an
+   *    implicit type.
+   * 2. We can't check for qualifiers when comparing these bindings because those annotation calls
+   *    are not resolved at this point. E.g. a compiler critical annotation
+   *    like @ContributesBinding(..) will be resolved but @Named(..) will not. This means that
+   *    qualifiers are unsupported for rank interop support. Rank can only effectively be used for
+   *    binding types where all of them are unqualified or all use the same qualifier. Other
+   *    combinations will need to be migrated to instead use explicit replacements or exclusions.
+   *
+   * @return The bindings which have been outranked and should not be included in the merged graph.
+   */
+  private fun processRankBasedReplacements(
+    contributions: TreeMap<ClassId, ConeKotlinType>,
+    typeResolver: TypeResolveService,
+  ): Set<ClassId> {
+    val pendingRankReplacements = mutableSetOf<ClassId>()
+
+    val rankedBindings =
+      contributions.values
+        .filterIsInstance<ConeClassLikeType>()
+        .mapNotNull { it.toClassSymbol(session)?.getContainingClassSymbol() }
+        .flatMap { contributingType ->
+          contributingType.annotations
+            .annotationsIn(session, session.classIds.contributesBindingAnnotations)
+            .mapNotNull { annotation ->
+              annotation.resolvedBindingArgument(session, typeResolver)?.let { bindingArg ->
+                ContributedBinding(contributingType, bindingArg, annotation.rankValue())
+              }
+            }
+        }
+    val bindingGroups =
+      rankedBindings
+        .groupBy { binding -> binding.boundType?.coneType }
+        .filter { bindingGroup -> bindingGroup.value.size > 1 }
+
+    for (bindingGroup in bindingGroups.values) {
+      val topBindings =
+        bindingGroup
+          .groupBy { binding -> binding.rank }
+          .toSortedMap()
+          .let { it.getValue(it.lastKey()) }
+
+      // These are the bindings that were outranked and should not be processed further
+      bindingGroup.minus(topBindings).forEach {
+        pendingRankReplacements += it.contributingType.classId
+      }
+    }
+
+    return pendingRankReplacements
+  }
+
+  private data class ContributedBinding(
+    val contributingType: FirClassLikeSymbol<*>,
+    val boundType: FirTypeRef?,
+    val rank: Long,
+  )
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -6,6 +6,7 @@ import dev.zacsweers.metro.compiler.ClassIds
 import dev.zacsweers.metro.compiler.Symbols
 import dev.zacsweers.metro.compiler.fir.annotationsIn
 import dev.zacsweers.metro.compiler.fir.classIds
+import dev.zacsweers.metro.compiler.fir.metroFirBuiltIns
 import dev.zacsweers.metro.compiler.fir.rankValue
 import dev.zacsweers.metro.compiler.fir.resolvedAdditionalScopesClassIds
 import dev.zacsweers.metro.compiler.fir.resolvedBindingArgument
@@ -219,19 +220,20 @@ internal class ContributedInterfaceSupertypeGenerator(
       // TODO warn?
     }
 
-    // TODO(j) should short-circuit if interop isn't enabled
-    val unmatchedRankReplacements = mutableSetOf<ClassId>()
-    val pendingRankReplacements = processRankBasedReplacements(contributions, typeResolver)
+    if (session.metroFirBuiltIns.options.enableDaggerAnvilInterop) {
+      val unmatchedRankReplacements = mutableSetOf<ClassId>()
+      val pendingRankReplacements = processRankBasedReplacements(contributions, typeResolver)
 
-    pendingRankReplacements.distinct().forEach { replacedClassId ->
-      val removed = contributions.remove(replacedClassId)
-      if (removed != null) {
-        unmatchedRankReplacements += replacedClassId
+      pendingRankReplacements.distinct().forEach { replacedClassId ->
+        val removed = contributions.remove(replacedClassId)
+        if (removed != null) {
+          unmatchedRankReplacements += replacedClassId
+        }
       }
-    }
 
-    if (unmatchedRankReplacements.isNotEmpty()) {
-      // TODO we could report all rank based replacements here
+      if (unmatchedRankReplacements.isNotEmpty()) {
+        // TODO we could report all rank based replacements here
+      }
     }
 
     return contributions.values.toList()

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
@@ -197,6 +197,9 @@ abstract class MetroCompilerTest {
                   customContributesIntoSetAnnotations.joinToString(":"),
                 )
               }
+              MetroOption.ENABLE_DAGGER_ANVIL_INTEROP -> {
+                processor.option(entry.raw.cliOption, enableDaggerAnvilInterop)
+              }
             }
           yield(option)
         }

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AnvilInteropTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AnvilInteropTest.kt
@@ -1,0 +1,311 @@
+package dev.zacsweers.metro.compiler.fir
+
+import com.google.common.truth.Truth.assertThat
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
+import dev.zacsweers.metro.compiler.ExampleGraph
+import dev.zacsweers.metro.compiler.MetroCompilerTest
+import dev.zacsweers.metro.compiler.MetroOptions
+import dev.zacsweers.metro.compiler.assertDiagnostics
+import dev.zacsweers.metro.compiler.callProperty
+import dev.zacsweers.metro.compiler.createGraphWithNoArgs
+import dev.zacsweers.metro.compiler.generatedMetroGraphClass
+import org.jetbrains.kotlin.name.ClassId
+import kotlin.test.Test
+
+class AnvilInteropTest : MetroCompilerTest() {
+
+  @Test
+  fun `a library binding can outrank an upstream binding`() {
+    val previousCompilation = compile(
+      source(
+        """
+          interface ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 100)
+          object LibImpl : ContributedInterface
+        """
+          .trimIndent()
+      ),
+      options = metroOptions.withAnvilContributesBinding(),
+    )
+
+    compile(
+      source(
+        """
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class)
+          object AppImpl : ContributedInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      ),
+      previousCompilationResult = previousCompilation,
+      options = metroOptions.withAnvilContributesBinding(),
+    ) {
+      val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val contributedInterface = graph.callProperty<Any>("contributedInterface")
+      assertThat(contributedInterface).isNotNull()
+      assertThat(contributedInterface.javaClass.name).isEqualTo("test.LibImpl")
+    }
+  }
+
+  @Test
+  fun `an upstream binding can outrank a library binding`() {
+    val libCompilation = compile(
+      source(
+        """
+          interface ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 1)
+          object LibImpl : ContributedInterface
+        """
+          .trimIndent()
+      ),
+      options = metroOptions.withAnvilContributesBinding(),
+    )
+
+    compile(
+      source(
+        """
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 100)
+          object AppImpl : ContributedInterface          
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      ),
+      previousCompilationResult = libCompilation,
+      options = metroOptions.withAnvilContributesBinding(),
+    ) {
+      val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val contributedInterface = graph.callProperty<Any>("contributedInterface")
+      assertThat(contributedInterface).isNotNull()
+      assertThat(contributedInterface.javaClass.name).isEqualTo("test.AppImpl")
+    }
+  }
+
+  @Test fun `the binding with the highest rank is used when there are more than two`() {
+    compile(
+      source(
+        """
+          interface ContributedInterface          
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class)
+          object Impl1 : ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 10)
+          object Impl2 : ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 100)
+          object Impl3 : ContributedInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      ),
+      options = metroOptions.withAnvilContributesBinding(),
+    ) {
+      val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val contributedInterface = graph.callProperty<Any>("contributedInterface")
+      assertThat(contributedInterface).isNotNull()
+      assertThat(contributedInterface.javaClass.name).isEqualTo("test.Impl3")
+    }
+  }
+
+  @Test fun `rank requires an explicit binding type`() {
+    compile(
+      source(
+        """
+          interface ContributedInterface          
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 10)
+          object Impl1 : ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, rank = 100)
+          object Impl2 : ContributedInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      ),
+      options = metroOptions.withAnvilContributesBinding(),
+      expectedExitCode = ExitCode.COMPILATION_ERROR,
+    ) {
+      assertDiagnostics(
+        """
+          e: ContributedInterface.kt:11:1 `@ContributesBinding`-annotated class test.Impl2 sets a rank but doesn't declare its binding type.
+          Bindings with non-default ranks must declare explicit binding types. This is because
+          we're not able to resolve supertypes to get the implicit binding type when
+          processing ranked contributions.
+        """
+          .trimIndent()
+      )
+    }
+  }
+
+  @Test fun `an outranked binding requires an explicit binding type`() {
+    compile(
+      source(
+        """
+          interface ContributedInterface          
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 10)
+          object Impl1 : ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class)
+          object Impl2 : ContributedInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      ),
+      options = metroOptions.withAnvilContributesBinding(),
+      expectedExitCode = ExitCode.COMPILATION_ERROR,
+    ) {
+      // Duplicate bindings are reported in IR where we no longer have info about 'rank', so it's
+      // expected that this use-case results in a generic duplicate binding error. We could update
+      // to plumb the rank info down so it's not lost but as a feature that's only supported for
+      // interop and making migration easier, it seems better to minimize its code-level exposure.
+      assertDiagnostics(
+        """
+          e: ContributedInterface.kt:14:1 [Metro/DuplicateBinding] Duplicate binding for test.ContributedInterface
+          ├─ Binding 1: ContributedInterface.kt:8:1
+          ├─ Binding 2: ContributedInterface.kt:11:1
+        """
+          .trimIndent()
+      )
+    }
+  }
+
+  @Test fun `rank cannot be used for bindings when there are differently qualified bindings for the same type`() {
+    compile(
+      source(
+        """
+          interface ContributedInterface          
+
+          @Named("Bob")
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class)
+          object Impl1 : ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 100)
+          object Impl2 : ContributedInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+            
+            @Named("Bob")
+            val namedContributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      ),
+      options = metroOptions.withAnvilContributesBinding(),
+      expectedExitCode = ExitCode.COMPILATION_ERROR,
+    ) {
+      // Missing bindings are reported in IR where we no longer have info about 'rank', so it's
+      // expected that this use-case results in a generic missing binding error. We could update
+      // to plumb the rank info down so it's not lost but as a feature that's only supported for
+      // interop and making migration easier, it seems better to minimize its code-level exposure.
+      assertDiagnostics(
+        """
+          e: ContributedInterface.kt:19:3 [Metro/MissingBinding] Cannot find an @Inject constructor or @Provides-annotated function/property for: @Named("Bob") test.ContributedInterface
+
+    @Named("Bob") test.ContributedInterface is requested at
+        [test.ExampleGraph] test.ExampleGraph.namedContributedInterface
+
+Similar bindings:
+  - ContributedInterface (Different qualifier). Type: Alias. Source: ContributedInterface.kt:12:1
+  - Impl2 (Subtype). Type: ObjectClass. Source: ContributedInterface.kt:12:1
+        """
+          .trimIndent()
+      )
+    }
+  }
+
+  @Test fun `a lower ranked binding can use 'replaces' to replace a higher ranked binding`() {
+    compile(
+      source(
+        """
+          interface ContributedInterface          
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, replaces = [Impl2::class], rank = 10)
+          object Impl1 : ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 100)
+          object Impl2 : ContributedInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      ),
+      options = metroOptions.withAnvilContributesBinding(),
+    ) {
+      val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val contributedInterface = graph.callProperty<Any>("contributedInterface")
+      assertThat(contributedInterface).isNotNull()
+      assertThat(contributedInterface.javaClass.name).isEqualTo("test.Impl1")
+    }
+  }
+
+  @Test fun `bindings with the same rank are treated like normal duplicate bindings`() {
+    compile(
+      source(
+        """
+          interface ContributedInterface          
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 100)
+          object Impl1 : ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class)
+          object Impl2 : ContributedInterface
+
+          @com.squareup.anvil.annotations.ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 100)
+          object Impl3 : ContributedInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      ),
+      options = metroOptions.withAnvilContributesBinding(),
+      expectedExitCode = ExitCode.COMPILATION_ERROR,
+    ) {
+      assertDiagnostics(
+        """
+          e: ContributedInterface.kt:17:1 [Metro/DuplicateBinding] Duplicate binding for test.ContributedInterface
+          ├─ Binding 1: ContributedInterface.kt:8:1
+          ├─ Binding 2: ContributedInterface.kt:14:1
+        """
+          .trimIndent()
+      )
+    }
+  }
+
+  private fun MetroOptions.withAnvilContributesBinding(): MetroOptions {
+    return metroOptions.copy(
+      customContributesBindingAnnotations =
+        setOf(ClassId.fromString("com/squareup/anvil/annotations/ContributesBinding"))
+    )
+  }
+}

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -44,6 +44,7 @@ public abstract class dev/zacsweers/metro/gradle/MetroPluginExtension$InteropHan
 	public final fun getContributesIntoSet ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getContributesTo ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getElementsIntoSet ()Lorg/gradle/api/provider/SetProperty;
+	public final fun getEnableDaggerAnvilInterop ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnableDaggerRuntimeInterop ()Lorg/gradle/api/provider/Property;
 	public final fun getGraph ()Lorg/gradle/api/provider/SetProperty;
 	public final fun getGraphFactory ()Lorg/gradle/api/provider/SetProperty;

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
@@ -173,6 +173,10 @@ public class MetroGradleSubplugin : KotlinCompilerPluginSupportPlugin {
               .takeUnless { it.isEmpty() }
               ?.let { SubpluginOption("custom-scope", value = it.joinToString(":")) }
               ?.let(::add)
+          add(
+              SubpluginOption(
+                  "enable-dagger-anvil-interop",
+                  value = enableDaggerAnvilInterop.getOrElse(false).toString()))
         }
       }
     }

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
@@ -100,6 +100,9 @@ public abstract class MetroPluginExtension @Inject constructor(objects: ObjectFa
     public val qualifier: SetProperty<String> = objects.setProperty(String::class.java)
     public val scope: SetProperty<String> = objects.setProperty(String::class.java)
 
+    // Interop markers
+    public val enableDaggerAnvilInterop: Property<Boolean> = objects.property(Boolean::class.java)
+
     /** Includes Javax annotations support. */
     public fun includeJavax() {
       provider.add("javax/inject/Provider")
@@ -168,6 +171,7 @@ public abstract class MetroPluginExtension @Inject constructor(objects: ObjectFa
       check(includeDaggerAnvil || includeKotlinInjectAnvil) {
         "At least one of includeDaggerAnvil or includeKotlinInjectAnvil must be true"
       }
+      enableDaggerAnvilInterop.set(includeDaggerAnvil)
       if (includeDaggerAnvil) {
         graph.add("com/squareup/anvil/annotations/MergeComponent")
         graphFactory.add("com/squareup/anvil/annotations/MergeComponent.Factory")


### PR DESCRIPTION
This specifically helps with migration for users coming from Dagger-Anvil since eliminating existing rank usages can get pretty tricky and time consuming depending on how many there are. There are a few limitation with handling this in FIR -- see ContributedInterfaceSupertypeGenerator#processRankBasedReplacements for a comment with all the details.