### PR TITLE
Fix walking successors + rework missing binding validation order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Changelog
 
 - **Enhancement:** Use a simple numbered (but deterministic) naming for contributed graph classes to avoid long class names.
 - **Enhancement:** Improve graph validation performance by avoiding unnecessary intermediate sorts.
+- **Enhancement:** Move binding validation into graph validation step.
+- **Enhancement:** Avoid unnecessary BFS graph walk in provider field collection.
+- **Fix:** Fix provider field populating missing types that previously seen types dependent on.
 
 0.3.3
 -----

--- a/compiler-tests/src/test/data/box/provides/TransitiveSuccessorScope.kt
+++ b/compiler-tests/src/test/data/box/provides/TransitiveSuccessorScope.kt
@@ -1,0 +1,25 @@
+import kotlin.test.assertEquals
+import java.util.concurrent.atomic.AtomicInteger
+
+@DependencyGraph(AppScope::class)
+interface App {
+  val string: String
+  val int: Int
+}
+
+var counter = AtomicInteger(0)
+
+@ContributesTo(AppScope::class)
+interface Providers {
+  // due to SingleIn this should only be called once and return `1`
+  @Provides @SingleIn(AppScope::class) fun incr(): AtomicInteger = counter.also { counter.incrementAndGet() }
+  @Provides fun string(int: Int): String = "$int"
+  @Provides fun int(incr: AtomicInteger): Int = incr.get()
+}
+
+fun box(): String {
+  val graph = createGraph<App>()
+  assertEquals("1", graph.string)
+  assertEquals("1", graph.int.toString())
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/provides/TransitiveSuccessorScope.kt
+++ b/compiler-tests/src/test/data/box/provides/TransitiveSuccessorScope.kt
@@ -1,4 +1,3 @@
-import kotlin.test.assertEquals
 import java.util.concurrent.atomic.AtomicInteger
 
 @DependencyGraph(AppScope::class)

--- a/compiler-tests/src/test/data/dump/ir/cycles/CycleGraph.fir.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/cycles/CycleGraph.fir.kt.txt
@@ -309,7 +309,6 @@ interface ChildCycleGraph {
     private /* final field */ val childCycleGraphProvider: Provider<ChildCycleGraph> = Companion.invoke<ChildCycleGraph>(value = <this>.#thisGraphInstance)
     private /* final field */ val cProvider: Provider<C> = DelegateFactory<C>()
     private /* final field */ val provideObjectWithCycleProvider: Provider<Any> = DelegateFactory<Any>()
-    private /* final field */ val aProvider: Provider<A> = Companion.create(b = Companion.create(c = <this>.#cProvider), e = Companion.create(d = Companion.create(b = Companion.create(c = <this>.#cProvider))))
     private /* final field */ val bProvider: Provider<B> = Companion.create(c = <this>.#cProvider)
     constructor(@Extends cycleGraph: CycleGraph) /* primary */ {
       super/*Any*/()
@@ -318,13 +317,13 @@ interface ChildCycleGraph {
       when {
         cycleGraph !is $$MetroGraph -> throw illegalArgumentException(arg0 = "Constructor parameter cycleGraph _must_ be a Metro-compiler-generated instance of CycleGraph but was " + cycleGraph.toString())
       }
-      Companion.setDelegate<C>(delegateFactory = <this>.#cProvider, delegate = Companion.create(aProvider = <this>.#aProvider, aLazy = <this>.#aProvider, aLazyProvider = <this>.#aProvider))
+      Companion.setDelegate<C>(delegateFactory = <this>.#cProvider, delegate = Companion.create(aProvider = Companion.create(b = <this>.#bProvider, e = Companion.create(d = Companion.create(b = <this>.#bProvider))), aLazy = Companion.create(b = <this>.#bProvider, e = Companion.create(d = Companion.create(b = <this>.#bProvider))), aLazyProvider = Companion.create(b = <this>.#bProvider, e = Companion.create(d = Companion.create(b = <this>.#bProvider)))))
       Companion.setDelegate<Any>(delegateFactory = <this>.#provideObjectWithCycleProvider, delegate = Companion.create(instance = <this>.#cycleGraphInstance, obj = <this>.#provideObjectWithCycleProvider))
     }
 
     override val a: A
       override get(): A {
-        return <this>.#aProvider.invoke()
+        return Companion.create(b = <this>.#bProvider, e = Companion.create(d = Companion.create(b = <this>.#bProvider))).invoke()
       }
 
     override val obj: Any
@@ -370,18 +369,17 @@ interface CycleGraph {
     private /* final field */ val cycleGraphProvider: Provider<CycleGraph> = Companion.invoke<CycleGraph>(value = <this>.#thisGraphInstance)
     private /* final field */ val cProvider: Provider<C> = DelegateFactory<C>()
     private /* final field */ val provideObjectWithCycleProvider: Provider<Any> = DelegateFactory<Any>()
-    private /* final field */ val aProvider: Provider<A> = Companion.create(b = Companion.create(c = <this>.#cProvider), e = Companion.create(d = Companion.create(b = Companion.create(c = <this>.#cProvider))))
     private /* final field */ val bProvider: Provider<B> = Companion.create(c = <this>.#cProvider)
     constructor() /* primary */ {
       super/*Any*/()
       /* <init>() */
 
-      Companion.setDelegate<C>(delegateFactory = <this>.#cProvider, delegate = Companion.create(aProvider = <this>.#aProvider, aLazy = <this>.#aProvider, aLazyProvider = <this>.#aProvider))
+      Companion.setDelegate<C>(delegateFactory = <this>.#cProvider, delegate = Companion.create(aProvider = Companion.create(b = <this>.#bProvider, e = Companion.create(d = Companion.create(b = <this>.#bProvider))), aLazy = Companion.create(b = <this>.#bProvider, e = Companion.create(d = Companion.create(b = <this>.#bProvider))), aLazyProvider = Companion.create(b = <this>.#bProvider, e = Companion.create(d = Companion.create(b = <this>.#bProvider)))))
       Companion.setDelegate<Any>(delegateFactory = <this>.#provideObjectWithCycleProvider, delegate = Companion.create(instance = <this>.#thisGraphInstance, obj = <this>.#provideObjectWithCycleProvider))
     }
 
     override fun a(): A {
-      return <this>.#aProvider.invoke()
+      return Companion.create(b = <this>.#bProvider, e = Companion.create(d = Companion.create(b = <this>.#bProvider))).invoke()
     }
 
     override fun c(): C {

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -206,5 +206,11 @@ public class BoxTestGenerated extends AbstractBoxTest {
     public void testSimpleFunctionProvider() {
       runTest("compiler-tests/src/test/data/box/provides/SimpleFunctionProvider.kt");
     }
+
+    @Test
+    @TestMetadata("TransitiveSuccessorScope.kt")
+    public void testTransitiveSuccessorScope() {
+      runTest("compiler-tests/src/test/data/box/provides/TransitiveSuccessorScope.kt");
+    }
   }
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BaseBindingStack.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BaseBindingStack.kt
@@ -9,7 +9,7 @@ internal interface BaseBindingStack<
   Type : Any,
   TypeKey : BaseTypeKey<Type, *, *>,
   Entry : BaseBindingStack.BaseEntry<Type, TypeKey, *>,
-  Impl : BaseBindingStack<ClassType, Type, TypeKey, Entry, Impl>
+  Impl : BaseBindingStack<ClassType, Type, TypeKey, Entry, Impl>,
 > {
   val graph: ClassType
   val entries: List<Entry>

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BaseBindingStack.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BaseBindingStack.kt
@@ -9,6 +9,7 @@ internal interface BaseBindingStack<
   Type : Any,
   TypeKey : BaseTypeKey<Type, *, *>,
   Entry : BaseBindingStack.BaseEntry<Type, TypeKey, *>,
+  Impl : BaseBindingStack<ClassType, Type, TypeKey, Entry, Impl>
 > {
   val graph: ClassType
   val entries: List<Entry>
@@ -17,6 +18,8 @@ internal interface BaseBindingStack<
   fun push(entry: Entry)
 
   fun pop()
+
+  fun copy(): Impl
 
   fun entryFor(key: TypeKey): Entry?
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
@@ -14,10 +14,9 @@ internal interface BindingGraph<
   ContextualTypeKey : BaseContextualTypeKey<Type, TypeKey, ContextualTypeKey>,
   Binding : BaseBinding<Type, TypeKey, ContextualTypeKey>,
   BindingStackEntry : BaseBindingStack.BaseEntry<Type, TypeKey, ContextualTypeKey>,
-  BindingStack : BaseBindingStack<*, Type, TypeKey, BindingStackEntry>,
+  BindingStack : BaseBindingStack<*, Type, TypeKey, BindingStackEntry, BindingStack>,
 > {
   val bindings: Map<TypeKey, Binding>
-  val adjacency: Map<TypeKey, Set<TypeKey>>
 
   operator fun get(key: TypeKey): Binding?
 
@@ -26,13 +25,15 @@ internal interface BindingGraph<
   fun TypeKey.dependsOn(other: TypeKey): Boolean
 }
 
+// TODO instead of implementing BindingGraph, maybe just make this a builder and have build()
+//  produce one?
 internal open class MutableBindingGraph<
   Type : Any,
   TypeKey : BaseTypeKey<Type, *, TypeKey>,
   ContextualTypeKey : BaseContextualTypeKey<Type, TypeKey, ContextualTypeKey>,
   Binding : BaseBinding<Type, TypeKey, ContextualTypeKey>,
   BindingStackEntry : BaseBindingStack.BaseEntry<Type, TypeKey, ContextualTypeKey>,
-  BindingStack : BaseBindingStack<*, Type, TypeKey, BindingStackEntry>,
+  BindingStack : BaseBindingStack<*, Type, TypeKey, BindingStackEntry, BindingStack>,
 >(
   private val newBindingStack: () -> BindingStack,
   private val newBindingStackEntry:
@@ -53,12 +54,6 @@ internal open class MutableBindingGraph<
   // Populated by initial graph setup and later seal()
   override val bindings = mutableMapOf<TypeKey, Binding>()
   private val bindingIndices = mutableMapOf<TypeKey, Int>()
-  private var _adjacency: Map<TypeKey, Set<TypeKey>>? = null
-  override val adjacency: Map<TypeKey, Set<TypeKey>>
-    get() {
-      check(sealed) { "Adjacency is only available after sealing" }
-      return _adjacency!!
-    }
 
   var sealed = false
     private set
@@ -84,73 +79,22 @@ internal open class MutableBindingGraph<
   fun seal(
     roots: Map<ContextualTypeKey, BindingStackEntry> = emptyMap(),
     tracer: Tracer = Tracer.NONE,
+    validateBinding:
+      (
+        Binding,
+        BindingStack,
+        roots: Map<ContextualTypeKey, BindingStackEntry>,
+        adjacency: Map<TypeKey, Set<TypeKey>>,
+      ) -> Unit =
+      { binding, stack, roots, adjacency -> /* noop */
+      },
   ): TopoSortResult<TypeKey> {
     val stack = newBindingStack()
 
-    populateGraph(roots, stack, tracer)
-
-    val topo = tracer.traceNested("Sort and validate") { sortAndValidate(roots, stack, it) }
-
-    tracer.traceNested("Compute binding indices") {
-      // If it depends itself or something that comes later in the topo sort, it
-      // must be deferred. This is how we handle cycles that are broken by deferrable
-      // types like Provider/Lazy/...
-      // O(1) “does A depend on B?”
-      bindingIndices.putAll(topo.sortedKeys.withIndex().associate { it.value to it.index })
-    }
+    val missingBindings = populateGraph(roots, stack, tracer)
 
     sealed = true
-    return topo
-  }
 
-  private fun populateGraph(
-    roots: Map<ContextualTypeKey, BindingStackEntry>,
-    stack: BindingStack,
-    tracer: Tracer,
-  ) {
-    // Traverse all the bindings up front to
-    // First ensure all the roots' bindings are present
-    for (contextKey in roots.keys) {
-      if (contextKey.typeKey !in bindings) {
-        computeBinding(contextKey)?.let { tryPut(it, stack, contextKey.typeKey) }
-      }
-    }
-
-    // Then populate the rest of the bindings. This is important to do because some bindings
-    // are computed (i.e., constructor-injected types) as they are used. We do this upfront
-    // so that the graph is fully populated before we start validating it and avoid mutating
-    // it while we're validating it.
-    val bindingQueue = ArrayDeque<Binding>().also { it.addAll(bindings.values) }
-
-    tracer.traceNested("Populate bindings") {
-      while (bindingQueue.isNotEmpty()) {
-        val binding = bindingQueue.removeFirst()
-        if (binding.typeKey !in bindings && !binding.isTransient) {
-          bindings[binding.typeKey] = binding
-        }
-
-        fun Binding.visitDependencies() {
-          for (depKey in dependencies) {
-            stack.withEntry(stack.newBindingStackEntry(depKey, this, roots)) {
-              val typeKey = depKey.typeKey
-              if (typeKey !in bindings) {
-                // If the binding isn't present, we'll report it later
-                computeBinding(depKey)?.let { bindingQueue.addLast(it) }
-              }
-            }
-          }
-        }
-
-        binding.visitDependencies()
-      }
-    }
-  }
-
-  private fun sortAndValidate(
-    roots: Map<ContextualTypeKey, BindingStackEntry>,
-    stack: BindingStack,
-    parentTracer: Tracer,
-  ): TopoSortResult<TypeKey> {
     /**
      * Build the full adjacency mapping of keys to all their dependencies.
      *
@@ -158,7 +102,7 @@ internal open class MutableBindingGraph<
      * optional bindings).
      */
     val fullAdjacency =
-      parentTracer.traceNested("Build adjacency list") {
+      tracer.traceNested("Build adjacency list") {
         buildFullAdjacency(
           bindings = bindings,
           dependenciesOf = { binding -> binding.dependencies.map { it.typeKey } },
@@ -178,6 +122,88 @@ internal open class MutableBindingGraph<
         )
       }
 
+    // Report missing bindings _after_ building adjacency so we can backtrace where possible
+    // TODO report all
+    missingBindings.forEach { (key, stack) -> reportMissingBinding(key, stack) }
+
+    // Validate bindings
+    for (binding in bindings.values) {
+      validateBinding(binding, stack, roots, fullAdjacency)
+    }
+
+    val topo =
+      tracer.traceNested("Sort and validate") { sortAndValidate(roots, fullAdjacency, stack, it) }
+
+    tracer.traceNested("Compute binding indices") {
+      // If it depends itself or something that comes later in the topo sort, it
+      // must be deferred. This is how we handle cycles that are broken by deferrable
+      // types like Provider/Lazy/...
+      // O(1) “does A depend on B?”
+      bindingIndices.putAll(topo.sortedKeys.withIndex().associate { it.value to it.index })
+    }
+
+    return topo
+  }
+
+  private fun populateGraph(
+    roots: Map<ContextualTypeKey, BindingStackEntry>,
+    stack: BindingStack,
+    tracer: Tracer,
+  ): Map<TypeKey, BindingStack> {
+    // Traverse all the bindings up front to
+    // First ensure all the roots' bindings are present
+    // Defer missing binding reporting until after we finish populating
+    val missingBindings = mutableMapOf<TypeKey, BindingStack>()
+    for ((contextKey, entry) in roots) {
+      if (contextKey.typeKey !in bindings) {
+        val binding = computeBinding(contextKey)
+        if (binding != null) {
+          tryPut(binding, stack, contextKey.typeKey)
+        } else {
+          stack.withEntry(entry) { missingBindings[contextKey.typeKey] = stack.copy() }
+        }
+      }
+    }
+
+    // Then populate the rest of the bindings. This is important to do because some bindings
+    // are computed (i.e., constructor-injected types) as they are used. We do this upfront
+    // so that the graph is fully populated before we start validating it and avoid mutating
+    // it while we're validating it.
+    val bindingQueue = ArrayDeque<Binding>().also { it.addAll(bindings.values) }
+
+    tracer.traceNested("Populate bindings") {
+      while (bindingQueue.isNotEmpty()) {
+        val binding = bindingQueue.removeFirst()
+        if (binding.typeKey !in bindings && !binding.isTransient) {
+          bindings[binding.typeKey] = binding
+        }
+
+        for (depKey in binding.dependencies) {
+          stack.withEntry(stack.newBindingStackEntry(depKey, binding, roots)) {
+            val typeKey = depKey.typeKey
+            if (typeKey !in bindings) {
+              // If the binding isn't present, we'll report it later
+              val binding = computeBinding(depKey)
+              if (binding != null) {
+                bindingQueue.addLast(binding)
+              } else {
+                missingBindings[typeKey] = stack.copy()
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return missingBindings
+  }
+
+  private fun sortAndValidate(
+    roots: Map<ContextualTypeKey, BindingStackEntry>,
+    fullAdjacency: Map<TypeKey, Set<TypeKey>>,
+    stack: BindingStack,
+    parentTracer: Tracer,
+  ): TopoSortResult<TypeKey> {
     // Run topo sort. It gives back either a valid order or calls onCycle for errors
     val result =
       parentTracer.traceNested("Topo sort") { nestedTracer ->
@@ -220,7 +246,6 @@ internal open class MutableBindingGraph<
         )
       }
 
-    _adjacency = fullAdjacency
     return result
   }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
@@ -220,6 +220,7 @@ internal open class MutableBindingGraph<
         )
       }
 
+    _adjacency = fullAdjacency
     return result
   }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
@@ -96,7 +96,7 @@ internal fun <T> Iterable<T>.buildFullAdjacency(
 /**
  * Builds the full adjacency list.
  * * Keeps all edges (strict _and_ deferrable).
- * * Prunes edges whose target isn’t in [bindings], delegating the decision to [onMissing].
+ * * Prunes edges whose target isn't in [bindings], delegating the decision to [onMissing].
  */
 internal fun <TypeKey, Binding> buildFullAdjacency(
   bindings: Map<TypeKey, Binding>,
@@ -120,7 +120,7 @@ internal data class TopoSortResult<T>(val sortedKeys: List<T>, val deferredTypes
  * strict cycles throw, breakable cycles (those containing a deferrable edge) are deferred.
  *
  * @param fullAdjacency outgoing‑edge map (every vertex key must be present)
- * @param isDeferrable predicate for “edge may break a cycle”
+ * @param isDeferrable predicate for "edge may break a cycle"
  * @param onCycle called with the offending cycle if no deferrable edge
  */
 internal fun <V : Comparable<V>> topologicalSort(
@@ -306,7 +306,7 @@ private fun <V> buildComponentDag(
       // dependent side
       val dependentComp = componentOf.getValue(toVertex)
       if (prereqComp != dependentComp) {
-        // Reverse the arrow so Kahn sees “prereq → dependent”
+        // Reverse the arrow so Kahn sees "prereq → dependent"
         dag.getOrPut(dependentComp, ::mutableSetOf) += prereqComp
       }
     }
@@ -339,7 +339,7 @@ private fun topologicallySortComponentDag(dag: Map<Int, Set<Int>>, componentCoun
    *  └───▶(1)
    * ```
    *
-   * After we process component 0, both 1 and 2 are “ready”. A plain ArrayDeque would enqueue them
+   * After we process component 0, both 1 and 2 are "ready". A plain ArrayDeque would enqueue them
    * in whatever order the [dag]'s keys are, which isn't deterministic.
    *
    * Using a PriorityQueue means we *always* dequeue the lowest id first (1 before 2 in this

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
@@ -84,7 +84,7 @@ internal fun <T : Comparable<T>> Iterable<T>.buildFullAdjacency(
   val adjacency = TreeMap<T, TreeSet<T>>()
 
   for (key in set) {
-    val listForVertex = adjacency.getOrPut(key, ::TreeSet)
+    val dependencies = adjacency.getOrPut(key, ::TreeSet)
 
     for (targetKey in sourceToTarget(key)) {
       if (targetKey !in set) {
@@ -93,7 +93,7 @@ internal fun <T : Comparable<T>> Iterable<T>.buildFullAdjacency(
         // If we got here, this missing target is allowable (i.e. a default value). Just ignore it
         continue
       }
-      listForVertex += targetKey
+      dependencies += targetKey
     }
   }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/BindingGraphGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/BindingGraphGenerator.kt
@@ -34,6 +34,7 @@ internal class BindingGraphGenerator(
     val graph =
       IrBindingGraph(
         this,
+        node,
         newBindingStack = {
           IrBindingStack(node.sourceGraph, loggerFor(MetroLogger.Type.BindingGraphConstruction))
         },

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindingGraph.kt
@@ -3,6 +3,7 @@
 package dev.zacsweers.metro.compiler.ir
 
 import dev.zacsweers.metro.compiler.MetroAnnotations
+import dev.zacsweers.metro.compiler.decapitalizeUS
 import dev.zacsweers.metro.compiler.exitProcessing
 import dev.zacsweers.metro.compiler.graph.MutableBindingGraph
 import dev.zacsweers.metro.compiler.ir.parameters.wrapInProvider
@@ -24,6 +25,7 @@ import org.jetbrains.kotlin.ir.util.kotlinFqName
 
 internal class IrBindingGraph(
   private val metroContext: IrMetroContext,
+  private val node: DependencyGraphNode,
   newBindingStack: () -> IrBindingStack,
 ) {
 
@@ -39,19 +41,13 @@ internal class IrBindingGraph(
       },
       absentBinding = { key -> Binding.Absent(key) },
       computeBinding = { contextKey -> metroContext.injectedClassBindingOrNull(contextKey) },
-      onError = { message, stack ->
-        val location = stack.lastEntryOrGraph.locationOrNull()
-        metroContext.reportError(message, location)
-        exitProcessing()
-      },
+      onError = ::onError,
       findSimilarBindings = { key -> findSimilarBindings(key).mapValues { it.value.toString() } },
     )
 
   // TODO hoist accessors up and visit in seal?
   private val accessors = mutableMapOf<IrContextualTypeKey, IrBindingStack.Entry>()
   private val injectors = mutableMapOf<IrTypeKey, IrBindingStack.Entry>()
-
-  val adjacency get() = realGraph.adjacency
 
   // Thin immutable view over the internal bindings
   fun bindingsSnapshot(): Map<IrTypeKey, Binding> = realGraph.bindings
@@ -167,7 +163,9 @@ internal class IrBindingGraph(
 
   fun validate(parentTracer: Tracer, onError: (List<GraphError>) -> Nothing): BindingGraphResult {
     val (sortedKeys, deferredTypes) =
-      parentTracer.traceNested("seal graph") { tracer -> realGraph.seal(accessors, tracer) }
+      parentTracer.traceNested("seal graph") { tracer ->
+        realGraph.seal(accessors, tracer, validateBinding = ::checkScope)
+      }
 
     metroContext.writeDiagnostic("validatedKeys-${parentTracer.tag}.txt") {
       buildString { sortedKeys.joinTo(this, separator = "\n") { it.render(short = false) } }
@@ -359,6 +357,140 @@ internal class IrBindingGraph(
           appendBinding(binding, short, isNested = false)
         }
     }
+  }
+
+  private fun onError(message: String, stack: IrBindingStack): Nothing {
+    val location = stack.lastEntryOrGraph.locationOrNull()
+    metroContext.reportError(message, location)
+    exitProcessing()
+  }
+
+  // Check scoping compatibility
+  // TODO FIR error?
+  private fun checkScope(
+    binding: Binding,
+    stack: IrBindingStack,
+    roots: Map<IrContextualTypeKey, IrBindingStack.Entry>,
+    adjacency: Map<IrTypeKey, Set<IrTypeKey>>,
+  ) {
+    val bindingScope = binding.scope
+    if (bindingScope != null) {
+      if (node.scopes.isEmpty() || bindingScope !in node.scopes) {
+        val isUnscoped = node.scopes.isEmpty()
+        // Error if there are mismatched scopes
+        val declarationToReport = node.sourceGraph
+        val backTrace = buildRouteToRoot(binding.typeKey, roots, adjacency)
+        for (entry in backTrace) {
+          stack.push(entry)
+        }
+        stack.push(
+          IrBindingStack.Entry.simpleTypeRef(
+            binding.contextualTypeKey,
+            usage = "(scoped to '$bindingScope')",
+          )
+        )
+        val message = buildString {
+          append("[Metro/IncompatiblyScopedBindings] ")
+          append(declarationToReport.kotlinFqName)
+          if (isUnscoped) {
+            // Unscoped graph but scoped binding
+            append(" (unscoped) may not reference scoped bindings:")
+          } else {
+            // Scope mismatch
+            append(
+              " (scopes ${node.scopes.joinToString { "'$it'" }}) may not reference bindings from different scopes:"
+            )
+          }
+          appendLine()
+          appendBindingStack(stack, short = false)
+          if (!isUnscoped && binding is Binding.ConstructorInjected) {
+            val matchingParent =
+              node.allExtendedNodes.values.firstOrNull { bindingScope in it.scopes }
+            if (matchingParent != null) {
+              appendLine()
+              appendLine()
+              val shortTypeKey = binding.typeKey.render(short = true)
+              appendLine(
+                """
+                  (Hint)
+                  It appears that extended parent graph '${matchingParent.sourceGraph.kotlinFqName}' does declare the '$bindingScope' scope but doesn't use '$shortTypeKey' directly.
+                  To work around this, consider declaring an accessor for '$shortTypeKey' in that graph (i.e. `val ${shortTypeKey.decapitalizeUS()}: $shortTypeKey`).
+                  See https://github.com/ZacSweers/metro/issues/377 for more details.
+                """
+                  .trimIndent()
+              )
+            }
+          }
+        }
+        with(metroContext) { declarationToReport.reportError(message) }
+      }
+    }
+  }
+
+  /**
+   * Builds a route from this binding back to one of the root bindings. Useful for error messaging
+   * to show a trace back to an entry point.
+   */
+  private fun buildRouteToRoot(
+    key: IrTypeKey,
+    roots: Map<IrContextualTypeKey, IrBindingStack.Entry>,
+    adjacency: Map<IrTypeKey, Set<IrTypeKey>>,
+  ): List<IrBindingStack.Entry> {
+    // Build who depends on what
+    val dependents = mutableMapOf<IrTypeKey, MutableSet<IrTypeKey>>()
+    for ((key, deps) in adjacency) {
+      for (dep in deps) {
+        dependents.getOrPut(dep) { mutableSetOf() }.add(key)
+      }
+    }
+
+    // Walk backwards from this binding to find a root
+    val visited = mutableSetOf<IrTypeKey>()
+
+    fun walkToRoot(current: IrTypeKey, path: List<IrTypeKey>): List<IrTypeKey>? {
+      if (current in visited) return null // Cycle
+
+      // Is this a root?
+      if (roots.any { it.key.typeKey == current }) {
+        return path + current
+      }
+
+      visited.add(current)
+
+      // Try walking through each dependent
+      for (dependent in dependents[current].orEmpty()) {
+        walkToRoot(dependent, path + current)?.let {
+          return it
+        }
+      }
+
+      visited.remove(current)
+      return null
+    }
+
+    val path = walkToRoot(key, emptyList()) ?: return emptyList()
+
+    // Convert to stack entries - just create a simple stack and build it up
+    val result = mutableListOf<IrBindingStack.Entry>()
+
+    for (i in path.indices.reversed()) {
+      val typeKey = path[i]
+
+      if (i == path.lastIndex) {
+        // This is the root
+        val rootEntry = roots.entries.first { it.key.typeKey == typeKey }.value
+        result.add(0, rootEntry)
+      } else {
+        // Create an entry for this step
+        val callingBinding = realGraph.bindings.getValue(path[i + 1])
+        val contextKey = callingBinding.dependencies.first { it.typeKey == typeKey }
+        val entry = bindingStackEntryForDependency(callingBinding, contextKey, contextKey.typeKey)
+        result.add(0, entry)
+      }
+    }
+
+    // Reverse the route as these will push onto the top of the stack
+    return result.asReversed()
   }
 
   private fun Appendable.appendBinding(binding: Binding, short: Boolean, isNested: Boolean) {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindingStack.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindingStack.kt
@@ -26,9 +26,10 @@ import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.propertyIfAccessor
 import org.jetbrains.kotlin.name.FqName
 
-internal interface IrBindingStack : BaseBindingStack<IrClass, IrType, IrTypeKey, Entry> {
+internal interface IrBindingStack :
+  BaseBindingStack<IrClass, IrType, IrTypeKey, Entry, IrBindingStack> {
 
-  fun copy(): IrBindingStack
+  override fun copy(): IrBindingStack
 
   class Entry(
     override val contextKey: IrContextualTypeKey,
@@ -236,7 +237,8 @@ internal inline fun <
   Type : Any,
   TypeKey : BaseTypeKey<Type, *, *>,
   Entry : BaseBindingStack.BaseEntry<Type, TypeKey, *>,
-> BaseBindingStack<*, Type, TypeKey, Entry>.withEntry(entry: Entry?, block: () -> T): T {
+  Impl : BaseBindingStack<*, Type, TypeKey, Entry, Impl>,
+> Impl.withEntry(entry: Entry?, block: () -> T): T {
   if (entry == null) return block()
   push(entry)
   val result = block()
@@ -248,7 +250,7 @@ internal val IrBindingStack.lastEntryOrGraph
   get() = entries.firstOrNull()?.declaration ?: graph
 
 internal fun Appendable.appendBindingStack(
-  stack: BaseBindingStack<*, *, *, *>,
+  stack: BaseBindingStack<*, *, *, *, *>,
   indent: String = "    ",
   ellipse: Boolean = false,
   short: Boolean = true,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrGraphGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrGraphGenerator.kt
@@ -321,12 +321,7 @@ internal class IrGraphGenerator(
       // Collect bindings and their dependencies for provider field ordering
       val initOrder =
         parentTracer.traceNested("Collect bindings") {
-          val providerFieldBindings =
-            ProviderFieldCollector(node, bindingGraph) { declaration, message ->
-                declaration.reportError(message)
-                exitProcessing()
-              }
-              .collect()
+          val providerFieldBindings = ProviderFieldCollector(bindingGraph).collect()
           buildList(providerFieldBindings.size) {
             for (key in sealResult.sortedKeys) {
               providerFieldBindings[key]?.let(::add)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ProviderFieldCollector.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ProviderFieldCollector.kt
@@ -2,17 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.compiler.ir
 
-import dev.zacsweers.metro.compiler.MetroLogger
-import dev.zacsweers.metro.compiler.decapitalizeUS
-import org.jetbrains.kotlin.ir.declarations.IrDeclaration
-import org.jetbrains.kotlin.ir.util.kotlinFqName
-
 private const val INITIAL_VALUE = 512
 
 /** Computes the set of bindings that must end up in provider fields. */
-internal class ProviderFieldCollector(
-  private val graph: IrBindingGraph,
-) {
+internal class ProviderFieldCollector(private val graph: IrBindingGraph) {
 
   private data class Node(val binding: Binding, var refCount: Int = 0) {
     val needsField: Boolean

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/StringBindingStack.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/StringBindingStack.kt
@@ -5,7 +5,7 @@ package dev.zacsweers.metro.compiler.graph
 import org.jetbrains.kotlin.name.FqName
 
 internal class StringBindingStack(override val graph: String) :
-  BaseBindingStack<String, String, StringTypeKey, StringBindingStack.Entry> {
+  BaseBindingStack<String, String, StringTypeKey, StringBindingStack.Entry, StringBindingStack> {
   override val entries = ArrayDeque<Entry>()
   override val graphFqName: FqName = FqName(graph)
 
@@ -15,6 +15,10 @@ internal class StringBindingStack(override val graph: String) :
 
   override fun pop() {
     entries.removeFirstOrNull() ?: error("Binding stack is empty!")
+  }
+
+  override fun copy(): StringBindingStack {
+    return StringBindingStack(graph).also { it.entries.addAll(entries) }
   }
 
   override fun entryFor(key: StringTypeKey): Entry? {

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/ir/TracingTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/ir/TracingTest.kt
@@ -87,9 +87,9 @@ class TracingTest : MetroCompilerTest() {
                   ▶ seal graph
                     ▶ Populate bindings
                     ◀ Populate bindings (xx ms)
+                    ▶ Build adjacency list
+                    ◀ Build adjacency list (xx ms)
                     ▶ Sort and validate
-                      ▶ Build adjacency list
-                      ◀ Build adjacency list (xx ms)
                       ▶ Topo sort
                         ▶ Compute SCCs
                         ◀ Compute SCCs (xx ms)
@@ -234,9 +234,9 @@ class TracingTest : MetroCompilerTest() {
                   ▶ seal graph
                     ▶ Populate bindings
                     ◀ Populate bindings (xx ms)
+                    ▶ Build adjacency list
+                    ◀ Build adjacency list (xx ms)
                     ▶ Sort and validate
-                      ▶ Build adjacency list
-                      ◀ Build adjacency list (xx ms)
                       ▶ Topo sort
                         ▶ Compute SCCs
                         ◀ Compute SCCs (xx ms)
@@ -282,9 +282,9 @@ class TracingTest : MetroCompilerTest() {
                   ▶ seal graph
                     ▶ Populate bindings
                     ◀ Populate bindings (xx ms)
+                    ▶ Build adjacency list
+                    ◀ Build adjacency list (xx ms)
                     ▶ Sort and validate
-                      ▶ Build adjacency list
-                      ◀ Build adjacency list (xx ms)
                       ▶ Topo sort
                         ▶ Compute SCCs
                         ◀ Compute SCCs (xx ms)
@@ -430,9 +430,9 @@ class TracingTest : MetroCompilerTest() {
                   ▶ seal graph
                     ▶ Populate bindings
                     ◀ Populate bindings (xx ms)
+                    ▶ Build adjacency list
+                    ◀ Build adjacency list (xx ms)
                     ▶ Sort and validate
-                      ▶ Build adjacency list
-                      ◀ Build adjacency list (xx ms)
                       ▶ Topo sort
                         ▶ Compute SCCs
                         ◀ Compute SCCs (xx ms)
@@ -480,9 +480,9 @@ class TracingTest : MetroCompilerTest() {
                   ▶ seal graph
                     ▶ Populate bindings
                     ◀ Populate bindings (xx ms)
+                    ▶ Build adjacency list
+                    ◀ Build adjacency list (xx ms)
                     ▶ Sort and validate
-                      ▶ Build adjacency list
-                      ◀ Build adjacency list (xx ms)
                       ▶ Topo sort
                         ▶ Compute SCCs
                         ◀ Compute SCCs (xx ms)

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/GraphExtensionTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/GraphExtensionTest.kt
@@ -560,7 +560,7 @@ class GraphExtensionTest : MetroCompilerTest() {
     compile(
       source(
         """
-          @DependencyGraph
+          @DependencyGraph(AppScope::class)
           abstract class ExampleGraph {
             @Provides
             @SingleIn(AppScope::class)


### PR DESCRIPTION
Adds a testcase for walking successors in the graph where due to accessor walk order scopes for transitive successors may be dropped.