### PR TITLE
Fix contributed binding replacements not being respected in contributed graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 --------------
 
 - **Fix**: Fix generic members inherited from generic supertypes of contributed graphs.
+- **Fix**: Fix contributed binding replacements not being respected in contributed graphs.
 
 0.3.1
 -----

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContributionData.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContributionData.kt
@@ -4,7 +4,6 @@ package dev.zacsweers.metro.compiler.ir
 
 import dev.zacsweers.metro.compiler.Symbols
 import dev.zacsweers.metro.compiler.mapNotNullToSet
-import kotlin.collections.flatMap
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classOrFail
@@ -44,7 +43,21 @@ internal class IrContributionData(private val metroContext: IrMetroContext) {
     contributingClasses: List<IrClass>,
     scopeClassId: ClassId,
   ): Set<IrType> {
-    return contributingClasses
+    val filteredContributions = contributingClasses.toMutableList()
+
+    // Remove replaced contributions
+    filteredContributions
+      .flatMap { contributingType ->
+        contributingType
+          .annotationsIn(metroContext.symbols.classIds.allContributesAnnotations)
+          .flatMap { annotation -> annotation.replacedClasses() }
+      }
+      .distinct()
+      .forEach { replacedClass ->
+        filteredContributions.removeIf { it.symbol == replacedClass.symbol }
+      }
+
+    return filteredContributions
       .flatMap { it.nestedClasses }
       .mapNotNullToSet { nestedClass ->
         val metroContribution =

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -669,6 +669,14 @@ internal fun IrConstructorCall.getSingleConstBooleanArgumentOrNull(): Boolean? {
 internal fun IrConstructorCall.getConstBooleanArgumentOrNull(name: Name): Boolean? =
   (getValueArgument(name) as IrConst?)?.value as Boolean?
 
+internal fun IrConstructorCall.replacesArgument() =
+  getValueArgument(Symbols.Names.replaces)?.expectAsOrNull<IrVararg>()
+
+internal fun IrConstructorCall.replacedClasses(): Set<IrClassReference> {
+  return replacesArgument()?.elements?.expectAsOrNull<List<IrClassReference>>()?.toSet()
+    ?: return emptySet()
+}
+
 internal fun IrConstructorCall.scopeOrNull(): ClassId? {
   return scopeClassOrNull()?.classIdOrFail
 }


### PR DESCRIPTION
Seems like we may need to apply a similar fix for other filtering that currently happens in `ContributedInterfaceSupertypeGenerator` like excludes and rank, but figured I'd keep this as an isolated fix for now since I haven't hit a use-case for the others yet.