### PR TITLE
Support repeatable @ContributesBinding annotations with different scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 - **Enhancement**: Optimize empty map multibindings to reuse a singleton instance.
 - **Enhancement**: Report error diagnostic if Dagger's `@Reusable` is used on a provider or injected class.
 - **Enhancement**: Multibindings may not be empty by default. To allow an empty multibinding, `@Multibinds(allowEmpty = true)` must be explicitly declared now.
+- **Enhancement**: Support repeatable @ContributesBinding annotations with different scopes
 - **Fix**: Handle scenarios where the compose-compiler plugin runs _before_ Metro's when generating wrapper classes for top-level `@Composable` functions.
 - Temporarily disable hint generation in WASM targets to avoid file count mismatches until [KT-75865](https://youtrack.jetbrains.com/issue/KT-75865).
 - Add an Android sample: https://github.com/ZacSweers/metro/tree/main/samples/android-app

--- a/compiler-tests/src/test/data/dump/fir/aggregation/ContributingTypes.fir.txt
+++ b/compiler-tests/src/test/data/dump/fir/aggregation/ContributingTypes.fir.txt
@@ -1,10 +1,10 @@
 FILE: ContributingTypes.kt
     @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface ContributedInterface : R|kotlin/Any| {
-        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract interface $$MetroContributionAppScope : R|ContributedInterface| {
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface $$MetroContribution : R|ContributedInterface| {
         }
 
     }
-    @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface ExampleGraph : R|kotlin/Any|, R|ContributedInterface.$$MetroContributionAppScope| {
+    @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface ExampleGraph : R|kotlin/Any|, R|ContributedInterface.$$MetroContribution| {
         @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final class $$MetroGraph : R|ExampleGraph| {
             public constructor(): R|ExampleGraph.$$MetroGraph| {
                 super<R|kotlin/Any|>()

--- a/compiler-tests/src/test/data/dump/fir/aggregation/ContributingTypes.fir.txt
+++ b/compiler-tests/src/test/data/dump/fir/aggregation/ContributingTypes.fir.txt
@@ -1,10 +1,10 @@
 FILE: ContributingTypes.kt
     @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface ContributedInterface : R|kotlin/Any| {
-        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract interface $$MetroContribution : R|ContributedInterface| {
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract interface $$MetroContributionAppScope : R|ContributedInterface| {
         }
 
     }
-    @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface ExampleGraph : R|kotlin/Any|, R|ContributedInterface.$$MetroContribution| {
+    @R|dev/zacsweers/metro/DependencyGraph|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface ExampleGraph : R|kotlin/Any|, R|ContributedInterface.$$MetroContributionAppScope| {
         @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public final class $$MetroGraph : R|ExampleGraph| {
             public constructor(): R|ExampleGraph.$$MetroGraph| {
                 super<R|kotlin/Any|>()

--- a/compiler-tests/src/test/data/dump/fir/aggregation/ContributingTypesDependency.fir.txt
+++ b/compiler-tests/src/test/data/dump/fir/aggregation/ContributingTypesDependency.fir.txt
@@ -1,7 +1,7 @@
 Module: lib
 FILE: module_lib_ContributingTypesDependency.kt
     @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface ContributedInterface : R|kotlin/Any| {
-        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract interface $$MetroContribution : R|ContributedInterface| {
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract interface $$MetroContributionAppScope : R|ContributedInterface| {
         }
 
     }

--- a/compiler-tests/src/test/data/dump/fir/aggregation/ContributingTypesDependency.fir.txt
+++ b/compiler-tests/src/test/data/dump/fir/aggregation/ContributingTypesDependency.fir.txt
@@ -1,7 +1,7 @@
 Module: lib
 FILE: module_lib_ContributingTypesDependency.kt
     @R|dev/zacsweers/metro/ContributesTo|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface ContributedInterface : R|kotlin/Any| {
-        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) public abstract interface $$MetroContributionAppScope : R|ContributedInterface| {
+        @R|kotlin/Deprecated|(message = String(This synthesized declaration should not be used directly), level = Q|kotlin/DeprecationLevel|.R|kotlin/DeprecationLevel.HIDDEN|) @R|dev/zacsweers/metro/internal/MetroContribution|(scope = <getClass>(Q|dev/zacsweers/metro/AppScope|)) public abstract interface $$MetroContribution : R|ContributedInterface| {
         }
 
     }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/Symbols.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/Symbols.kt
@@ -78,6 +78,8 @@ internal class Symbols(
     val composable = ClassId(FqNames.composeRuntime, "Composable".asName())
     val stable = ClassId(FqNames.composeRuntime, "Stable".asName())
     val metroBinds = ClassId(FqNames.metroRuntimePackage, Names.bindsClassName)
+    val metroContribution =
+      ClassId(FqNames.metroRuntimeInternalPackage, "MetroContribution".asName())
     val metroExtends = ClassId(FqNames.metroRuntimePackage, "Extends".asName())
     val metroFactory = ClassId(FqNames.metroRuntimeInternalPackage, Names.factoryClassName)
     val metroIncludes = ClassId(FqNames.metroRuntimePackage, "Includes".asName())

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/MetroFirBuiltIns.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/MetroFirBuiltIns.kt
@@ -108,6 +108,11 @@ internal class MetroFirBuiltIns(
       as FirRegularClassSymbol
   }
 
+  val metroContributionClassSymbol by unsafeLazy {
+    session.symbolProvider.getClassLikeSymbolByClassId(Symbols.ClassIds.metroContribution)
+      as FirRegularClassSymbol
+  }
+
   companion object {
     fun getFactory(classIds: ClassIds, options: MetroOptions) = Factory { session ->
       MetroFirBuiltIns(session, classIds, ExtensionPredicates(classIds), options)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
@@ -6,7 +6,6 @@ import dev.zacsweers.metro.compiler.Symbols
 import dev.zacsweers.metro.compiler.asName
 import dev.zacsweers.metro.compiler.capitalizeUS
 import dev.zacsweers.metro.compiler.decapitalizeUS
-import dev.zacsweers.metro.compiler.expectAs
 import dev.zacsweers.metro.compiler.expectAsOrNull
 import dev.zacsweers.metro.compiler.mapToArray
 import java.util.Objects
@@ -64,7 +63,6 @@ import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMappi
 import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationCall
 import org.jetbrains.kotlin.fir.expressions.builder.buildEnumEntryDeserializedAccessExpression
 import org.jetbrains.kotlin.fir.expressions.builder.buildLiteralExpression
-import org.jetbrains.kotlin.fir.expressions.toReference
 import org.jetbrains.kotlin.fir.expressions.unexpandedClassId
 import org.jetbrains.kotlin.fir.extensions.FirSupertypeGenerationExtension.TypeResolveService
 import org.jetbrains.kotlin.fir.extensions.buildUserTypeFromQualifierParts
@@ -857,16 +855,6 @@ internal fun FirAnnotation.resolvedScopeClassId(typeResolver: TypeResolveService
   // try to resolve within the enclosing scope
   return scopeArgument.resolvedClassId()
     ?: scopeArgument.resolvedClassArgumentTarget(typeResolver)?.classId
-}
-
-internal fun FirAnnotation.scopeName(session: FirSession): String? {
-  return resolvedScopeClassId()?.shortClassName?.identifier
-    ?: scopeArgument()
-      ?.argument
-      ?.toReference(session)
-      ?.expectAs<FirSimpleNamedReference>()
-      ?.name
-      ?.identifier
 }
 
 internal fun FirAnnotation.resolvedAdditionalScopesClassIds() =

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
@@ -6,6 +6,7 @@ import dev.zacsweers.metro.compiler.Symbols
 import dev.zacsweers.metro.compiler.asName
 import dev.zacsweers.metro.compiler.capitalizeUS
 import dev.zacsweers.metro.compiler.decapitalizeUS
+import dev.zacsweers.metro.compiler.expectAs
 import dev.zacsweers.metro.compiler.expectAsOrNull
 import dev.zacsweers.metro.compiler.mapToArray
 import java.util.Objects
@@ -63,6 +64,7 @@ import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMappi
 import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationCall
 import org.jetbrains.kotlin.fir.expressions.builder.buildEnumEntryDeserializedAccessExpression
 import org.jetbrains.kotlin.fir.expressions.builder.buildLiteralExpression
+import org.jetbrains.kotlin.fir.expressions.toReference
 import org.jetbrains.kotlin.fir.expressions.unexpandedClassId
 import org.jetbrains.kotlin.fir.extensions.FirSupertypeGenerationExtension.TypeResolveService
 import org.jetbrains.kotlin.fir.extensions.buildUserTypeFromQualifierParts
@@ -855,6 +857,16 @@ internal fun FirAnnotation.resolvedScopeClassId(typeResolver: TypeResolveService
   // try to resolve within the enclosing scope
   return scopeArgument.resolvedClassId()
     ?: scopeArgument.resolvedClassArgumentTarget(typeResolver)?.classId
+}
+
+internal fun FirAnnotation.scopeName(session: FirSession): String? {
+  return resolvedScopeClassId()?.shortClassName?.identifier
+    ?: scopeArgument()
+      ?.argument
+      ?.toReference(session)
+      ?.expectAs<FirSimpleNamedReference>()
+      ?.name
+      ?.identifier
 }
 
 internal fun FirAnnotation.resolvedAdditionalScopesClassIds() =

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionsFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionsFirGenerator.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.compiler.fir.generators
 
+import dev.zacsweers.metro.compiler.NameAllocator
+import dev.zacsweers.metro.compiler.NameAllocator.Mode
 import dev.zacsweers.metro.compiler.Symbols
 import dev.zacsweers.metro.compiler.asName
 import dev.zacsweers.metro.compiler.capitalizeUS
@@ -20,22 +22,27 @@ import dev.zacsweers.metro.compiler.fir.metroFirBuiltIns
 import dev.zacsweers.metro.compiler.fir.predicates
 import dev.zacsweers.metro.compiler.fir.qualifierAnnotation
 import dev.zacsweers.metro.compiler.fir.replaceAnnotationsSafe
-import dev.zacsweers.metro.compiler.fir.scopeName
+import dev.zacsweers.metro.compiler.fir.resolvedClassId
+import dev.zacsweers.metro.compiler.fir.scopeArgument
 import dev.zacsweers.metro.compiler.joinSimpleNames
-import dev.zacsweers.metro.compiler.plus
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.analysis.checkers.getContainingClassSymbol
+import org.jetbrains.kotlin.fir.declarations.toAnnotationClassId
 import org.jetbrains.kotlin.fir.declarations.toAnnotationClassIdSafe
 import org.jetbrains.kotlin.fir.expressions.FirAnnotation
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
+import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMapping
+import org.jetbrains.kotlin.fir.expressions.toReference
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
 import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
 import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
 import org.jetbrains.kotlin.fir.plugin.createMemberProperty
 import org.jetbrains.kotlin.fir.plugin.createNestedClass
+import org.jetbrains.kotlin.fir.references.impl.FirSimpleNamedReference
 import org.jetbrains.kotlin.fir.resolve.defaultType
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
@@ -51,6 +58,11 @@ import org.jetbrains.kotlin.name.Name
 
 internal class ContributionsFirGenerator(session: FirSession) :
   FirDeclarationGenerationExtension(session) {
+
+  // For each contributing class, track its nested contribution classes and their scope arguments
+  private val contributingClassToScopedContributions:
+    MutableMap<FirClassSymbol<*>, MutableMap<Name, FirGetClassCall?>> =
+    mutableMapOf()
 
   override fun FirDeclarationPredicateRegistrar.registerPredicates() {
     register(session.predicates.contributesAnnotationPredicate)
@@ -158,18 +170,41 @@ internal class ContributionsFirGenerator(session: FirSession) :
         .annotationsIn(session, session.classIds.allContributesAnnotations)
         .toList()
 
+    val contributionNamesToScopeArgs =
+      contributingClassToScopedContributions.getOrPut(classSymbol) { mutableMapOf() }
+
     return if (contributionAnnotations.isNotEmpty()) {
-      // Encode the scope into the nested contribution class name. When there are contributions for
-      // multiple scopes we'll end up with a nested class for each.
-      // E.g. $$MetroContributionAppScope and $$MetroContributionLibScope
+      // We create a contribution class for each scope being contributed to. E.g. if there are
+      // contributions for AppScope and LibScope we'll create $$MetroContribution and
+      // $$MetroContribution2
+      val nameAllocator = NameAllocator(mode = Mode.COUNT)
       contributionAnnotations
-        .mapNotNull { it.scopeName(session) }
-        .distinct()
-        .map { Symbols.Names.metroContribution.plus(it) }
+        .mapNotNull { it.scopeArgument() }
+        .distinctBy { it.scopeName(session) }
+        .map { scopeArgument ->
+          val nestedContributionName =
+            nameAllocator.newName(Symbols.Names.metroContribution.identifier).asName()
+
+          contributionNamesToScopeArgs.put(nestedContributionName, scopeArgument)
+
+          nestedContributionName
+        }
         .toSet()
     } else {
       emptySet()
     }
+  }
+
+  /**
+   * Assumes we are calling this on an annotation's 'scope' argument value -- used in contexts where
+   * we can't resolve the scope argument to get the full classId
+   */
+  private fun FirGetClassCall?.scopeName(session: FirSession): String? {
+    return this?.argument
+      ?.toReference(session)
+      ?.expectAsOrNull<FirSimpleNamedReference>()
+      ?.name
+      ?.identifier
   }
 
   override fun generateNestedClassLikeDeclaration(
@@ -193,7 +228,21 @@ internal class ContributionsFirGenerator(session: FirSession) :
           }
         }
       }
-      .apply { markAsDeprecatedHidden(session) }
+      .apply {
+        markAsDeprecatedHidden(session)
+        val metroContributionAnnotation =
+          buildMetroContributionAnnotation().apply {
+            replaceArgumentMapping(
+              buildAnnotationArgumentMapping {
+                val originalScopeArg =
+                  contributingClassToScopedContributions[owner]?.get(name)
+                    ?: error("Could not find a contribution scope for ${owner.classId}.$name")
+                this.mapping.put("scope".asName(), originalScopeArg)
+              }
+            )
+          }
+        replaceAnnotations(annotations + listOf(metroContributionAnnotation))
+      }
       .symbol
   }
 
@@ -204,12 +253,15 @@ internal class ContributionsFirGenerator(session: FirSession) :
     if (!classSymbol.hasOrigin(Keys.MetroContributionClassDeclaration)) return emptySet()
     val origin = classSymbol.getContainingClassSymbol() as? FirClassSymbol<*> ?: return emptySet()
     val contributions = findContributions(origin) ?: return emptySet()
-    val scope = classSymbol.name.parseEncodedContributionScope()
+    val scopeArg =
+      classSymbol.annotations
+        .single { it.toAnnotationClassId(session) == Symbols.ClassIds.metroContribution }
+        .scopeArgument()
     // Note the names we supply here are not final, we just need to know if we're going to generate
     // _any_ names for this type. We will return n >= 1 properties in generateProperties later.
     return contributions
       .filterIsInstance<Contribution.BindingContribution>()
-      .filter { it.annotation.scopeName(session) == scope }
+      .filter { it.annotation.scopeArgument().scopeName(session) == scopeArg.scopeName(session) }
       .groupBy { it.callableName.asName() }
       .keys
   }
@@ -237,17 +289,17 @@ internal class ContributionsFirGenerator(session: FirSession) :
     if (!owner.hasOrigin(Keys.MetroContributionClassDeclaration)) return emptyList()
     val origin = owner.getContainingClassSymbol() as? FirClassSymbol<*> ?: return emptyList()
     val contributions = findContributions(origin) ?: return emptyList()
-    val scope = owner.name.parseEncodedContributionScope()
+    val scopeId =
+      owner.annotations
+        .single { it.toAnnotationClassId(session) == Symbols.ClassIds.metroContribution }
+        .scopeArgument()
+        ?.resolvedClassId() ?: error("Could not find a contribution scope for ${owner.classId}")
 
     return contributions
       .filterIsInstance<Contribution.BindingContribution>()
       .filter { it.callableName == callableId.callableName.identifier }
-      .filter { it.annotation.scopeName(session) == scope }
+      .filter { it.annotation.scopeArgument()?.resolvedClassId() == scopeId }
       .map { contribution -> buildBindingProperty(owner, contribution) }
-  }
-
-  private fun Name.parseEncodedContributionScope(): String {
-    return identifier.substringAfter(Symbols.Names.metroContribution.identifier)
   }
 
   private fun buildBindingProperty(
@@ -316,5 +368,9 @@ internal class ContributionsFirGenerator(session: FirSession) :
 
   private fun buildIntoMapAnnotation(): FirAnnotation {
     return buildSimpleAnnotation { session.metroFirBuiltIns.intoMapClassSymbol }
+  }
+
+  private fun buildMetroContributionAnnotation(): FirAnnotation {
+    return buildSimpleAnnotation { session.metroFirBuiltIns.metroContributionClassSymbol }
   }
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/Binding.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/Binding.kt
@@ -219,8 +219,8 @@ internal sealed interface Binding {
         return (ir.overriddenSymbolsSequence().lastOrNull()?.owner ?: ir).let {
           if (it.propertyIfAccessor.origin == Origins.MetroContributionCallableDeclaration) {
             // If it's a contribution, the source is
-            // SourceClass.$$MetroContribution.bindingFunction
-            //                                 ^^^
+            // SourceClass.$$MetroContributionScopeName.bindingFunction
+            //                                          ^^^
             it.parentAsClass.parentAsClass.locationOrNull()
           } else {
             it.locationOrNull()

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AggregationTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AggregationTest.kt
@@ -940,22 +940,41 @@ class AggregationTest : MetroCompilerTest() {
 
       val altGraphClass = classLoader.loadClass("test.AltGraph")
       val altGraph = altGraphClass.generatedMetroGraphClass().createGraphWithNoArgs()
-      altGraphClass.assertHasContributedSupertype("test.ContributedInterface", "AltScope")
+      altGraphClass.assertHasContributedSupertype(
+        "test.ContributedInterface",
+        contributionNumber = 2,
+      )
       assertThat(altGraph.callProperty<String>("altVal")).isEqualTo("Hello, world!")
 
       val thirdGraphClass = classLoader.loadClass("test.ThirdGraph")
       val thirdGraph = thirdGraphClass.generatedMetroGraphClass().createGraphWithNoArgs()
-      thirdGraphClass.assertHasContributedSupertype("test.ContributedInterface", "ThirdScope")
+      thirdGraphClass.assertHasContributedSupertype(
+        "test.ContributedInterface",
+        contributionNumber = 3,
+      )
       assertThat(thirdGraph.callProperty<String>("thirdVal")).isEqualTo("Hello, world!")
     }
   }
 
+  /**
+   * @param contributionNumber Represents which nested class is expected. Each nested contribution
+   *   class is suffixed with a number when it's created depending on how many scopes are
+   *   contributed to. E.g.
+   *
+   * ```
+   * @ContributesBinding(AppScope::class) // This maps to $$MetroContribution (technically number 1)
+   * @ContributesBinding(AltScope::class) // This maps to $$MetroContribution2
+   * @Inject
+   * class ContributingClass : SomeInterface
+   * ```
+   */
   private fun Class<*>.assertHasContributedSupertype(
     superTypeFqName: String,
-    scopeName: String = "AppScope",
+    contributionNumber: Int = 1,
   ) {
+    val contributionSuffix = if (contributionNumber == 1) "" else contributionNumber.toString()
     assertThat(allSupertypes().map { it.name })
-      .containsExactly("$superTypeFqName$$\$MetroContribution$scopeName", superTypeFqName)
+      .containsExactly("$superTypeFqName$$\$MetroContribution$contributionSuffix", superTypeFqName)
   }
 
   @Test
@@ -992,7 +1011,10 @@ class AggregationTest : MetroCompilerTest() {
 
       val altGraphClass = classLoader.loadClass("test.AltGraph")
       val altGraph = altGraphClass.generatedMetroGraphClass().createGraphWithNoArgs()
-      altGraphClass.assertHasContributedSupertype("test.ContributedInterface", "AltScope")
+      altGraphClass.assertHasContributedSupertype(
+        "test.ContributedInterface",
+        contributionNumber = 2,
+      )
       assertThat(altGraph.callProperty<String>("altVal")).isEqualTo("Hello, world!")
     }
   }
@@ -2840,7 +2862,7 @@ Similar bindings:
       ),
     ) {
       val graph = ExampleGraph
-      graph.assertHasContributedSupertype("test.ContributedInterface", "UserScope")
+      graph.assertHasContributedSupertype("test.ContributedInterface")
     }
   }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AggregationTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AggregationTest.kt
@@ -940,19 +940,22 @@ class AggregationTest : MetroCompilerTest() {
 
       val altGraphClass = classLoader.loadClass("test.AltGraph")
       val altGraph = altGraphClass.generatedMetroGraphClass().createGraphWithNoArgs()
-      altGraphClass.assertHasContributedSupertype("test.ContributedInterface")
+      altGraphClass.assertHasContributedSupertype("test.ContributedInterface", "AltScope")
       assertThat(altGraph.callProperty<String>("altVal")).isEqualTo("Hello, world!")
 
       val thirdGraphClass = classLoader.loadClass("test.ThirdGraph")
       val thirdGraph = thirdGraphClass.generatedMetroGraphClass().createGraphWithNoArgs()
-      thirdGraphClass.assertHasContributedSupertype("test.ContributedInterface")
+      thirdGraphClass.assertHasContributedSupertype("test.ContributedInterface", "ThirdScope")
       assertThat(thirdGraph.callProperty<String>("thirdVal")).isEqualTo("Hello, world!")
     }
   }
 
-  private fun Class<*>.assertHasContributedSupertype(superTypeFqName: String) {
+  private fun Class<*>.assertHasContributedSupertype(
+    superTypeFqName: String,
+    scopeName: String = "AppScope",
+  ) {
     assertThat(allSupertypes().map { it.name })
-      .containsExactly("$superTypeFqName$$\$MetroContribution", superTypeFqName)
+      .containsExactly("$superTypeFqName$$\$MetroContribution$scopeName", superTypeFqName)
   }
 
   @Test
@@ -989,7 +992,7 @@ class AggregationTest : MetroCompilerTest() {
 
       val altGraphClass = classLoader.loadClass("test.AltGraph")
       val altGraph = altGraphClass.generatedMetroGraphClass().createGraphWithNoArgs()
-      altGraphClass.assertHasContributedSupertype("test.ContributedInterface")
+      altGraphClass.assertHasContributedSupertype("test.ContributedInterface", "AltScope")
       assertThat(altGraph.callProperty<String>("altVal")).isEqualTo("Hello, world!")
     }
   }
@@ -1530,6 +1533,272 @@ class AggregationTest : MetroCompilerTest() {
     ) {
       assertDiagnostics(
         "e: Impl.kt:7:46 Redundant explicit bound type test.Impl is the same as the annotated class test.Impl."
+      )
+    }
+  }
+
+  @Test
+  fun `repeated ContributesBinding supports multiple scopes for a single type in a merging module`() {
+    compile(
+      source(
+        """
+          abstract class AltScope private constructor()
+
+          interface ContributedInterface
+
+          @ContributesBinding(AppScope::class)
+          @ContributesBinding(AltScope::class)
+          @Inject
+          class Impl : ContributedInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+
+          @DependencyGraph(scope = AltScope::class)
+          interface AltGraph {
+            val contributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      )
+    ) {
+      val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val contributedInterface = graph.callProperty<Any>("contributedInterface")
+      assertThat(contributedInterface).isNotNull()
+      assertThat(contributedInterface.javaClass.name).isEqualTo("test.Impl")
+
+      val altGraph =
+        classLoader.loadClass("test.AltGraph").generatedMetroGraphClass().createGraphWithNoArgs()
+      val altContributedInterface = altGraph.callProperty<Any>("contributedInterface")
+      assertThat(altContributedInterface).isNotNull()
+      assertThat(altContributedInterface.javaClass.name).isEqualTo("test.Impl")
+    }
+  }
+
+  @Test
+  fun `repeated ContributesBinding supports multiple scopes for a single type in a downstream module`() {
+    val previousCompilation =
+      compile(
+        source(
+          """
+          abstract class AltScope private constructor()
+
+          interface ContributedInterface
+
+          @ContributesBinding(AppScope::class)
+          @ContributesBinding(AltScope::class)
+          @Inject
+          class Impl : ContributedInterface
+        """
+            .trimIndent()
+        )
+      )
+
+    compile(
+      source(
+        """
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+
+          @DependencyGraph(scope = AltScope::class)
+          interface AltGraph {
+            val contributedInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      ),
+      previousCompilationResult = previousCompilation,
+    ) {
+      val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val contributedInterface = graph.callProperty<Any>("contributedInterface")
+      assertThat(contributedInterface).isNotNull()
+      assertThat(contributedInterface.javaClass.name).isEqualTo("test.Impl")
+
+      val altGraph =
+        classLoader.loadClass("test.AltGraph").generatedMetroGraphClass().createGraphWithNoArgs()
+      val altContributedInterface = altGraph.callProperty<Any>("contributedInterface")
+      assertThat(altContributedInterface).isNotNull()
+      assertThat(altContributedInterface.javaClass.name).isEqualTo("test.Impl")
+    }
+  }
+
+  @Test
+  fun `repeated ContributesBinding supports multiple scopes for a different type in a merging module`() {
+    compile(
+      source(
+        """
+          abstract class AltScope private constructor()
+
+          interface ContributedInterface
+          interface OtherInterface
+
+          @ContributesBinding(AppScope::class, binding = binding<ContributedInterface>())
+          @ContributesBinding(AltScope::class, binding = binding<OtherInterface>())
+          @Inject
+          class Impl : ContributedInterface, OtherInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+
+          @DependencyGraph(scope = AltScope::class)
+          interface AltGraph {
+            val otherInterface: OtherInterface
+          }
+        """
+          .trimIndent()
+      )
+    ) {
+      val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val contributedInterface = graph.callProperty<Any>("contributedInterface")
+      assertThat(contributedInterface).isNotNull()
+      assertThat(contributedInterface.javaClass.name).isEqualTo("test.Impl")
+
+      val altGraph =
+        classLoader.loadClass("test.AltGraph").generatedMetroGraphClass().createGraphWithNoArgs()
+      val altContributedInterface = altGraph.callProperty<Any>("otherInterface")
+      assertThat(altContributedInterface).isNotNull()
+      assertThat(altContributedInterface.javaClass.name).isEqualTo("test.Impl")
+    }
+  }
+
+  @Test
+  fun `repeated ContributesBinding supports multiple scopes for a different type in a downstream module`() {
+    val previousCompilation =
+      compile(
+        source(
+          """
+          abstract class AltScope private constructor()
+
+          interface ContributedInterface
+          interface OtherInterface
+
+          @ContributesBinding(AppScope::class, binding = binding<ContributedInterface>())
+          @ContributesBinding(AltScope::class, binding = binding<OtherInterface>())
+          @Inject
+          class Impl : ContributedInterface, OtherInterface
+        """
+            .trimIndent()
+        )
+      )
+
+    compile(
+      source(
+        """
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+
+          @DependencyGraph(scope = AltScope::class)
+          interface AltGraph {
+            val otherInterface: OtherInterface
+          }
+        """
+          .trimIndent()
+      ),
+      previousCompilationResult = previousCompilation,
+    ) {
+      val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val contributedInterface = graph.callProperty<Any>("contributedInterface")
+      assertThat(contributedInterface).isNotNull()
+      assertThat(contributedInterface.javaClass.name).isEqualTo("test.Impl")
+
+      val altGraph =
+        classLoader.loadClass("test.AltGraph").generatedMetroGraphClass().createGraphWithNoArgs()
+      val altContributedInterface = altGraph.callProperty<Any>("otherInterface")
+      assertThat(altContributedInterface).isNotNull()
+      assertThat(altContributedInterface.javaClass.name).isEqualTo("test.Impl")
+    }
+  }
+
+  @Test
+  fun `repeated ContributesBinding supports multiple scopes with a qualifier difference in a merging module`() {
+    compile(
+      source(
+        """
+          abstract class AltScope private constructor()
+
+          interface ContributedInterface
+
+          @ContributesBinding(AppScope::class)
+          @ContributesBinding(AltScope::class, binding = binding<@Named("Alt") ContributedInterface>())
+          @Inject
+          class Impl : ContributedInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+
+          @DependencyGraph(scope = AltScope::class)
+          interface AltGraph {
+            @Named("Alt")
+            val otherInterface: ContributedInterface
+          }
+        """
+          .trimIndent()
+      )
+    ) {
+      val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val contributedInterface = graph.callProperty<Any>("contributedInterface")
+      assertThat(contributedInterface).isNotNull()
+      assertThat(contributedInterface.javaClass.name).isEqualTo("test.Impl")
+
+      val altGraph =
+        classLoader.loadClass("test.AltGraph").generatedMetroGraphClass().createGraphWithNoArgs()
+      val altContributedInterface = altGraph.callProperty<Any>("otherInterface")
+      assertThat(altContributedInterface).isNotNull()
+      assertThat(altContributedInterface.javaClass.name).isEqualTo("test.Impl")
+    }
+  }
+
+  @Test
+  fun `repeated ContributesBinding supports multiple scopes for a different type without leaking the bindings`() {
+    compile(
+      source(
+        """
+          abstract class AltScope private constructor()
+
+          interface ContributedInterface
+          interface OtherInterface
+
+          @ContributesBinding(AppScope::class, binding = binding<ContributedInterface>())
+          @ContributesBinding(AltScope::class, binding = binding<OtherInterface>())
+          @Inject
+          class Impl : ContributedInterface, OtherInterface
+
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val contributedInterface: ContributedInterface
+          }
+
+          @DependencyGraph(scope = AltScope::class)
+          interface AltGraph {
+            val contributedInterface: ContributedInterface
+            val otherInterface: OtherInterface
+          }
+        """
+          .trimIndent()
+      ),
+      expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
+    ) {
+      assertDiagnostics(
+        """
+          e: AltScope.kt:24:3 [Metro/MissingBinding] Cannot find an @Inject constructor or @Provides-annotated function/property for: test.ContributedInterface
+
+    test.ContributedInterface is requested at
+        [test.AltGraph] test.AltGraph.contributedInterface
+
+Similar bindings:
+  - Impl (Subtype). Type: ConstructorInjected. Source: AltScope.kt:12:1
+        """
+          .trimIndent()
       )
     }
   }
@@ -2571,7 +2840,7 @@ class AggregationTest : MetroCompilerTest() {
       ),
     ) {
       val graph = ExampleGraph
-      graph.assertHasContributedSupertype("test.ContributedInterface")
+      graph.assertHasContributedSupertype("test.ContributedInterface", "UserScope")
     }
   }
 
@@ -2716,11 +2985,7 @@ class AggregationTest : MetroCompilerTest() {
       )
     ) {
       val graph = ExampleGraph
-      assertThat(graph.allSupertypes().map { it.name })
-        .containsExactly(
-          "test.ContributedInterface2",
-          "test.ContributedInterface2$$\$MetroContribution",
-        )
+      assertThat(graph.assertHasContributedSupertype("test.ContributedInterface2"))
     }
   }
 

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/internal/MetroContribution.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/internal/MetroContribution.kt
@@ -1,0 +1,9 @@
+// Copyright (C) 2025 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.internal
+
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.reflect.KClass
+
+/** Marker for generated nested classes for top level declarations annotated with @Contributes_. */
+@Target(CLASS) public annotation class MetroContribution(val scope: KClass<*>)


### PR DESCRIPTION
- Addresses https://github.com/ZacSweers/metro/issues/210
- @ContributesBinding could already be repeated to contribute multiple types to a single scope. These changes expand the support to include bindings for different scopes, bringing behavior closer to Dagger-Anvil.
- A notable implementation change is that previously classes with contributions would have a 1:1 relationship where each class has a nested $$MetroContribution class created. Now, a class with contributions will have a nested class for each scope that it is contributed to. These nested classes will be sequentially numbered like `$$MetroContribution`, and `$$MetroContribution2`.
- Introduces `@MetroContribution` which is used to annotate each of the nested contribution classes and track the scope that they are associated with.