### PR TITLE
Issue 309 - Fix runtime class cast exception when interoping with javax provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changelog
 - **Fix**: Don't allow multiple ancestor graphs of graph extensions to use the same scope.
 - **Fix**: Handle scenarios where the compose-compiler plugin runs _before_ Metro's when generating wrapper classes for top-level `@Composable` functions.
 - **Fix**: Fix an edge case in graph extensions where child graphs would miss a provided scoped binding in a parent graph that was also exposed as an accessor.
+- **Fix**: Fix Dagger interop issue when calling Javax/Jakarta/Dagger providers from Metro factories.
+- **Fix**: Fix Dagger interop issue when calling `dagger.Lazy` from Metro factories.
+- **Fix**: Preserve the original `Provider` or `Lazy` type used in injected types when generating factory creators.
 - Temporarily disable hint generation in WASM targets to avoid file count mismatches until [KT-75865](https://youtrack.jetbrains.com/issue/KT-75865).
 - Add an Android sample: https://github.com/ZacSweers/metro/tree/main/samples/android-app
 - Add a multiplatform Circuit sample: https://github.com/ZacSweers/metro/tree/main/samples/circuit-app

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/WrappedType.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/WrappedType.kt
@@ -23,7 +23,8 @@ internal sealed interface WrappedType<T : Any> {
   data class Canonical<T : Any>(val type: T) : WrappedType<T>
 
   /** A type wrapped in a Provider. */
-  data class Provider<T : Any>(val innerType: WrappedType<T>, val providerType: ClassId) : WrappedType<T>
+  data class Provider<T : Any>(val innerType: WrappedType<T>, val providerType: ClassId) :
+    WrappedType<T>
 
   /** A type wrapped in a Lazy. */
   data class Lazy<T : Any>(val innerType: WrappedType<T>, val lazyType: ClassId) : WrappedType<T>

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/WrappedType.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/WrappedType.kt
@@ -3,6 +3,7 @@
 package dev.zacsweers.metro.compiler
 
 import dev.drewhamilton.poko.Poko
+import org.jetbrains.kotlin.name.ClassId
 
 /**
  * A sealed class hierarchy representing the different types of wrapping for a type. This is useful
@@ -22,10 +23,10 @@ internal sealed interface WrappedType<T : Any> {
   data class Canonical<T : Any>(val type: T) : WrappedType<T>
 
   /** A type wrapped in a Provider. */
-  data class Provider<T : Any>(val innerType: WrappedType<T>) : WrappedType<T>
+  data class Provider<T : Any>(val innerType: WrappedType<T>, val providerType: ClassId) : WrappedType<T>
 
   /** A type wrapped in a Lazy. */
-  data class Lazy<T : Any>(val innerType: WrappedType<T>) : WrappedType<T>
+  data class Lazy<T : Any>(val innerType: WrappedType<T>, val lazyType: ClassId) : WrappedType<T>
 
   /** A map type with special handling for the value type. */
   @Poko

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
@@ -690,7 +690,10 @@ internal fun FirClassLikeDeclaration.markAsDeprecatedHidden(session: FirSession)
   replaceDeprecationsProvider(this.getDeprecationsProvider(session))
 }
 
-internal fun ConeTypeProjection.wrapInProviderIfNecessary(session: FirSession): ConeClassLikeType {
+internal fun ConeTypeProjection.wrapInProviderIfNecessary(
+  session: FirSession,
+  providerClassId: ClassId,
+): ConeClassLikeType {
   val type = this.type
   if (type is ConeClassLikeType) {
     val classId = type.lookupTag.classId
@@ -699,10 +702,13 @@ internal fun ConeTypeProjection.wrapInProviderIfNecessary(session: FirSession): 
       return type
     }
   }
-  return Symbols.ClassIds.metroProvider.constructClassLikeType(arrayOf(this))
+  return providerClassId.constructClassLikeType(arrayOf(this))
 }
 
-internal fun ConeTypeProjection.wrapInLazyIfNecessary(session: FirSession): ConeClassLikeType {
+internal fun ConeTypeProjection.wrapInLazyIfNecessary(
+  session: FirSession,
+  lazyClassId: ClassId,
+): ConeClassLikeType {
   val type = this.type
   if (type is ConeClassLikeType) {
     val classId = type.lookupTag.classId
@@ -711,7 +717,7 @@ internal fun ConeTypeProjection.wrapInLazyIfNecessary(session: FirSession): Cone
       return type
     }
   }
-  return Symbols.ClassIds.lazy.constructClassLikeType(arrayOf(this))
+  return lazyClassId.constructClassLikeType(arrayOf(this))
 }
 
 internal fun FirClassSymbol<*>.constructType(

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/AssistedFactoryImplFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/AssistedFactoryImplFirGenerator.kt
@@ -229,7 +229,7 @@ internal class AssistedFactoryImplFirGenerator(session: FirSession) :
           Keys.Default,
           Symbols.Names.create,
           returnTypeProvider = {
-            implClass.source.constructType(it).wrapInProviderIfNecessary(session)
+            implClass.source.constructType(it).wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider)
           },
         ) {
           // Delegate factory

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/AssistedFactoryImplFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/AssistedFactoryImplFirGenerator.kt
@@ -229,7 +229,9 @@ internal class AssistedFactoryImplFirGenerator(session: FirSession) :
           Keys.Default,
           Symbols.Names.create,
           returnTypeProvider = {
-            implClass.source.constructType(it).wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider)
+            implClass.source
+              .constructType(it)
+              .wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider)
           },
         ) {
           // Delegate factory

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/InjectedClassFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/InjectedClassFirGenerator.kt
@@ -537,7 +537,7 @@ internal class InjectedClassFirGenerator(session: FirSession) :
                 param.contextKey.typeKey.type
                   // TODO need to remap these
                   //  .withArguments(it.mapToArray(FirTypeParameterRef::toConeType))
-                  .wrapInProviderIfNecessary(session)
+                  .wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider)
               },
               key = Keys.ValueParameter,
             )

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/firFactoryUtil.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/firFactoryUtil.kt
@@ -49,7 +49,7 @@ internal fun FirExtension.buildFactoryConstructor(
       extensionReceiver?.let {
         valueParameter(
           Symbols.Names.receiver,
-          it.wrapInProviderIfNecessary(session),
+          it.wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider),
           key = Keys.ReceiverParameter,
         )
       }
@@ -63,7 +63,7 @@ internal fun FirExtension.buildFactoryConstructor(
         }
         valueParameter(
           valueParameter.name,
-          valueParameter.contextKey.typeKey.type.wrapInProviderIfNecessary(session),
+          valueParameter.contextKey.typeKey.type.wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider),
           key = Keys.ValueParameter,
         )
       }
@@ -131,7 +131,7 @@ internal fun FirExtension.buildFactoryCreateFunction(
         this.valueParameters +=
           buildSimpleValueParameter(
             name = Symbols.Names.receiver,
-            type = it.wrapInProviderIfNecessary(session).toFirResolvedTypeRef(),
+            type = it.wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider).toFirResolvedTypeRef(),
             containingFunctionSymbol = thisFunctionSymbol,
             origin = Keys.ReceiverParameter.origin,
           )
@@ -147,7 +147,7 @@ internal fun FirExtension.buildFactoryCreateFunction(
         copyParameterDefaults = false,
       ) { original ->
         this.returnTypeRef =
-          original.contextKey.typeKey.type.wrapInProviderIfNecessary(session).toFirResolvedTypeRef()
+          original.contextKey.typeKey.type.wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider).toFirResolvedTypeRef()
       }
     }
     .symbol
@@ -210,7 +210,7 @@ internal fun FirExtension.buildNewInstanceFunction(
         // Will be copied in IR
         copyParameterDefaults = false,
       ) { original ->
-        this.returnTypeRef = original.symbol.resolvedReturnTypeRef
+        this.returnTypeRef = original.contextKey.originalType(session).toFirResolvedTypeRef()
       }
     }
     .symbol

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/firFactoryUtil.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/firFactoryUtil.kt
@@ -210,7 +210,7 @@ internal fun FirExtension.buildNewInstanceFunction(
         // Will be copied in IR
         copyParameterDefaults = false,
       ) { original ->
-        this.returnTypeRef = original.contextKey.originalType(session).toFirResolvedTypeRef()
+        this.returnTypeRef = original.symbol.resolvedReturnTypeRef
       }
     }
     .symbol

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/firFactoryUtil.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/firFactoryUtil.kt
@@ -63,7 +63,10 @@ internal fun FirExtension.buildFactoryConstructor(
         }
         valueParameter(
           valueParameter.name,
-          valueParameter.contextKey.typeKey.type.wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider),
+          valueParameter.contextKey.typeKey.type.wrapInProviderIfNecessary(
+            session,
+            Symbols.ClassIds.metroProvider,
+          ),
           key = Keys.ValueParameter,
         )
       }
@@ -131,7 +134,10 @@ internal fun FirExtension.buildFactoryCreateFunction(
         this.valueParameters +=
           buildSimpleValueParameter(
             name = Symbols.Names.receiver,
-            type = it.wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider).toFirResolvedTypeRef(),
+            type =
+              it
+                .wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider)
+                .toFirResolvedTypeRef(),
             containingFunctionSymbol = thisFunctionSymbol,
             origin = Keys.ReceiverParameter.origin,
           )
@@ -147,7 +153,9 @@ internal fun FirExtension.buildFactoryCreateFunction(
         copyParameterDefaults = false,
       ) { original ->
         this.returnTypeRef =
-          original.contextKey.typeKey.type.wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider).toFirResolvedTypeRef()
+          original.contextKey.typeKey.type
+            .wrapInProviderIfNecessary(session, Symbols.ClassIds.metroProvider)
+            .toFirResolvedTypeRef()
       }
     }
     .symbol

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ContextualTypeKey.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ContextualTypeKey.kt
@@ -22,6 +22,7 @@ import org.jetbrains.kotlin.ir.types.removeAnnotations
 import org.jetbrains.kotlin.ir.types.typeOrFail
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.classId
+import org.jetbrains.kotlin.ir.util.classIdOrFail
 import org.jetbrains.kotlin.ir.util.render
 
 /** A class that represents a type with contextual information. */
@@ -82,13 +83,13 @@ internal class ContextualTypeKey(
         val innerType =
           ContextualTypeKey(typeKey, wt.innerType, hasDefault, isIntoMultibinding)
             .toIrType(metroContext)
-        innerType.wrapInProvider(metroContext.symbols.metroProvider)
+        innerType.wrapInProvider(metroContext.pluginContext.referenceClass(wt.providerType)!!)
       }
       is WrappedType.Lazy -> {
         val innerType =
           ContextualTypeKey(typeKey, wt.innerType, hasDefault, isIntoMultibinding)
             .toIrType(metroContext)
-        innerType.wrapInProvider(metroContext.symbols.stdlibLazy)
+        innerType.wrapInProvider(metroContext.pluginContext.referenceClass(wt.lazyType)!!)
       }
       is WrappedType.Map -> {
         // For Map types, we need to create a Map<K, V> type
@@ -143,13 +144,22 @@ internal class ContextualTypeKey(
       isIntoMultibinding: Boolean = false,
       rawType: IrType? = null,
     ): ContextualTypeKey {
+      val rawClassId = rawType?.rawTypeOrNull()?.classId
       val wrappedType =
         when {
-          isLazyWrappedInProvider ->
-            WrappedType.Provider(WrappedType.Lazy(WrappedType.Canonical(typeKey.type)))
-          isWrappedInProvider -> WrappedType.Provider(WrappedType.Canonical(typeKey.type))
-          isWrappedInLazy -> WrappedType.Lazy(WrappedType.Canonical(typeKey.type))
-          else -> WrappedType.Canonical(typeKey.type)
+          isLazyWrappedInProvider -> {
+            val lazyType = rawType!!.expectAs<IrSimpleType>().arguments.single().typeOrFail.rawType().classIdOrFail
+            WrappedType.Provider(WrappedType.Lazy(WrappedType.Canonical(typeKey.type), lazyType), rawClassId!!)
+          }
+          isWrappedInProvider -> {
+            WrappedType.Provider(WrappedType.Canonical(typeKey.type), rawClassId!!)
+          }
+          isWrappedInLazy -> {
+            WrappedType.Lazy(WrappedType.Canonical(typeKey.type), rawClassId!!)
+          }
+          else -> {
+            WrappedType.Canonical(typeKey.type)
+          }
         }
 
       return ContextualTypeKey(
@@ -235,7 +245,7 @@ private fun IrSimpleType.asWrappedType(context: IrMetroContext): WrappedType<IrT
     // Recursively analyze the inner type
     val innerWrappedType = innerType.expectAs<IrSimpleType>().asWrappedType(context)
 
-    return WrappedType.Provider(innerWrappedType)
+    return WrappedType.Provider(innerWrappedType, rawClassId!!)
   }
 
   // Check if this is a Lazy type
@@ -245,7 +255,7 @@ private fun IrSimpleType.asWrappedType(context: IrMetroContext): WrappedType<IrT
     // Recursively analyze the inner type
     val innerWrappedType = innerType.expectAs<IrSimpleType>().asWrappedType(context)
 
-    return WrappedType.Lazy(innerWrappedType)
+    return WrappedType.Lazy(innerWrappedType, rawClassId!!)
   }
 
   // If it's not a special type, it's a canonical type

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ContextualTypeKey.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ContextualTypeKey.kt
@@ -148,8 +148,18 @@ internal class ContextualTypeKey(
       val wrappedType =
         when {
           isLazyWrappedInProvider -> {
-            val lazyType = rawType!!.expectAs<IrSimpleType>().arguments.single().typeOrFail.rawType().classIdOrFail
-            WrappedType.Provider(WrappedType.Lazy(WrappedType.Canonical(typeKey.type), lazyType), rawClassId!!)
+            val lazyType =
+              rawType!!
+                .expectAs<IrSimpleType>()
+                .arguments
+                .single()
+                .typeOrFail
+                .rawType()
+                .classIdOrFail
+            WrappedType.Provider(
+              WrappedType.Lazy(WrappedType.Canonical(typeKey.type), lazyType),
+              rawClassId!!,
+            )
           }
           isWrappedInProvider -> {
             WrappedType.Provider(WrappedType.Canonical(typeKey.type), rawClassId!!)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -444,12 +444,7 @@ internal fun IrBuilderWithScope.typeAsProviderArgument(
 
     contextKey.isWrappedInLazy -> {
       // DoubleCheck.lazy(...)
-      irInvoke(
-        dispatchReceiver = irGetObject(providerSymbols.doubleCheckCompanionObject),
-        callee = providerSymbols.doubleCheckLazy,
-        args = listOf(providerExpression),
-        typeHint = contextKey.toIrType(context),
-      )
+      with(providerSymbols) { invokeDoubleCheckLazy(context, contextKey, providerExpression) }
     }
 
     isAssisted || isGraphInstance -> {

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
@@ -411,7 +411,7 @@ class DaggerInteropTest : MetroCompilerTest() {
         """
           .trimIndent()
       ),
-      debug = true
+      debug = true,
     ) {
       val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
       val fooInstance = graph.callProperty<Any>("fooBar").callProperty<Provider<*>>("provider")

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
@@ -14,6 +14,7 @@ import dev.zacsweers.metro.compiler.callProperty
 import dev.zacsweers.metro.compiler.createGraphWithNoArgs
 import dev.zacsweers.metro.compiler.generatedMetroGraphClass
 import dev.zacsweers.metro.compiler.invokeInstanceMethod
+import dev.zacsweers.metro.interop.dagger.internal.DaggerInteropDoubleCheck
 import javax.inject.Provider
 import kotlin.test.assertNotNull
 import org.jetbrains.kotlin.name.ClassId
@@ -436,12 +437,13 @@ class DaggerInteropTest : MetroCompilerTest() {
           )
         """
           .trimIndent()
-      ),
+      )
     ) {
       val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
       val fooInstance = graph.callProperty<Any>("fooBar").callProperty<Lazy<Any>>("lazy")
       assertThat(fooInstance).isNotNull()
-      assertThat(fooInstance.get().javaClass.name).isEqualTo("asdf")
+      assertThat(fooInstance).isInstanceOf(DaggerInteropDoubleCheck::class.java)
+      assertThat(fooInstance.get().javaClass.name).isEqualTo("test.Foo")
     }
   }
 }

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
@@ -402,6 +402,7 @@ class DaggerInteropTest : MetroCompilerTest() {
           interface ExampleGraph {
             val fooBar: FooBar
           }
+
           class Foo @Inject constructor()
 
           class FooBar @Inject constructor(
@@ -409,7 +410,8 @@ class DaggerInteropTest : MetroCompilerTest() {
           )
         """
           .trimIndent()
-      )
+      ),
+      debug = true
     ) {
       val graph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
       val fooInstance = graph.callProperty<Any>("fooBar").callProperty<Provider<*>>("provider")
@@ -430,6 +432,7 @@ class DaggerInteropTest : MetroCompilerTest() {
           interface ExampleGraph {
             val fooBar: FooBar
           }
+
           class Foo @Inject constructor()
 
           class FooBar @Inject constructor(

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/TopLevelInjectTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/TopLevelInjectTest.kt
@@ -98,7 +98,8 @@ class TopLevelInjectTest : MetroCompilerTest() {
             }
           """
             .trimIndent()
-        )
+        ),
+        debug = true
       )
 
     val graph =

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/TopLevelInjectTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/TopLevelInjectTest.kt
@@ -99,7 +99,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
           """
             .trimIndent()
         ),
-        debug = true
+        debug = true,
       )
 
     val graph =

--- a/interop-dagger/api/interop-dagger.api
+++ b/interop-dagger/api/interop-dagger.api
@@ -19,9 +19,10 @@ public final class dev/zacsweers/metro/interop/dagger/internal/DaggerInteropDoub
 	public final fun daggerProvider (Ljavax/inject/Provider;)Ldagger/internal/Provider;
 	public final fun jakartaProvider (Ljavax/inject/Provider;)Ljakarta/inject/Provider;
 	public final fun javaxProvider (Ljavax/inject/Provider;)Ljavax/inject/Provider;
-	public final fun lazy (Ldagger/internal/Provider;)Ldagger/Lazy;
-	public final fun lazy (Ljakarta/inject/Provider;)Ldagger/Lazy;
-	public final fun lazy (Ljavax/inject/Provider;)Ldagger/Lazy;
+	public final fun lazyFromDaggerProvider (Ldagger/internal/Provider;)Ldagger/Lazy;
+	public final fun lazyFromJakartaProvider (Ljakarta/inject/Provider;)Ldagger/Lazy;
+	public final fun lazyFromJavaxProvider (Ljavax/inject/Provider;)Ldagger/Lazy;
+	public final fun lazyFromMetroProvider (Ldev/zacsweers/metro/Provider;)Ldagger/Lazy;
 }
 
 public final class dev/zacsweers/metro/interop/dagger/internal/InternalDaggerInteropKt {

--- a/interop-dagger/src/main/kotlin/dev/zacsweers/metro/interop/dagger/internal/DaggerInteropDoubleCheck.kt
+++ b/interop-dagger/src/main/kotlin/dev/zacsweers/metro/interop/dagger/internal/DaggerInteropDoubleCheck.kt
@@ -56,7 +56,9 @@ public class DaggerInteropDoubleCheck<T : Any>(provider: MetroProvider<T>) :
       return DaggerInteropDoubleCheck(provider.asMetroProvider())
     }
 
-    public fun <P : JakartaProvider<T>, T : Any> lazyFromJakartaProvider(provider: P): DaggerLazy<T> {
+    public fun <P : JakartaProvider<T>, T : Any> lazyFromJakartaProvider(
+      provider: P
+    ): DaggerLazy<T> {
       if (provider is DaggerLazy<*>) {
         @Suppress("UNCHECKED_CAST")
         return provider as DaggerLazy<T>

--- a/interop-dagger/src/main/kotlin/dev/zacsweers/metro/interop/dagger/internal/DaggerInteropDoubleCheck.kt
+++ b/interop-dagger/src/main/kotlin/dev/zacsweers/metro/interop/dagger/internal/DaggerInteropDoubleCheck.kt
@@ -40,7 +40,7 @@ public class DaggerInteropDoubleCheck<T : Any>(provider: MetroProvider<T>) :
       return DaggerInteropDoubleCheck(delegate.asMetroProvider())
     }
 
-    public fun <P : DaggerProvider<T>, T : Any> lazy(provider: P): DaggerLazy<T> {
+    public fun <P : DaggerProvider<T>, T : Any> lazyFromDaggerProvider(provider: P): DaggerLazy<T> {
       if (provider is DaggerLazy<*>) {
         @Suppress("UNCHECKED_CAST")
         return provider as DaggerLazy<T>
@@ -48,7 +48,7 @@ public class DaggerInteropDoubleCheck<T : Any>(provider: MetroProvider<T>) :
       return DaggerInteropDoubleCheck((provider as JakartaProvider<T>).asMetroProvider())
     }
 
-    public fun <P : JavaxProvider<T>, T : Any> lazy(provider: P): DaggerLazy<T> {
+    public fun <P : JavaxProvider<T>, T : Any> lazyFromJavaxProvider(provider: P): DaggerLazy<T> {
       if (provider is DaggerLazy<*>) {
         @Suppress("UNCHECKED_CAST")
         return provider as DaggerLazy<T>
@@ -56,12 +56,20 @@ public class DaggerInteropDoubleCheck<T : Any>(provider: MetroProvider<T>) :
       return DaggerInteropDoubleCheck(provider.asMetroProvider())
     }
 
-    public fun <P : JakartaProvider<T>, T : Any> lazy(provider: P): DaggerLazy<T> {
+    public fun <P : JakartaProvider<T>, T : Any> lazyFromJakartaProvider(provider: P): DaggerLazy<T> {
       if (provider is DaggerLazy<*>) {
         @Suppress("UNCHECKED_CAST")
         return provider as DaggerLazy<T>
       }
       return DaggerInteropDoubleCheck(provider.asMetroProvider())
+    }
+
+    public fun <P : MetroProvider<T>, T : Any> lazyFromMetroProvider(provider: P): DaggerLazy<T> {
+      if (provider is DaggerLazy<*>) {
+        @Suppress("UNCHECKED_CAST")
+        return provider as DaggerLazy<T>
+      }
+      return DaggerInteropDoubleCheck(provider)
     }
   }
 }


### PR DESCRIPTION
The original provider type(javax.inject.Provider vs dev.zacsweers.metro.Provider) was being lost when requested via the ContextualTypeKey using: `original.contextKey.originalType(session).toFirResolvedTypeRef()`. Instead retrieving the resolvedReturnTypeRef directly from the original symbol ensures that the correct Provider is used when building the newInstance method.

Resolves #309 