### PR TITLE
ignore additional non-abstract methods in AssistedFactory

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/AssistedFactoryTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/AssistedFactoryTransformer.kt
@@ -12,7 +12,6 @@ import dev.zacsweers.metro.compiler.ir.createIrBuilder
 import dev.zacsweers.metro.compiler.ir.finalizeFakeOverride
 import dev.zacsweers.metro.compiler.ir.irExprBodySafe
 import dev.zacsweers.metro.compiler.ir.irInvoke
-import dev.zacsweers.metro.compiler.ir.isAbstractAndVisible
 import dev.zacsweers.metro.compiler.ir.isAnnotatedWithAny
 import dev.zacsweers.metro.compiler.ir.isExternalParent
 import dev.zacsweers.metro.compiler.ir.parameters.Parameter
@@ -22,7 +21,6 @@ import dev.zacsweers.metro.compiler.ir.rawType
 import dev.zacsweers.metro.compiler.ir.requireSimpleFunction
 import dev.zacsweers.metro.compiler.ir.thisReceiverOrFail
 import dev.zacsweers.metro.compiler.ir.transformers.AssistedFactoryTransformer.AssistedFactoryFunction.Companion.toAssistedFactoryFunction
-import org.jetbrains.kotlin.backend.jvm.ir.isJvmAbstract
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irGetField

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/AssistedFactoryTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/AssistedFactoryTransformer.kt
@@ -12,6 +12,7 @@ import dev.zacsweers.metro.compiler.ir.createIrBuilder
 import dev.zacsweers.metro.compiler.ir.finalizeFakeOverride
 import dev.zacsweers.metro.compiler.ir.irExprBodySafe
 import dev.zacsweers.metro.compiler.ir.irInvoke
+import dev.zacsweers.metro.compiler.ir.isAbstractAndVisible
 import dev.zacsweers.metro.compiler.ir.isAnnotatedWithAny
 import dev.zacsweers.metro.compiler.ir.isExternalParent
 import dev.zacsweers.metro.compiler.ir.parameters.Parameter
@@ -21,6 +22,8 @@ import dev.zacsweers.metro.compiler.ir.rawType
 import dev.zacsweers.metro.compiler.ir.requireSimpleFunction
 import dev.zacsweers.metro.compiler.ir.thisReceiverOrFail
 import dev.zacsweers.metro.compiler.ir.transformers.AssistedFactoryTransformer.AssistedFactoryFunction.Companion.toAssistedFactoryFunction
+import org.jetbrains.kotlin.backend.jvm.ir.isJvmAbstract
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irGetField
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -105,6 +108,7 @@ internal class AssistedFactoryTransformer(
 
     val creatorFunction =
       implClass.functions
+        .filter { it.modality == Modality.ABSTRACT }
         .single { it.isFakeOverride && !it.isFakeOverriddenFromAny() }
         .let { function -> function.toAssistedFactoryFunction(this, function) }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/AssistedFactoryTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/AssistedFactoryTransformerTest.kt
@@ -770,4 +770,34 @@ class AssistedFactoryTransformerTest : MetroCompilerTest() {
       assertThat(result).isEqualTo("hello 0")
     }
   }
+
+  @Test
+  fun `assisted factory with additional non abstract methods work`() {
+    compile(
+      source(
+        """
+            class ExampleClass @Inject constructor(
+              @Assisted val count: Int,
+              val message: String,
+            ) : Callable<String> {
+              override fun call(): String = message + count
+            }
+
+            @AssistedFactory
+            interface ExampleClassFactory {
+              fun foo(): ExampleClass = create(0)
+              fun bar() {}
+
+              fun create(count: Int): ExampleClass
+            }
+          """
+          .trimIndent()
+      )
+    ) {
+      val exampleClassFactory =
+        ExampleClass.generatedFactoryClassAssisted().invokeCreate(provider { "Hello, " })
+      val exampleClass = exampleClassFactory.callFactoryInvoke<Callable<String>>(2)
+      assertThat(exampleClass.call()).isEqualTo("Hello, 2")
+    }
+  }
 }


### PR DESCRIPTION
Currently having other non abstract methods in the factory fails with
```
e: java.lang.IllegalArgumentException: Sequence contains more than one matching element.
        at dev.zacsweers.metro.compiler.ir.transformers.AssistedFactoryTransformer.getOrGenerateImplClass$compiler(AssistedFactoryTransformer.kt:237)
        at dev.zacsweers.metro.compiler.ir.transformers.AssistedFactoryTransformer.visitClass(AssistedFactoryTransformer.kt:50)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitClass(DependencyGraphTransformer.kt:192)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitClass(DependencyGraphTransformer.kt:150)
        at org.jetbrains.kotlin.ir.declarations.IrClass.accept(IrClass.kt:72)
        at org.jetbrains.kotlin.ir.IrElementBase.transform(IrElementBase.kt:34)
        at org.jetbrains.kotlin.ir.util.TransformKt.transformInPlace(transform.kt:35)
        at org.jetbrains.kotlin.ir.declarations.IrClass.transformChildren(IrClass.kt:82)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformer$DefaultImpls.visitDeclaration(IrElementTransformer.kt:38)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitDeclaration(DependencyGraphTransformer.kt:150)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitDeclaration(DependencyGraphTransformer.kt:150)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformer$DefaultImpls.visitClass(IrElementTransformer.kt:46)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitClass(DependencyGraphTransformer.kt:197)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitClass(DependencyGraphTransformer.kt:150)
        at org.jetbrains.kotlin.ir.declarations.IrClass.accept(IrClass.kt:72)
        at org.jetbrains.kotlin.ir.IrElementBase.transform(IrElementBase.kt:34)
        at org.jetbrains.kotlin.ir.util.TransformKt.transformInPlace(transform.kt:35)
        at org.jetbrains.kotlin.ir.declarations.IrFile.transformChildren(IrFile.kt:38)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformer$DefaultImpls.visitFile(IrElementTransformer.kt:104)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitFile(DependencyGraphTransformer.kt:150)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitFile(DependencyGraphTransformer.kt:150)
        at org.jetbrains.kotlin.ir.declarations.IrFile.accept(IrFile.kt:28)
        at org.jetbrains.kotlin.ir.declarations.IrFile.transform(IrFile.kt:31)
        at org.jetbrains.kotlin.ir.declarations.IrFile.transform(IrFile.kt:20)
        at org.jetbrains.kotlin.ir.util.TransformKt.transformInPlace(transform.kt:35)
        at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.transformChildren(IrModuleFragment.kt:40)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformer$DefaultImpls.visitModuleFragment(IrElementTransformer.kt:73)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitModuleFragment(DependencyGraphTransformer.kt:150)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitModuleFragment(DependencyGraphTransformer.kt:150)
        at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.accept(IrModuleFragment.kt:30)
        at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.transform(IrModuleFragment.kt:33)
        at dev.zacsweers.metro.compiler.ir.MetroIrGenerationExtension.generate(MetroIrGenerationExtension.kt:29)
        at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.applyIrGenerationExtensions(convertToIr.kt:472)
        at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.runActualizationPipeline(convertToIr.kt:241)
        at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.convertToIrAndActualize(convertToIr.kt:130)
        at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize(convertToIr.kt:100)
        at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize$default(convertToIr.kt:75)
        at org.jetbrains.kotlin.cli.jvm.compiler.legacy.pipeline.JvmCompilerPipelineKt.convertToIrAndActualizeForJvm(jvmCompilerPipeline.kt:108)
        at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:26)
        at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:17)
        at org.jetbrains.kotlin.cli.pipeline.PipelinePhase.phaseBody(PipelinePhase.kt:68)
        at org.jetbrains.kotlin.cli.pipeline.PipelinePhase.phaseBody(PipelinePhase.kt:58)
        at org.jetbrains.kotlin.config.phaser.SimpleNamedCompilerPhase.phaseBody(CompilerPhase.kt:215)
        at org.jetbrains.kotlin.config.phaser.NamedCompilerPhase.invoke(CompilerPhase.kt:111)
        at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:28)
        at org.jetbrains.kotlin.config.phaser.CompilerPhaseKt.invokeToplevel(CompilerPhase.kt:62)
        at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.runPhasedPipeline(AbstractCliPipeline.kt:106)
        at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.execute(AbstractCliPipeline.kt:65)
        at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecutePhased(K2JVMCompiler.kt:61)
        at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecutePhased(K2JVMCompiler.kt:36)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:80)
        at org.jetbrains.kotlin.cli.common.CLICompiler.exec(CLICompiler.kt:337)
        at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:466)
        at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:75)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:514)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:431)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileNonIncrementally(IncrementalCompilerRunner.kt:310)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:137)
        at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:678)
        at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:92)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1805)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:360)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:714)
        at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:598)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:844)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:721)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:720)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1575)
```

Same use case as for supporting `protected` described here https://github.com/ZacSweers/metro/issues/364#issuecomment-2849190080