### PR TITLE
Fix a couple multibinding errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog
 - **Fix**: Don't transform `@Provides` function's to be private if its visibility is already explicitly defined.
 - **Fix**: Fix a comparator infinite loop vector.
 - **Fix**: Fix @ElementsIntoSet multibinding contributions triggering a dependency cycle in some situations.
+- **Fix**: Fix assertion error for generated multibinding name hint when using both @Multibinds and @ElementsIntoSet for the same multibinding.
+- **Fix**: Fix contributed graph extensions not inheriting empty declared multibindings.
 - When debug logging + reports dir is enabled, output a `logTrace.txt` to the reports dir for tracing data.
 
 0.3.0

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/Binding.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/Binding.kt
@@ -446,7 +446,7 @@ internal sealed interface Binding : BaseBinding<IrType, IrTypeKey, IrContextualT
       }
 
     override val nameHint: String
-      get() = error("Should never be called")
+      get() = "${typeKey.type.rawType().name}Multibinding"
 
     override val contextualTypeKey: IrContextualTypeKey = IrContextualTypeKey(typeKey)
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
@@ -800,7 +800,7 @@ internal class DependencyGraphTransformer(
         throw e
       }
       throw AssertionError(
-        "Code gen exception while processing ${dependencyGraphDeclaration.classIdOrFail}",
+        "Code gen exception while processing ${dependencyGraphDeclaration.classIdOrFail}. ${e.message}",
         e,
       )
     }
@@ -991,7 +991,17 @@ internal class DependencyGraphTransformer(
       }
     }
 
-    node.accessors.forEach { (getter, contextualTypeKey) ->
+    val accessorsToAdd = buildList {
+      addAll(node.accessors)
+      addAll(
+        node.allExtendedNodes.flatMap { (_, extendedNode) ->
+          // Pass down @Multibinds declarations in the same way we do for multibinding providers
+          extendedNode.accessors.filter { it.first.annotations.isMultibinds }
+        }
+      )
+    }
+
+    accessorsToAdd.forEach { (getter, contextualTypeKey) ->
       val multibinds = getter.annotations.multibinds
       val isMultibindingDeclaration = multibinds != null
 


### PR DESCRIPTION
- Fix contributed graph extensions not inheriting empty declared multibindings. This would show up as a normal missing binding error.
- Fix assertion error for generated multibinding name hint when using both @Multibinds and @ElementsIntoSet for the same multibinding. The error for this would show up as
```
e: java.lang.AssertionError: Code gen exception while processing test/ExampleGraph. Should never be called
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.transformDependencyGraph(DependencyGraphTransformer.kt:802)
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.tryTransformDependencyGraph$lambda$35(DependencyGraphTransformer.kt:732)
...
```