### PR TITLE
Support generic providers in Graph Factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 
 - **Fix:** Support type parameters with `where` bounds.
 - **Fix:** Support injected class type parameters with any bounds.
+- **Fix:** Support generic graph factory interfaces.
 - **Fix:** In the presence of multiple contributing annotations to the same scope, ensure only hint function/file is generated.
 
 0.3.4

--- a/compiler-tests/src/test/data/box/dependencygraph/GraphFactoriesSupportGenericProviders.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/GraphFactoriesSupportGenericProviders.kt
@@ -1,0 +1,17 @@
+interface BaseFactory<T, R> {
+  fun create(@Provides value: T): R
+}
+
+@DependencyGraph
+interface ExampleGraph {
+  val value: Int
+
+  @DependencyGraph.Factory
+  interface Factory : BaseFactory<Int, ExampleGraph>
+}
+
+fun box(): String {
+  val graph = createGraphFactory<ExampleGraph.Factory>().create(3)
+  assertEquals(graph.value, 3)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -116,6 +116,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("GraphFactoriesSupportGenericProviders.kt")
+    public void testGraphFactoriesSupportGenericProviders() {
+      runTest("compiler-tests/src/test/data/box/dependencygraph/GraphFactoriesSupportGenericProviders.kt");
+    }
+
+    @Test
     @TestMetadata("MultibindingGraphWithWithScopedSetDeps.kt")
     public void testMultibindingGraphWithWithScopedSetDeps() {
       runTest("compiler-tests/src/test/data/box/dependencygraph/MultibindingGraphWithWithScopedSetDeps.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/DependencyGraphFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/DependencyGraphFirGenerator.kt
@@ -578,18 +578,16 @@ private fun FirValueParameterSymbol.resolveReturnTypeFrom(
   val originalSamFunctionOwner =
     containingFunctionSymbol?.containingClassLookupTag()?.toSymbol(session)
       as? FirRegularClassSymbol
-  if (typeOwner == null || originalSamFunctionOwner == null) {
-    return resolvedReturnType
-  }
 
   // Find the specific superType reference from creator to originalSamFunctionOwner
   val superTypeRefToSamOwner =
-    typeOwner.resolvedSuperTypes.find { superType ->
-      (superType as? ConeClassLikeType)?.lookupTag == originalSamFunctionOwner.toLookupTag()
+    typeOwner?.resolvedSuperTypes?.find { superType ->
+      (superType as? ConeClassLikeType)?.lookupTag == originalSamFunctionOwner?.toLookupTag()
     } as? ConeClassLikeType
-      ?: error(
-        "Could not find supertype reference from ${typeOwner.classId} to ${originalSamFunctionOwner.classId}"
-      )
+
+  if (typeOwner == null || originalSamFunctionOwner == null || superTypeRefToSamOwner == null) {
+    return resolvedReturnType
+  }
 
   val substitutionMap =
     originalSamFunctionOwner.typeParameterSymbols

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/DependencyGraphFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/DependencyGraphFirGenerator.kt
@@ -346,7 +346,7 @@ internal class DependencyGraphFirGenerator(session: FirSession) :
                 log("Generating SAM param ${valueParameterSymbol.name}")
                 val paramType =
                   if (valueParameterSymbol.resolvedReturnType is ConeTypeParameterType) {
-                    valueParameterSymbol.resolveReturnTypeFrom(
+                    valueParameterSymbol.materializeTypeParameterType(
                       typeOwner = creator.classSymbol,
                       session = session,
                     )
@@ -422,7 +422,7 @@ internal class DependencyGraphFirGenerator(session: FirSession) :
                         "generateConstructors for ${context.owner.classId}",
                         ::log,
                       )
-                  parameter.resolveReturnTypeFrom(
+                  parameter.materializeTypeParameterType(
                     typeOwner = creator?.classSymbol,
                     session = session,
                   )
@@ -571,7 +571,7 @@ internal class DependencyGraphFirGenerator(session: FirSession) :
   }
 }
 
-private fun FirValueParameterSymbol.resolveReturnTypeFrom(
+private fun FirValueParameterSymbol.materializeTypeParameterType(
   typeOwner: FirClassSymbol<*>?,
   session: FirSession,
 ): ConeKotlinType {

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/TestUtils.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/TestUtils.kt
@@ -422,7 +422,7 @@ fun Class<*>.createGraphWithNoArgs(): Any {
 fun Class<*>.createGraphViaFactory(vararg args: Any): Any {
   val factoryInstance = invokeGraphFactory()
   return factoryInstance.javaClass.declaredMethods
-    .single { it.name == Symbols.StringNames.CREATE }
+    .first { it.name == Symbols.StringNames.CREATE }
     .invoke(factoryInstance, *args)
 }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/TestUtils.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/TestUtils.kt
@@ -422,7 +422,7 @@ fun Class<*>.createGraphWithNoArgs(): Any {
 fun Class<*>.createGraphViaFactory(vararg args: Any): Any {
   val factoryInstance = invokeGraphFactory()
   return factoryInstance.javaClass.declaredMethods
-    .first { it.name == Symbols.StringNames.CREATE }
+    .single { it.name == Symbols.StringNames.CREATE && Modifier.isFinal(it.modifiers) }
     .invoke(factoryInstance, *args)
 }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
@@ -1201,33 +1201,6 @@ class DependencyGraphTransformerTest : MetroCompilerTest() {
   }
 
   @Test
-  fun `graph factories support generic providers`() {
-    val result =
-      compile(
-        source(
-          """
-            interface BaseFactory<T, R> {
-              fun create(@Provides value: T): R
-            }
-
-            @DependencyGraph
-            interface ExampleGraph {
-              val value: Int
-
-              @DependencyGraph.Factory
-              interface Factory : BaseFactory<Int, ExampleGraph>
-            }
-          """
-            .trimIndent()
-        ),
-        expectedExitCode = ExitCode.OK,
-      )
-    val graph = result.ExampleGraph.generatedMetroGraphClass().createGraphViaFactory(3)
-    val count = graph.callProperty<Int>("value")
-    assertThat(count).isEqualTo(3)
-  }
-
-  @Test
   fun `graph factories params must be unique - check bindsinstance`() {
     val result =
       compile(

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
@@ -1201,7 +1201,7 @@ class DependencyGraphTransformerTest : MetroCompilerTest() {
   }
 
   @Test
-  fun `base graph factory allows specifying multiple generic types`() {
+  fun `graph factories support generic providers`() {
     val result =
       compile(
         source(

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
@@ -8,6 +8,7 @@ import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.compiler.ExampleGraph
 import dev.zacsweers.metro.compiler.MetroCompilerTest
 import dev.zacsweers.metro.compiler.assertDiagnostics
+import dev.zacsweers.metro.compiler.assertNoWarningsOrErrors
 import dev.zacsweers.metro.compiler.callFunction
 import dev.zacsweers.metro.compiler.callProperty
 import dev.zacsweers.metro.compiler.companionObjectInstance
@@ -1197,6 +1198,29 @@ class DependencyGraphTransformerTest : MetroCompilerTest() {
       """
           .trimIndent()
       )
+    }
+  }
+
+  @Test
+  fun `base graph factory allows specifying multiple generic types`() {
+    compile(
+      source(
+        """
+            interface BaseFactory<T, R> {
+              fun create(@Provides value: T): R
+            }
+
+            @DependencyGraph
+            interface ExampleGraph {
+              @DependencyGraph.Factory
+              interface Factory : BaseFactory<Int, ExampleGraph>
+            }
+          """
+          .trimIndent()
+      ),
+      expectedExitCode = ExitCode.OK,
+    ) {
+      assertNoWarningsOrErrors()
     }
   }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DependencyGraphTransformerTest.kt
@@ -8,15 +8,12 @@ import dev.zacsweers.metro.Provider
 import dev.zacsweers.metro.compiler.ExampleGraph
 import dev.zacsweers.metro.compiler.MetroCompilerTest
 import dev.zacsweers.metro.compiler.assertDiagnostics
-import dev.zacsweers.metro.compiler.assertNoWarningsOrErrors
 import dev.zacsweers.metro.compiler.callFunction
 import dev.zacsweers.metro.compiler.callProperty
 import dev.zacsweers.metro.compiler.companionObjectInstance
 import dev.zacsweers.metro.compiler.createGraphViaFactory
 import dev.zacsweers.metro.compiler.createGraphWithNoArgs
-import dev.zacsweers.metro.compiler.generatedFactoryClass
 import dev.zacsweers.metro.compiler.generatedMetroGraphClass
-import dev.zacsweers.metro.compiler.invokeCreate
 import dev.zacsweers.metro.compiler.invokeInstanceMethod
 import dev.zacsweers.metro.compiler.invokeMain
 import dev.zacsweers.metro.compiler.newInstanceStrict
@@ -1216,7 +1213,7 @@ class DependencyGraphTransformerTest : MetroCompilerTest() {
             @DependencyGraph
             interface ExampleGraph {
               val value: Int
-            
+
               @DependencyGraph.Factory
               interface Factory : BaseFactory<Int, ExampleGraph>
             }


### PR DESCRIPTION
It's me with generic issues again 😅 

The test reproduces the following stacktrace:
```
e: org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments: Not supported: class org.jetbrains.kotlin.fir.types.impl.ConeTypeParameterTypeImpl
	at org.jetbrains.kotlin.fir.types.TypeUtilsKt.withArguments$error(TypeUtils.kt:1121)
	at org.jetbrains.kotlin.fir.types.TypeUtilsKt.withArguments(TypeUtils.kt:172)
	at dev.zacsweers.metro.compiler.fir.generators.DependencyGraphFirGenerator.generateConstructors$lambda$8$lambda$7$lambda$6(DependencyGraphFirGenerator.kt:347)
	at org.jetbrains.kotlin.fir.plugin.FunctionBuildingContext.generateValueParameter(FunctionBuildingContext.kt:86)
	at org.jetbrains.kotlin.fir.plugin.ConstructorBuildingContext.build$lambda$5(ConstructorBuildingContext.kt:62)
	at org.jetbrains.kotlin.fir.plugin.ConstructorBuildingContext.build(ConstructorBuildingContext.kt:185)
	at org.jetbrains.kotlin.fir.plugin.ConstructorBuildingContextKt.createConstructor(ConstructorBuildingContext.kt:133)
	at dev.zacsweers.metro.compiler.fir.generators.DependencyGraphFirGenerator.generateConstructors(DependencyGraphFirGenerator.kt:333)
```

My question is, should this scenario be supported? If so, I can look into a fix 🙏 

Resolves https://github.com/ZacSweers/metro/issues/504