### PR TITLE
Enable child graphs to depend on parent-scoped dependencies that are unused and not referenced in the parent scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 **Unreleased**
 --------------
 
+- **Enhancement**: Enable child graphs to depend on parent-scoped dependencies that are unused and not referenced in the parent scope. This involves generating hints for classes with scoped @Inject constructors and is gated on a new Metro option `enableInjectConstructorHints`.
 - **Fix:** Don't unnecessarily recompute bindings for roots when populating graphs.
 - Migrate to new IR `parameters`/`arguments`/`typeArguments` APIs.
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
@@ -413,6 +413,17 @@ internal enum class MetroOption(val raw: RawMetroOption<*>) {
       required = false,
       allowMultipleOccurrences = false,
     )
+  ),
+  ENABLE_INJECT_CONSTRUCTOR_HINTS(
+    RawMetroOption.boolean(
+      name = "enable-inject-constructor-hints",
+      defaultValue = false,
+      valueDescription = "<true | false>",
+      description =
+        "Enable/disable generating hints for scoped @Inject constructors. By default, a scoped injectable class that isn't used in its associated graph node will result in an error if a graph extension later tries to inject it. Enabling this setting prevents such errors by generating an accessor for all scoped types within the graph node. See https://github.com/ZacSweers/metro/issues/377 for more context.",
+      required = false,
+      allowMultipleOccurrences = false,
+    )
   );
 
   companion object {
@@ -489,6 +500,8 @@ public data class MetroOptions(
   val customScopeAnnotations: Set<ClassId> = MetroOption.CUSTOM_SCOPE.raw.defaultValue.expectAs(),
   val enableDaggerAnvilInterop: Boolean =
     MetroOption.ENABLE_DAGGER_ANVIL_INTEROP.raw.defaultValue.expectAs(),
+  val enableInjectConstructorHints: Boolean =
+    MetroOption.ENABLE_INJECT_CONSTRUCTOR_HINTS.raw.defaultValue.expectAs(),
 ) {
   internal companion object {
     fun load(configuration: CompilerConfiguration): MetroOptions {
@@ -608,6 +621,9 @@ public data class MetroOptions(
 
           MetroOption.ENABLE_DAGGER_ANVIL_INTEROP -> {
             options = options.copy(enableDaggerAnvilInterop = configuration.getAsBoolean(entry))
+          }
+          MetroOption.ENABLE_INJECT_CONSTRUCTOR_HINTS -> {
+            options = options.copy(enableInjectConstructorHints = configuration.getAsBoolean(entry))
           }
         }
       }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/ExtensionPredicates.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/ExtensionPredicates.kt
@@ -16,6 +16,11 @@ internal class ExtensionPredicates(private val classIds: ClassIds) {
       metaAnnotated(classIds.qualifierAnnotations.asFqNames(), includeItself = false)
     }
 
+  internal val scopesPredicate =
+    DeclarationPredicate.create {
+      metaAnnotated(classIds.scopeAnnotations.asFqNames(), includeItself = false)
+    }
+
   internal val dependencyGraphPredicate = annotated(classIds.dependencyGraphAnnotations.asFqNames())
   internal val contributesGraphExtensionPredicate =
     annotated(classIds.contributesGraphExtensionAnnotations.asFqNames())

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
@@ -101,6 +101,7 @@ import org.jetbrains.kotlin.fir.types.FirTypeProjectionWithVariance
 import org.jetbrains.kotlin.fir.types.FirTypeRef
 import org.jetbrains.kotlin.fir.types.builder.buildResolvedTypeRef
 import org.jetbrains.kotlin.fir.types.classId
+import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.fir.types.coneTypeOrNull
 import org.jetbrains.kotlin.fir.types.constructClassLikeType
 import org.jetbrains.kotlin.fir.types.constructType
@@ -954,7 +955,12 @@ internal fun FirAnnotation.resolvedReplacedClassIds(
   return replaced.toSet()
 }
 
-internal fun FirGetClassCall.resolvedClassId() = (argument as? FirResolvedQualifier)?.classId
+internal fun FirGetClassCall.resolvedClassId(): ClassId? {
+  return (argument as? FirResolvedQualifier)?.classId
+    // Sometimes additional unwrapping is necessary e.g. when we're dealing with a directly applied
+    // scope annotation like @Singleton on a processed class
+    ?: (argument as? FirClassReferenceExpression)?.classTypeRef?.coneType?.classId
+}
 
 internal fun FirAnnotation.resolvedClassArgumentTarget(
   name: Name,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -179,6 +179,19 @@ internal fun IrAnnotationContainer.findAnnotations(classId: ClassId): Sequence<I
   return annotations.asSequence().filter { it.symbol.owner.parentAsClass.classId == classId }
 }
 
+internal fun IrAnnotationContainer.annotationsAnnotatedWithAny(
+  names: Set<ClassId>
+): Sequence<IrConstructorCall> {
+  return annotations.asSequence().filter { annotationCall ->
+    annotationCall.isAnnotatedWithAny(names)
+  }
+}
+
+internal fun IrConstructorCall.isAnnotatedWithAny(names: Set<ClassId>): Boolean {
+  val annotationClass = this.symbol.owner.parentAsClass
+  return annotationClass.annotationsIn(names).any()
+}
+
 internal fun <T> IrConstructorCall.constArgumentOfTypeAt(position: Int): T? {
   if (arguments.isEmpty()) return null
   return (arguments[position] as? IrConst?)?.valueAs()

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
@@ -231,6 +231,9 @@ abstract class MetroCompilerTest {
               MetroOption.ENABLE_DAGGER_ANVIL_INTEROP -> {
                 processor.option(entry.raw.cliOption, enableDaggerAnvilInterop)
               }
+              MetroOption.ENABLE_INJECT_CONSTRUCTOR_HINTS -> {
+                processor.option(entry.raw.cliOption, enableInjectConstructorHints)
+              }
             }
           yield(option)
         }

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -24,6 +24,7 @@ public final class dev/zacsweers/metro/gradle/MetroGradleSubplugin : org/jetbrai
 public abstract class dev/zacsweers/metro/gradle/MetroPluginExtension {
 	public fun <init> (Lorg/gradle/api/file/ProjectLayout;Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/provider/ProviderFactory;)V
 	public final fun getDebug ()Lorg/gradle/api/provider/Property;
+	public final fun getEnableInjectConstructorHints ()Lorg/gradle/api/provider/Property;
 	public final fun getEnableKotlinVersionCompatibilityChecks ()Lorg/gradle/api/provider/Property;
 	public final fun getEnableTopLevelFunctionInjection ()Lorg/gradle/api/provider/Property;
 	public final fun getEnabled ()Lorg/gradle/api/provider/Property;

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
@@ -82,6 +82,7 @@ public class MetroGradleSubplugin : KotlinCompilerPluginSupportPlugin {
         add(lazyOption("debug", extension.debug))
         add(lazyOption("generate-assisted-factories", extension.generateAssistedFactories))
         add(lazyOption("generate-hint-properties", extension.generateHintProperties))
+        add(lazyOption("enable-inject-constructor-hints", extension.enableInjectConstructorHints))
         add(lazyOption("transform-providers-to-private", extension.transformProvidersToPrivate))
         add(lazyOption("public-provider-severity", extension.publicProviderSeverity))
         add(

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
@@ -54,6 +54,13 @@ constructor(layout: ProjectLayout, objects: ObjectFactory, providers: ProviderFa
   public val generateHintProperties: Property<Boolean> =
     objects.property(Boolean::class.javaObjectType).convention(true)
 
+  /**
+   * Enable/disable hint property generation for scoped constructor-injected types. Disabled by
+   * default.
+   */
+  public val enableInjectConstructorHints: Property<Boolean> =
+    objects.property(Boolean::class.javaObjectType).convention(false)
+
   /** Enable/disable automatic transformation of providers to be private. Enabled by default. */
   public val transformProvidersToPrivate: Property<Boolean> =
     objects.property(Boolean::class.javaObjectType).convention(true)


### PR DESCRIPTION
- Applies to both contributed bindings and scoped constructor-injected classes without contributions.
- Introduces a new Metro option `enableInjectConstructorHints` which determines if we should generate hints for classes with scoped `@Inject` constructors. By default this option is disabled.
- Fixes https://github.com/ZacSweers/metro/issues/377.