### PR TITLE
Don't unnecessarily recompute bindings for roots when populating graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 **Unreleased**
 --------------
 
+- **Fix:** Don't unnecessarily recompute bindings for roots when populating graphs.
 - Migrate to new IR `parameters`/`arguments`/`typeArguments` APIs.
 
 0.3.2

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
@@ -104,7 +104,9 @@ internal open class MutableBindingGraph<
     // Traverse all the bindings up front to
     // First ensure all the roots' bindings are present
     for (contextKey in roots.keys) {
-      computeBinding(contextKey)?.let { tryPut(it, stack, contextKey.typeKey) }
+      if (contextKey.typeKey !in bindings) {
+        computeBinding(contextKey)?.let { tryPut(it, stack, contextKey.typeKey) }
+      }
     }
 
     // Then populate the rest of the bindings. This is important to do because some bindings

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/ContributesGraphExtensionTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/ContributesGraphExtensionTest.kt
@@ -1535,6 +1535,39 @@ class ContributesGraphExtensionTest : MetroCompilerTest() {
     }
   }
 
+  /**
+   * A more complex version of
+   * [DependencyGraphTransformerTest.`roots already in the graph are not re-added`].
+   */
+  @Test
+  fun `multiple contributed graphs should be able to inject dependency from parent`() {
+    compile(
+      source(
+        """
+          sealed interface LoggedInScope
+
+          @Inject @SingleIn(AppScope::class) class Dependency
+
+          @DependencyGraph(scope = AppScope::class, isExtendable = true)
+          interface ExampleGraph {
+            val dependency: Dependency
+          }
+
+          @ContributesGraphExtension(LoggedInScope::class)
+          interface LoggedInGraph {
+              val dependency: Dependency
+
+              @ContributesGraphExtension.Factory(AppScope::class)
+              interface Factory {
+                  fun createLoggedInGraph(): LoggedInGraph
+              }
+          }
+        """
+          .trimIndent()
+      )
+    )
+  }
+
   // TODO
   //  - multiple scopes to same graph. Need disambiguating names
 }

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
@@ -2917,4 +2917,30 @@ class DependencyGraphTransformerTest : MetroCompilerTest() {
       assertThat(foo.callProperty<String>("text")).isEqualTo("default")
     }
   }
+
+  @Test
+  fun `roots already in the graph are not re-added`() {
+    // Regression test to ensure we don't try to unnecessarily recompute
+    // bindings that are already present in the graph (provided some other way)
+    // This only affects constructor-injected classes as they would return a
+    // non-null value for the binding when it tried to create it
+    compile(
+      source(
+        """
+          @DependencyGraph(scope = AppScope::class)
+          interface ExampleGraph {
+            val value: Dependency
+
+            @DependencyGraph.Factory
+            interface Factory {
+              fun create(@Provides value: Dependency): ExampleGraph
+            }
+          }
+
+          @Inject class Dependency
+        """
+          .trimIndent()
+      )
+    )
+  }
 }


### PR DESCRIPTION
As reported by @r0adkll