### PR TITLE
reproducer for generic AssistedFactory with ViewBinding

### DIFF
--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/AssistedFactoryTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/AssistedFactoryTransformerTest.kt
@@ -827,4 +827,33 @@ class AssistedFactoryTransformerTest : MetroCompilerTest() {
       assertThat(exampleClass.call()).isEqualTo("Hello, 2")
     }
   }
+
+  @Test
+  fun `assisted factory with generic method works`() {
+    compile(
+      source(
+        """
+            class ExampleClass @Inject constructor(
+              @Assisted val count: Int,
+              val message: String,
+            ) : Callable<String> {
+              override fun call(): String = message + count
+            }
+
+            interface BaseFactory<B, T> {
+              fun create(b: B): T
+            }
+
+            @AssistedFactory
+            abstract class ExampleClassFactory : BaseFactory<Int, ExampleClass>
+          """
+          .trimIndent()
+      )
+    ) {
+      val exampleClassFactory =
+        ExampleClass.generatedFactoryClassAssisted().invokeCreate(provider { "Hello, " })
+      val exampleClass = exampleClassFactory.callFactoryInvoke<Callable<String>>(2)
+      assertThat(exampleClass.call()).isEqualTo("Hello, 2")
+    }
+  }
 }

--- a/samples/android-app/build.gradle.kts
+++ b/samples/android-app/build.gradle.kts
@@ -18,6 +18,10 @@ android {
     versionName = "1.0"
   }
 
+  buildFeatures {
+      viewBinding = true
+  }
+
   buildTypes { release { isMinifyEnabled = false } }
 
   compileOptions {

--- a/samples/android-app/src/main/kotlin/dev/zacsweers/metro/sample/android/Test.kt
+++ b/samples/android-app/src/main/kotlin/dev/zacsweers/metro/sample/android/Test.kt
@@ -1,0 +1,27 @@
+package dev.zacsweers.metro.sample.android
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.sample.android.databinding.ActivityMainBinding
+
+
+interface BaseFactory<B, T> {
+  fun create(b: B): T
+}
+
+@ContributesTo(AppScope::class)
+interface TestRendererGraph {
+  val factory: TestRenderer.Factory
+}
+
+class TestRenderer @Inject constructor(
+  @Assisted private val binding: ActivityMainBinding
+) {
+
+
+  @AssistedFactory
+  abstract class Factory : BaseFactory<ActivityMainBinding, TestRenderer>
+}


### PR DESCRIPTION
I've also left the compiler test that shows that generics generally work.
```
e: java.lang.AssertionError: Code gen exception while processing dev/zacsweers/metro/sample/android/AppGraph. Required a single abstract function for dev.zacsweers.metro.sample.android.TestRenderer.Factory but found multiple:
- dev.zacsweers.metro.sample.android.TestRenderer.Factory.create
  - create(dev.zacsweers.metro.sample.android.databinding.ActivityMainBinding)
- dev.zacsweers.metro.sample.android.BaseFactory.create
  - create(kotlin.Any)Required a single abstract function for dev.zacsweers.metro.sample.android.TestRenderer.Factory but found multiple:
- dev.zacsweers.metro.sample.android.TestRenderer.Factory.create
  - create(dev.zacsweers.metro.sample.android.databinding.ActivityMainBinding)
- dev.zacsweers.metro.sample.android.BaseFactory.create
  - create(kotlin.Any)
Caused by: java.lang.IllegalStateException: Required a single abstract function for dev.zacsweers.metro.sample.android.TestRenderer.Factory but found multiple:
- dev.zacsweers.metro.sample.android.TestRenderer.Factory.create
  - create(dev.zacsweers.metro.sample.android.databinding.ActivityMainBinding)
- dev.zacsweers.metro.sample.android.BaseFactory.create
  - create(kotlin.Any)Required a single abstract function for dev.zacsweers.metro.sample.android.TestRenderer.Factory but found multiple:
- dev.zacsweers.metro.sample.android.TestRenderer.Factory.create
  - create(dev.zacsweers.metro.sample.android.databinding.ActivityMainBinding)
- dev.zacsweers.metro.sample.android.BaseFactory.create
  - create(kotlin.Any)
        at dev.zacsweers.metro.compiler.UtilKt.singleOrError(util.kt:129)
        at dev.zacsweers.metro.compiler.ir.IrKt.singleAbstractFunction(ir.kt:610)
        at dev.zacsweers.metro.compiler.ir.BindingKt.injectedClassBindingOrNull(Binding.kt:566)
        at dev.zacsweers.metro.compiler.ir.IrBindingGraph.realGraph$lambda$2(IrBindingGraph.kt:41)
        at dev.zacsweers.metro.compiler.graph.MutableBindingGraph.populateGraph(BindingGraph.kt:108)
        at dev.zacsweers.metro.compiler.graph.MutableBindingGraph.seal(BindingGraph.kt:83)
        at dev.zacsweers.metro.compiler.ir.IrBindingGraph.validate$lambda$8(IrBindingGraph.kt:168)
        at dev.zacsweers.metro.compiler.tracing.TracerKt.trace(Tracer.kt:82)
        at dev.zacsweers.metro.compiler.tracing.TracerKt.traceNested(Tracer.kt:75)
        at dev.zacsweers.metro.compiler.ir.IrBindingGraph.validate(IrBindingGraph.kt:168)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.transformDependencyGraph$lambda$40$lambda$39(DependencyGraphTransformer.kt:736)
        at dev.zacsweers.metro.compiler.tracing.TracerKt.trace(Tracer.kt:82)
        at dev.zacsweers.metro.compiler.tracing.TracerKt.traceNested(Tracer.kt:75)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.transformDependencyGraph$lambda$40(DependencyGraphTransformer.kt:735)
        at dev.zacsweers.metro.compiler.tracing.TracerKt.trace(Tracer.kt:82)
        at dev.zacsweers.metro.compiler.tracing.TracerKt.traceNested(Tracer.kt:75)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.transformDependencyGraph(DependencyGraphTransformer.kt:726)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.tryTransformDependencyGraph$lambda$35(DependencyGraphTransformer.kt:683)
        at dev.zacsweers.metro.compiler.tracing.TracerKt.trace(Tracer.kt:82)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.tryTransformDependencyGraph(DependencyGraphTransformer.kt:682)
        at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitClass(DependencyGraphTransformer.kt:153)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:57)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:19)
        at org.jetbrains.kotlin.ir.declarations.IrClass.accept(IrClass.kt:72)
        at org.jetbrains.kotlin.ir.IrElementBase.transform(IrElementBase.kt:34)
        at org.jetbrains.kotlin.ir.util.TransformKt.transformInPlace(transform.kt:35)
        at org.jetbrains.kotlin.ir.declarations.IrFile.transformChildren(IrFile.kt:38)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitPackageFragment(IrElementTransformerVoid.kt:152)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:166)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:169)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:19)
        at org.jetbrains.kotlin.ir.declarations.IrFile.accept(IrFile.kt:28)
        at org.jetbrains.kotlin.ir.declarations.IrFile.transform(IrFile.kt:31)
        at org.jetbrains.kotlin.ir.declarations.IrFile.transform(IrFile.kt:20)
        at org.jetbrains.kotlin.ir.util.TransformKt.transformInPlace(transform.kt:35)
        at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.transformChildren(IrModuleFragment.kt:40)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitModuleFragment(IrElementTransformerVoid.kt:108)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitModuleFragment(IrElementTransformerVoid.kt:113)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitModuleFragment(IrElementTransformerVoid.kt:19)
        at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.accept(IrModuleFragment.kt:30)
        at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.transform(IrModuleFragment.kt:33)
        at dev.zacsweers.metro.compiler.ir.MetroIrGenerationExtension.generate(MetroIrGenerationExtension.kt:35)
        at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.applyIrGenerationExtensions(convertToIr.kt:472)
        at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.runActualizationPipeline(convertToIr.kt:241)
        at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.convertToIrAndActualize(convertToIr.kt:130)
        at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize(convertToIr.kt:100)
        at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize$default(convertToIr.kt:75)
        at org.jetbrains.kotlin.cli.jvm.compiler.legacy.pipeline.JvmCompilerPipelineKt.convertToIrAndActualizeForJvm(jvmCompilerPipeline.kt:108)
        at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:26)
        at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:17)
        at org.jetbrains.kotlin.cli.pipeline.PipelinePhase.phaseBody(PipelinePhase.kt:68)
        at org.jetbrains.kotlin.cli.pipeline.PipelinePhase.phaseBody(PipelinePhase.kt:58)
        at org.jetbrains.kotlin.config.phaser.SimpleNamedCompilerPhase.phaseBody(CompilerPhase.kt:215)
        at org.jetbrains.kotlin.config.phaser.NamedCompilerPhase.invoke(CompilerPhase.kt:111)
        at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:28)
        at org.jetbrains.kotlin.config.phaser.CompilerPhaseKt.invokeToplevel(CompilerPhase.kt:62)
        at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.runPhasedPipeline(AbstractCliPipeline.kt:106)
        at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.execute(AbstractCliPipeline.kt:65)
        at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecutePhased(K2JVMCompiler.kt:61)
        at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecutePhased(K2JVMCompiler.kt:36)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:80)
        at org.jetbrains.kotlin.cli.common.CLICompiler.exec(CLICompiler.kt:337)
        at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:466)
        at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:75)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:514)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:431)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileNonIncrementally(IncrementalCompilerRunner.kt:310)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:137)
        at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:678)
        at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:92)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1805)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:578)
        at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:360)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
        at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:598)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:844)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:721)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:720)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1589)
```