### PR TITLE
allow AssistedFactory methods to be protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog
 - **Enhancement**: Don't generate hints for contributed types with non-public API visibility.
 - **Enhancement**: When reporting duplicate binding errors where one of the bindings is contributed, report the contributing class in the error message.
 - **Enhancement**: When reporting scope incompatibility, check any extended parents match the scope and suggest a workaround in the error diagnostic.
+- **Enhancement**: Allow AssistedFactory methods to be protected.
 - **Fix**: Fix incremental compilation when a parent graph or supertype modifies/removes a provider.
 - **Fix**: Fix rank processing error when the outranked binding is contributed using Metro's ContributesBinding annotation.
 - **Fix**: Fix `@Provides` graph parameters not getting passed on to extended child graphs.

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirMetroErrors.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirMetroErrors.kt
@@ -91,7 +91,7 @@ internal object FirMetroErrors : BaseDiagnosticRendererFactory() {
   // Common
   val FACTORY_MUST_HAVE_ONE_ABSTRACT_FUNCTION by error2<String, String>(NAME_IDENTIFIER)
   val METRO_DECLARATION_ERROR by error1<String>(NAME_IDENTIFIER)
-  val METRO_DECLARATION_VISIBILITY_ERROR by error1<String>(VISIBILITY_MODIFIER)
+  val METRO_DECLARATION_VISIBILITY_ERROR by error2<String, String>(VISIBILITY_MODIFIER)
   val METRO_TYPE_PARAMETERS_ERROR by error1<String>(TYPE_PARAMETERS_LIST)
 
   // DependencyGraph factory errors
@@ -109,7 +109,7 @@ internal object FirMetroErrors : BaseDiagnosticRendererFactory() {
   val ONLY_CLASSES_CAN_BE_INJECTED by error0(NAME_IDENTIFIER)
   val ONLY_FINAL_AND_OPEN_CLASSES_CAN_BE_INJECTED by error0(MODALITY_MODIFIER)
   val LOCAL_CLASSES_CANNOT_BE_INJECTED by error0(NAME_IDENTIFIER)
-  val INJECTED_CLASSES_MUST_BE_VISIBLE by error0(VISIBILITY_MODIFIER)
+  val INJECTED_CLASSES_MUST_BE_VISIBLE by error1<String>(VISIBILITY_MODIFIER)
 
   // Assisted factory/inject errors
   val ASSISTED_INJECTION_ERROR by error1<String>(NAME_IDENTIFIER)
@@ -149,7 +149,7 @@ internal object FirMetroErrors : BaseDiagnosticRendererFactory() {
         "Local classes cannot be annotated with @Inject or have @Inject-annotated constructors.",
       )
       put(METRO_DECLARATION_ERROR, "{0}", TO_STRING)
-      put(METRO_DECLARATION_VISIBILITY_ERROR, "{0} must be public or internal.", TO_STRING)
+      put(METRO_DECLARATION_VISIBILITY_ERROR, "{0} must be {1}.", TO_STRING, STRING)
       put(METRO_TYPE_PARAMETERS_ERROR, "{0}", STRING)
 
       // DependencyGraph creator errors
@@ -181,7 +181,7 @@ internal object FirMetroErrors : BaseDiagnosticRendererFactory() {
       )
       put(
         INJECTED_CLASSES_MUST_BE_VISIBLE,
-        "Injected classes must be visible, either `public` or `internal`.",
+        "Injected classes must be visible, {0}.", STRING,
       )
       put(ASSISTED_INJECTION_ERROR, "{0}", STRING)
       put(PROVIDES_ERROR, "{0}", STRING)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirMetroErrors.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirMetroErrors.kt
@@ -179,10 +179,7 @@ internal object FirMetroErrors : BaseDiagnosticRendererFactory() {
         ONLY_FINAL_AND_OPEN_CLASSES_CAN_BE_INJECTED,
         "Only final and open classes be annotated with @Inject or have @Inject-annotated constructors.",
       )
-      put(
-        INJECTED_CLASSES_MUST_BE_VISIBLE,
-        "Injected classes must be visible, {0}.", STRING,
-      )
+      put(INJECTED_CLASSES_MUST_BE_VISIBLE, "Injected classes must be visible, {0}.", STRING)
       put(ASSISTED_INJECTION_ERROR, "{0}", STRING)
       put(PROVIDES_ERROR, "{0}", STRING)
       put(PROVIDES_WARNING, "{0}", STRING)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirMetroErrors.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirMetroErrors.kt
@@ -179,7 +179,7 @@ internal object FirMetroErrors : BaseDiagnosticRendererFactory() {
         ONLY_FINAL_AND_OPEN_CLASSES_CAN_BE_INJECTED,
         "Only final and open classes be annotated with @Inject or have @Inject-annotated constructors.",
       )
-      put(INJECTED_CLASSES_MUST_BE_VISIBLE, "Injected classes must be visible, {0}.", STRING)
+      put(INJECTED_CLASSES_MUST_BE_VISIBLE, "Injected classes must be {0}.", STRING)
       put(ASSISTED_INJECTION_ERROR, "{0}", STRING)
       put(PROVIDES_ERROR, "{0}", STRING)
       put(PROVIDES_WARNING, "{0}", STRING)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/AssistedInjectChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/AssistedInjectChecker.kt
@@ -48,6 +48,7 @@ internal object AssistedInjectChecker : FirClassChecker(MppCheckerKind.Common) {
         context,
         reporter,
         "@AssistedFactory declarations",
+        allowProtected = true,
       ) {
         return
       }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
@@ -174,20 +174,23 @@ internal fun List<FirAnnotation>.isAnnotatedWithAny(
 }
 
 internal inline fun FirMemberDeclaration.checkVisibility(
-  onError: (source: KtSourceElement?) -> Nothing
+  allowProtected: Boolean = false,
+  onError: (source: KtSourceElement?, allowedVisibilities: String) -> Nothing
 ) {
-  visibility.checkVisibility(source, onError)
+  visibility.checkVisibility(source, allowProtected, onError)
 }
 
 internal inline fun FirCallableSymbol<*>.checkVisibility(
-  onError: (source: KtSourceElement?) -> Nothing
+  allowProtected: Boolean = false,
+  onError: (source: KtSourceElement?, allowedVisibilities: String) -> Nothing
 ) {
-  visibility.checkVisibility(source, onError)
+  visibility.checkVisibility(source, allowProtected, onError)
 }
 
 internal inline fun Visibility.checkVisibility(
   source: KtSourceElement?,
-  onError: (source: KtSourceElement?) -> Nothing,
+  allowProtected: Boolean = false,
+  onError: (source: KtSourceElement?, allowedVisibilities: String) -> Nothing,
 ) {
   // TODO what about expect/actual/protected
   when (this) {
@@ -196,8 +199,13 @@ internal inline fun Visibility.checkVisibility(
       // These are fine
       // TODO what about across modules? Is internal really ok? Or PublishedApi?
     }
+    Visibilities.Protected -> {
+      if (!allowProtected) {
+        onError(source, "public or internal")
+      }
+    }
     else -> {
-      onError(source)
+      onError(source, if (allowProtected) "public, internal or protected" else "public or internal")
     }
   }
 }
@@ -301,6 +309,7 @@ internal inline fun FirClass.singleAbstractFunction(
   context: CheckerContext,
   reporter: DiagnosticReporter,
   type: String,
+  allowProtected: Boolean = false,
   onError: () -> Nothing,
 ): FirNamedFunctionSymbol {
   val abstractFunctions = symbol.abstractFunctions(session)
@@ -329,11 +338,12 @@ internal inline fun FirClass.singleAbstractFunction(
   }
 
   val function = abstractFunctions.single()
-  function.checkVisibility { source ->
+  function.checkVisibility(allowProtected) { source, allowedVisibilities ->
     reporter.reportOn(
       source,
       FirMetroErrors.METRO_DECLARATION_VISIBILITY_ERROR,
       "$type classes' single abstract functions",
+      allowedVisibilities,
       context,
     )
     onError()
@@ -473,8 +483,8 @@ internal inline fun FirClass.validateInjectedClass(
     }
   }
 
-  checkVisibility { source ->
-    reporter.reportOn(source, FirMetroErrors.INJECTED_CLASSES_MUST_BE_VISIBLE, context)
+  checkVisibility { source, allowedVisibilities ->
+    reporter.reportOn(source, FirMetroErrors.INJECTED_CLASSES_MUST_BE_VISIBLE, allowedVisibilities, context)
     onError()
   }
 }
@@ -552,8 +562,8 @@ internal inline fun FirClass.validateApiDeclaration(
     }
   }
 
-  checkVisibility { source ->
-    reporter.reportOn(source, FirMetroErrors.METRO_DECLARATION_VISIBILITY_ERROR, type, context)
+  checkVisibility { source, allowedVisibilities ->
+    reporter.reportOn(source, FirMetroErrors.METRO_DECLARATION_VISIBILITY_ERROR, type, allowedVisibilities, context)
     onError()
   }
   if (isAbstract && classKind == ClassKind.CLASS) {
@@ -573,8 +583,8 @@ internal inline fun FirConstructorSymbol.validateVisibility(
   type: String,
   onError: () -> Nothing,
 ) {
-  checkVisibility { source ->
-    reporter.reportOn(source, FirMetroErrors.METRO_DECLARATION_VISIBILITY_ERROR, type, context)
+  checkVisibility { source, allowedVisibilities ->
+    reporter.reportOn(source, FirMetroErrors.METRO_DECLARATION_VISIBILITY_ERROR, type, allowedVisibilities, context)
     onError()
   }
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
@@ -175,14 +175,14 @@ internal fun List<FirAnnotation>.isAnnotatedWithAny(
 
 internal inline fun FirMemberDeclaration.checkVisibility(
   allowProtected: Boolean = false,
-  onError: (source: KtSourceElement?, allowedVisibilities: String) -> Nothing
+  onError: (source: KtSourceElement?, allowedVisibilities: String) -> Nothing,
 ) {
   visibility.checkVisibility(source, allowProtected, onError)
 }
 
 internal inline fun FirCallableSymbol<*>.checkVisibility(
   allowProtected: Boolean = false,
-  onError: (source: KtSourceElement?, allowedVisibilities: String) -> Nothing
+  onError: (source: KtSourceElement?, allowedVisibilities: String) -> Nothing,
 ) {
   visibility.checkVisibility(source, allowProtected, onError)
 }
@@ -484,7 +484,12 @@ internal inline fun FirClass.validateInjectedClass(
   }
 
   checkVisibility { source, allowedVisibilities ->
-    reporter.reportOn(source, FirMetroErrors.INJECTED_CLASSES_MUST_BE_VISIBLE, allowedVisibilities, context)
+    reporter.reportOn(
+      source,
+      FirMetroErrors.INJECTED_CLASSES_MUST_BE_VISIBLE,
+      allowedVisibilities,
+      context,
+    )
     onError()
   }
 }
@@ -563,7 +568,13 @@ internal inline fun FirClass.validateApiDeclaration(
   }
 
   checkVisibility { source, allowedVisibilities ->
-    reporter.reportOn(source, FirMetroErrors.METRO_DECLARATION_VISIBILITY_ERROR, type, allowedVisibilities, context)
+    reporter.reportOn(
+      source,
+      FirMetroErrors.METRO_DECLARATION_VISIBILITY_ERROR,
+      type,
+      allowedVisibilities,
+      context,
+    )
     onError()
   }
   if (isAbstract && classKind == ClassKind.CLASS) {
@@ -584,7 +595,13 @@ internal inline fun FirConstructorSymbol.validateVisibility(
   onError: () -> Nothing,
 ) {
   checkVisibility { source, allowedVisibilities ->
-    reporter.reportOn(source, FirMetroErrors.METRO_DECLARATION_VISIBILITY_ERROR, type, allowedVisibilities, context)
+    reporter.reportOn(
+      source,
+      FirMetroErrors.METRO_DECLARATION_VISIBILITY_ERROR,
+      type,
+      allowedVisibilities,
+      context,
+    )
     onError()
   }
 }

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/InjectConstructorErrorsTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/InjectConstructorErrorsTest.kt
@@ -198,8 +198,8 @@ class InjectConstructorErrorsTest : MetroCompilerTest() {
     ) {
       assertDiagnostics(
         """
-            e: VisibleClasses.kt:7:1 Injected classes must be visible, either `public` or `internal`.
-            e: VisibleClasses.kt:11:3 Injected classes must be visible, either `public` or `internal`.
+            e: VisibleClasses.kt:7:1 Injected classes must be public or internal.
+            e: VisibleClasses.kt:11:3 Injected classes must be public or internal.
           """
           .trimIndent()
       )

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/AssistedFactoryTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/AssistedFactoryTransformerTest.kt
@@ -770,4 +770,31 @@ class AssistedFactoryTransformerTest : MetroCompilerTest() {
       assertThat(result).isEqualTo("hello 0")
     }
   }
+
+  @Test
+  fun `assisted factory with protected method works`() {
+    compile(
+      source(
+        """
+            class ExampleClass @Inject constructor(
+              @Assisted val count: Int,
+              val message: String,
+            ) : Callable<String> {
+              override fun call(): String = message + count
+            }
+
+            @AssistedFactory
+            abstract class ExampleClassFactory {
+              protected abstract fun create(count: Int): ExampleClass
+            }
+          """
+          .trimIndent()
+      )
+    ) {
+      val exampleClassFactory =
+        ExampleClass.generatedFactoryClassAssisted().invokeCreate(provider { "Hello, " })
+      val exampleClass = exampleClassFactory.callFactoryInvoke<Callable<String>>(2)
+      assertThat(exampleClass.call()).isEqualTo("Hello, 2")
+    }
+  }
 }


### PR DESCRIPTION
See https://github.com/ZacSweers/metro/issues/364#issuecomment-2849190080

I went with generally supporting this as an option in the `fir.kt` methods. If you thing this goes too far I can also limit it to `singleAbstractFunction` and have a special case only in there.