### PR TITLE
No longer generate bounds for API-invisible FIR declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- **Fix:** Support type parameters with `where` bounds.
+- **Fix:** Support injected class type parameters with any bounds.
 - **Fix:** In the presence of multiple contributing annotations to the same scope, ensure only hint function/file is generated.
 
 0.3.4

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/AssistedFactoryImplFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/AssistedFactoryImplFirGenerator.kt
@@ -8,6 +8,7 @@ import dev.zacsweers.metro.compiler.fir.Keys
 import dev.zacsweers.metro.compiler.fir.abstractFunctions
 import dev.zacsweers.metro.compiler.fir.classIds
 import dev.zacsweers.metro.compiler.fir.constructType
+import dev.zacsweers.metro.compiler.fir.copyTypeParametersFrom
 import dev.zacsweers.metro.compiler.fir.hasOrigin
 import dev.zacsweers.metro.compiler.fir.isAnnotatedWithAny
 import dev.zacsweers.metro.compiler.fir.predicates
@@ -135,14 +136,7 @@ internal class AssistedFactoryImplFirGenerator(session: FirSession) :
       Symbols.Names.MetroImpl -> {
         // TODO if there's no assisted params, we could optimize this to just be an object?
         createNestedClass(owner, name, Keys.AssistedFactoryImplClassDeclaration) {
-            for (typeParam in owner.typeParameterSymbols) {
-              typeParameter(typeParam.name, typeParam.variance, key = Keys.Default) {
-                if (typeParam.isBound) {
-                  typeParam.resolvedBounds.forEach { bound -> bound(bound.coneType) }
-                }
-              }
-            }
-
+            copyTypeParametersFrom(owner, session)
             superType(owner::constructType)
           }
           .symbol

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/DependencyGraphFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/DependencyGraphFirGenerator.kt
@@ -8,6 +8,7 @@ import dev.zacsweers.metro.compiler.fir.Keys
 import dev.zacsweers.metro.compiler.fir.abstractFunctions
 import dev.zacsweers.metro.compiler.fir.buildSimpleAnnotation
 import dev.zacsweers.metro.compiler.fir.constructType
+import dev.zacsweers.metro.compiler.fir.copyTypeParametersFrom
 import dev.zacsweers.metro.compiler.fir.hasOrigin
 import dev.zacsweers.metro.compiler.fir.isDependencyGraph
 import dev.zacsweers.metro.compiler.fir.isGraphFactory
@@ -244,13 +245,7 @@ internal class DependencyGraphFirGenerator(session: FirSession) :
         log("Generating graph class")
         createNestedClass(owner, name, Keys.MetroGraphDeclaration) {
             superType(owner::constructType)
-            for (typeParam in owner.typeParameterSymbols) {
-              typeParameter(typeParam.name, variance = typeParam.variance) {
-                for (bound in typeParam.resolvedBounds) {
-                  bound(bound.coneType)
-                }
-              }
-            }
+            copyTypeParametersFrom(owner, session)
           }
           .apply { markAsDeprecatedHidden(session) }
           .symbol

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/InjectedClassFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/InjectedClassFirGenerator.kt
@@ -11,6 +11,7 @@ import dev.zacsweers.metro.compiler.fir.buildSimpleAnnotation
 import dev.zacsweers.metro.compiler.fir.callableDeclarations
 import dev.zacsweers.metro.compiler.fir.classIds
 import dev.zacsweers.metro.compiler.fir.constructType
+import dev.zacsweers.metro.compiler.fir.copyTypeParametersFrom
 import dev.zacsweers.metro.compiler.fir.findInjectConstructors
 import dev.zacsweers.metro.compiler.fir.hasOrigin
 import dev.zacsweers.metro.compiler.fir.isAnnotatedInject
@@ -409,14 +410,7 @@ internal class InjectedClassFirGenerator(session: FirSession) :
             Keys.InjectConstructorFactoryClassDeclaration,
             classKind = classKind,
           ) {
-            // TODO what about backward-referencing type params?
-            injectedClass.classSymbol.typeParameterSymbols.forEach { typeParameter ->
-              typeParameter(typeParameter.name, typeParameter.variance, key = Keys.Default) {
-                if (typeParameter.isBound) {
-                  typeParameter.resolvedBounds.forEach { bound -> bound(bound.coneType) }
-                }
-              }
-            }
+            copyTypeParametersFrom(injectedClass.classSymbol, session)
 
             if (!injectedClass.isAssisted) {
               superType { typeParameterRefs ->
@@ -435,14 +429,7 @@ internal class InjectedClassFirGenerator(session: FirSession) :
         val injectedClass = membersInjectorClassIdsToInjectedClass[classId] ?: return null
 
         createNestedClass(owner, name.capitalizeUS(), Keys.MembersInjectorClassDeclaration) {
-            // TODO what about backward-referencing type params?
-            injectedClass.classSymbol.typeParameterSymbols.forEach { typeParameter ->
-              typeParameter(typeParameter.name, typeParameter.variance, key = Keys.Default) {
-                if (typeParameter.isBound) {
-                  typeParameter.resolvedBounds.forEach { bound -> bound(bound.coneType) }
-                }
-              }
-            }
+            copyTypeParametersFrom(injectedClass.classSymbol, session)
 
             superType { typeParameterRefs ->
               Symbols.ClassIds.MembersInjector.constructClassLikeType(
@@ -737,13 +724,7 @@ internal class InjectedClassFirGenerator(session: FirSession) :
                 returnType = session.builtinTypes.unitType.coneType,
               ) {
                 // Add any type args if necessary
-                injectedClass.classSymbol.typeParameterSymbols.forEach { typeParameter ->
-                  typeParameter(typeParameter.name, typeParameter.variance, key = Keys.Default) {
-                    if (typeParameter.isBound) {
-                      typeParameter.resolvedBounds.forEach { bound -> bound(bound.coneType) }
-                    }
-                  }
-                }
+                copyTypeParametersFrom(injectedClass.classSymbol, session)
 
                 // Add instance param
                 valueParameter(

--- a/samples/integration-tests/src/commonTest/kotlin/dev/zacsweers/metro/test/integration/DependencyGraphProcessingTest.kt
+++ b/samples/integration-tests/src/commonTest/kotlin/dev/zacsweers/metro/test/integration/DependencyGraphProcessingTest.kt
@@ -28,6 +28,7 @@ import kotlin.reflect.KClass
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -1179,6 +1180,39 @@ class DependencyGraphProcessingTest {
         fun create(intValue: Int): ExampleClass
       }
     }
+  }
+
+  // Regression test for https://github.com/ZacSweers/metro/issues/312
+  @Test
+  fun `where clauses work`() {
+    val graph = createGraph<WhereClausesGraph>()
+    assertNotNull(graph.manager)
+  }
+
+  @Inject
+  class LocationAvailabilityManager<F> where F : CharSequence
+
+  @DependencyGraph
+  interface WhereClausesGraph {
+    val manager: LocationAvailabilityManager<String>
+
+    @Provides fun provideString(): String = "Hello"
+  }
+
+  // Regression test for https://github.com/ZacSweers/metro/issues/498
+  @Test
+  fun `type parameter with bounds`() {
+    val graph = createGraph<TypeParameterBoundsGraph>()
+    assertNotNull(graph.example)
+  }
+
+  @Inject class ExampleWithBoundTypeParameter<T : Any>
+
+  @DependencyGraph
+  interface TypeParameterBoundsGraph {
+    val example: ExampleWithBoundTypeParameter<String>
+
+    @Provides fun provideString(): String = "Hello"
   }
 
   enum class Seasoning {


### PR DESCRIPTION
These aren't actually necessary for our needs (matches how kotlinx-serialization handles it). It'd be nice for maximum correctness but they are often not resolved at the times we look nor is there a way to check if they are resolved without try/catching reading them.

So... we're just not going to generate bounds for now. This resolves #312 and resolves #498 as a result 🥳 