### PR TITLE
Enable graph extensions to access scoped constructor-injected classes from parent graphs even if the parent doesn't have an explicit accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog
 - **Fix**: Fix accidentally adding contributed graphs as child elements of parent graphs twice.
 - **Fix**: Fix not deep copying `extensionReceiverParameter` when implementing fake overrides in contributed graphs.
 - **Fix**: Report fully qualified qualifier renderings in diagnostics.
+- **Fix**: Enable graph extensions to access scoped constructor-injected classes from parent graphs even if the parent doesn't have an explicit accessor.
 - When debug logging + reports dir is enabled, output a `logTrace.txt` to the reports dir for tracing data.
 
 0.3.0

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/DependencyGraphNode.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/DependencyGraphNode.kt
@@ -56,6 +56,10 @@ internal data class DependencyGraphNode(
 
   val allExtendedNodes by lazy { buildMap { recurseParents(this) } }
 
+  fun hasAccessToScope(scope: IrAnnotation): Boolean {
+    return scope in scopes || scope in allExtendedNodes.flatMap { it.value.scopes }
+  }
+
   override fun toString(): String = typeKey.render(short = true)
 
   sealed interface Creator {


### PR DESCRIPTION
Fixes the issue originally reported in https://github.com/ZacSweers/metro/issues/377