### PR TITLE
[Documentation] Reword aggregation @ContributesBinding section

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -91,7 +91,7 @@ For simple cases where there is a single supertype, that type is implicitly used
 class CacheImpl(...) : Cache
 ```
 
-For classes with multiple supertypes or advanced cases where you want to bind an ancestor type, you can explicitly define this via `binding` parameter.
+For advanced cases where you want to bind an ancestor type, you can explicitly define this via `binding` parameter. For example, if your class has multiple supertypes, you must define an explicit bound type for it.
 
 ```kotlin
 @Named("cache")


### PR DESCRIPTION
### Description

This PR updates the documentation with a small rewording on the `@ContributesBinding` section by stating that you MUST specify a binding if the class has multiple supertypes.

### Rationale
By reading that section you could assume that specifying the bound supertype was an option but not required in case of multiple supertypes. 
However, if you try to do that you correctly will get a compilation error:
```kotlin
`@ContributesBinding`-annotated class @dev.zacsweers.metro.ContributesBinding doesn't declare an explicit `bindingType` but has multiple supertypes. You must define an explicit bound type in this scenario.
```

By rewording the section, we state that in case of multiple supertypes, you must specify the bound supertype.