### PR TITLE
Fallback AssistedInjectChecker error report to the declaration source

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/AssistedInjectChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/AssistedInjectChecker.kt
@@ -27,7 +27,7 @@ import org.jetbrains.kotlin.fir.symbols.impl.FirValueParameterSymbol
 
 internal object AssistedInjectChecker : FirClassChecker(MppCheckerKind.Common) {
   override fun check(declaration: FirClass, context: CheckerContext, reporter: DiagnosticReporter) {
-    declaration.source ?: return
+    val source = declaration.source ?: return
     val session = context.session
     val classIds = session.classIds
 
@@ -55,7 +55,7 @@ internal object AssistedInjectChecker : FirClassChecker(MppCheckerKind.Common) {
     // TODO dagger doesn't allow type params on these, but seems like we could?
     if (function.typeParameterSymbols.isNotEmpty()) {
       reporter.reportOn(
-        function.source,
+        function.source ?: source,
         ASSISTED_INJECTION_ERROR,
         "`@AssistedFactory` functions cannot have type parameters.",
         context,
@@ -71,7 +71,7 @@ internal object AssistedInjectChecker : FirClassChecker(MppCheckerKind.Common) {
       }
     if (injectConstructor == null) {
       reporter.reportOn(
-        function.source,
+        function.source ?: source,
         ASSISTED_INJECTION_ERROR,
         "Invalid return type: ${targetType.symbol.classId.asSingleFqName()}. `@AssistedFactory` target classes must have a single `@Inject`-annotated constructor or be annotated `@Inject` with only a primary constructor.",
         context,


### PR DESCRIPTION
Context: https://github.com/ZacSweers/metro/issues/364#issuecomment-2849076562

The `function.source` might be null if the function lives in an external module, fallback to the factory declaration in this case. I couldn't find a place to add a relevant test, but I tested in a sample project, and it works.