### PR TITLE
Fix @ElementsIntoSet multibinding contributions triggering a dependency cycle in some situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 
 - **Fix**: Don't transform `@Provides` function's to be private if its visibility is already explicitly defined.
 - **Fix**: Fix a comparator infinite loop vector.
+- **Fix**: Fix @ElementsIntoSet multibinding contributions triggering a dependency cycle in some situations.
 
 0.3.0
 -----

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
@@ -186,15 +186,15 @@ internal open class MutableBindingGraph<
           key !in deferredTypes &&
             !contextKey.isDeferrable &&
             cycle.none { it.contextKey.isDeferrable }
-        if (isTrueCycle) {
+        if (contextKey.isIntoMultibinding) {
+          // Proceed
+          stackLogger.log("--> Into multibinding, proceeding")
+        } else if (isTrueCycle) {
           stackLogger.log("--> ❌True cycle!")
           // Pull the root entry from the stack and add it back to the bottom of the stack to
           // highlight the cycle
           val fullCycle = cycle + cycle[0]
           reportCycle(fullCycle)
-        } else if (contextKey.isIntoMultibinding) {
-          // Proceed
-          stackLogger.log("--> Into multibinding, proceeding")
         } else {
           // TODO this if check isn't great
           stackLogger.log("--> Deferring ${key.render(short = true)}")

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
@@ -860,7 +860,11 @@ internal class DependencyGraphTransformer(
       trackClassLookup(node.sourceGraph, providerFactory.clazz)
 
       val parameters = providerFactory.parameters
-      val contextKey = IrContextualTypeKey(typeKey)
+      val contextKey =
+        IrContextualTypeKey.create(
+          typeKey,
+          isIntoMultibinding = providerFactory.annotations.isIntoMultibinding,
+        )
 
       val provider =
         Binding.Provided(


### PR DESCRIPTION
The dependency cycle would primarily occur when contributing elements into set in a contributed interface, and that multibinding gets injected as a constructor argument. Changes that would work-around the issue included using @IntoSet instead of providing the set of elements, or accessing the multibinding directly as a dependency graph-level provider field.

Error would show up like:
```e: LoggedInScope.kt:20:1 [Metro/DependencyCycle] Found a dependency cycle while processing 'test.ExampleGraph'.
Cycle:
    Set<ContributedInterface> <--> Set<ContributedInterface>

Trace:
    kotlin.collections.Set<test.ContributedInterface> is injected at
        [test.ExampleGraph] test.MultibindingConsumer(…, contributions)
    kotlin.collections.Set<test.ContributedInterface> is injected at
        [test.ExampleGraph] test.MultibindingConsumer(…, contributions)
```