### PR TITLE
ContributesBinding: Fix implicit bound type resolution

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -397,8 +397,13 @@ internal class ContributedInterfaceSupertypeGenerator(session: FirSession) :
     return if (fir.resolveState.resolvePhase == FirResolvePhase.RAW_FIR) {
         // When processing bindings in the same module or compilation, we need to handle supertypes
         // that have not been resolved yet
-        (this as FirClassSymbol<*>).fir.superTypeRefs.map {
-          typeResolver.resolveUserType(it as FirUserTypeRef).coneType
+        (this as FirClassSymbol<*>).fir.superTypeRefs.map { superTypeRef ->
+          if (superTypeRef is FirUserTypeRef) {
+              typeResolver.resolveUserType(superTypeRef)
+            } else {
+              superTypeRef
+            }
+            .coneType
         }
       } else {
         (this as FirClassSymbol<*>).resolvedSuperTypes


### PR DESCRIPTION
Ran into an issue related to implicit bound type during migration. In my case, when running `:feature:impl:assemble`, `ContributedInterface` was already resolved so the type here is `FirResolvedTypeRef` instead of `FirUserTypeRef`.

```kotlin
// live in :feature:api module
interface ContributedInterface
```

```kotlin
// live in :feature:impl module
@Inject
@ContributesBinding(AppScope::class)
class ExampleClass : ContributedInterface
```