### PR TITLE
Failing test for extending a generic interface in ContributesGraphExtension.Factory

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
@@ -2021,9 +2021,17 @@ internal class DependencyGraphTransformer(
     return parentGraph.nestedClasses.firstOrNull { it.classId == classId }
       ?: run {
         val generator = IrContributedGraphGenerator(metroContext, contributionData)
+        // Find the function declaration in the original @ContributesGraphExtension.Factory
         val sourceFunction =
-          contributedAccessor.ir.overriddenSymbolsSequence().lastOrNull()?.owner
-            ?: contributedAccessor.ir
+          contributedAccessor.ir
+            .overriddenSymbolsSequence()
+            .filter {
+              it.owner.parentClassOrNull?.isAnnotatedWithAny(
+                metroContext.symbols.classIds.contributesGraphExtensionFactoryAnnotations
+              ) == true
+            }
+            .lastOrNull()
+            ?.owner ?: contributedAccessor.ir
         generator.generateContributedGraph(
           parentGraph = parentGraph,
           sourceFactory = sourceFunction.parentAsClass,

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/ContributesGraphExtensionTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/ContributesGraphExtensionTest.kt
@@ -266,6 +266,39 @@ class ContributesGraphExtensionTest : MetroCompilerTest() {
   }
 
   @Test
+  fun `contributed graph factory can extend a generic interface with create graph function`() {
+    compile(
+      source(
+        """
+          abstract class LoggedInScope
+
+          interface GraphExtensionFactory<T> {
+            fun createGraph(): T
+          }
+
+          @ContributesGraphExtension(LoggedInScope::class)
+          interface LoggedInGraph {
+            val int: Int
+
+            @ContributesGraphExtension.Factory(AppScope::class)
+            interface Factory : GraphExtensionFactory<LoggedInGraph>
+          }
+
+          @DependencyGraph(scope = AppScope::class, isExtendable = true)
+          interface ExampleGraph {
+            @Provides fun provideInt(): Int = 0
+          }
+        """
+          .trimIndent()
+      )
+    ) {
+      val exampleGraph = ExampleGraph.generatedMetroGraphClass().createGraphWithNoArgs()
+      val loggedInGraph = exampleGraph.callFunction<Any>("createGraph")
+      assertThat(loggedInGraph.callProperty<Int>("int")).isEqualTo(0)
+    }
+  }
+
+  @Test
   fun `params are forwarded - provides`() {
     compile(
       source(

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/ContributesGraphExtensionTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/ContributesGraphExtensionTest.kt
@@ -265,6 +265,7 @@ class ContributesGraphExtensionTest : MetroCompilerTest() {
     }
   }
 
+  // Regression test for https://github.com/ZacSweers/metro/pull/351
   @Test
   fun `contributed graph factory can extend a generic interface with create graph function`() {
     compile(


### PR DESCRIPTION
The test fails with the error:
```
Caused by: java.lang.IllegalStateException: Parent of this declaration is not a class: CLASS INTERFACE name:GraphExtensionFactory modality:ABSTRACT visibility:public superTypes:[kotlin.Any]
	at org.jetbrains.kotlin.ir.util.IrUtilsKt.getParentAsClass(IrUtils.kt:274)
	at dev.zacsweers.metro.compiler.ir.IrContributedGraphGenerator.generateContributedGraph(IrContributedGraphGenerator.kt:55)
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.getOrBuildContributedGraph(DependencyGraphTransformer.kt:2023)
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.implementOverrides(DependencyGraphTransformer.kt:1992)
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.generateMetroGraph(DependencyGraphTransformer.kt:1662)
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.getOrBuildDependencyGraph(DependencyGraphTransformer.kt:726)
	... 89 more
```