### PR TITLE
Revert "Avoid intermediate sorts (#483)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 - **Fix:** Support generic graph factory interfaces.
 - **Fix:** In the presence of multiple contributing annotations to the same scope, ensure only hint function/file is generated.
 - **Fix:** Improve shading to avoid packaging in stdlib and other dependency classes.
+- **Fix:** Revert "Improve graph validation performance by avoiding unnecessary intermediate sorts." as it broke some cases I haven't been able to debug yet.
 
 0.3.4
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 - **Fix:** Support generic graph factory interfaces.
 - **Fix:** In the presence of multiple contributing annotations to the same scope, ensure only hint function/file is generated.
 - **Fix:** Improve shading to avoid packaging in stdlib and other dependency classes.
-- **Fix:** Revert "Improve graph validation performance by avoiding unnecessary intermediate sorts." as it broke some cases I haven't been able to debug yet.
+- **Fix:** Revert [#483](https://github.com/ZacSweers/metro/pull/483) as it broke some cases we haven't been able to debug yet.
 
 0.3.4
 -----

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
@@ -19,8 +19,6 @@ package dev.zacsweers.metro.compiler.graph
 import dev.zacsweers.metro.compiler.tracing.Tracer
 import dev.zacsweers.metro.compiler.tracing.traceNested
 import java.util.PriorityQueue
-import java.util.TreeMap
-import java.util.TreeSet
 
 /**
  * Returns a new list where each element is preceded by its results in [sourceToTarget]. The first
@@ -72,19 +70,15 @@ internal fun <T> List<T>.isTopologicallySorted(sourceToTarget: (T) -> Iterable<T
   return true
 }
 
-internal fun <T : Comparable<T>> Iterable<T>.buildFullAdjacency(
+internal fun <T> Iterable<T>.buildFullAdjacency(
   sourceToTarget: (T) -> Iterable<T>,
   onMissing: (source: T, missing: T) -> Unit,
-): Map<T, Set<T>> {
+): Map<T, List<T>> {
   val set = toSet()
-  /**
-   * Sort our map keys and list values here for better performance later (avoiding needing to
-   * defensively sort in [computeStronglyConnectedComponents]).
-   */
-  val adjacency = TreeMap<T, TreeSet<T>>()
+  val adjacency = mutableMapOf<T, MutableList<T>>()
 
   for (key in set) {
-    val dependencies = adjacency.getOrPut(key, ::TreeSet)
+    val dependencies = adjacency.getOrPut(key, ::mutableListOf)
 
     for (targetKey in sourceToTarget(key)) {
       if (targetKey !in set) {
@@ -96,7 +90,6 @@ internal fun <T : Comparable<T>> Iterable<T>.buildFullAdjacency(
       dependencies += targetKey
     }
   }
-
   return adjacency
 }
 
@@ -105,11 +98,11 @@ internal fun <T : Comparable<T>> Iterable<T>.buildFullAdjacency(
  * * Keeps all edges (strict _and_ deferrable).
  * * Prunes edges whose target isn't in [bindings], delegating the decision to [onMissing].
  */
-internal fun <TypeKey : Comparable<TypeKey>, Binding> buildFullAdjacency(
+internal fun <TypeKey, Binding> buildFullAdjacency(
   bindings: Map<TypeKey, Binding>,
   dependenciesOf: (Binding) -> Iterable<TypeKey>,
   onMissing: (source: TypeKey, missing: TypeKey) -> Unit,
-): Map<TypeKey, Set<TypeKey>> {
+): Map<TypeKey, List<TypeKey>> {
   return bindings.keys.buildFullAdjacency(
     sourceToTarget = { key -> dependenciesOf(bindings.getValue(key)) },
     onMissing = onMissing,
@@ -160,7 +153,7 @@ internal data class TopoSortResult<T>(val sortedKeys: List<T>, val deferredTypes
  * @param onCycle called with the offending cycle if no deferrable edge
  */
 internal fun <V : Comparable<V>> topologicalSort(
-  fullAdjacency: Map<V, Set<V>>,
+  fullAdjacency: Map<V, List<V>>,
   isDeferrable: (from: V, to: V) -> Boolean,
   onCycle: (List<V>) -> Nothing,
   parentTracer: Tracer = Tracer.NONE,
@@ -238,11 +231,8 @@ internal data class Component<V>(val id: Int, val vertices: MutableList<V> = mut
 /**
  * Computes the strongly connected components (SCCs) of a directed graph using Tarjan's algorithm.
  *
- * NOTE: For performance and determinism, this implementation assumes [this] adjacency is already
- * sorted (both keys and each set of values).
- *
  * @param this A map representing the directed graph where the keys are vertices of type [V] and the
- *   values are sets of vertices to which each key vertex has outgoing edges.
+ *   values are lists of vertices to which each key vertex has outgoing edges.
  * @return A pair where the first element is a list of components (each containing an ID and its
  *   associated vertices) and the second element is a map that associates each vertex with the ID of
  *   its component.
@@ -250,7 +240,7 @@ internal data class Component<V>(val id: Int, val vertices: MutableList<V> = mut
  *   href="https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm">Tarjan's
  *   algorithm</a>
  */
-internal fun <V> Map<V, Set<V>>.computeStronglyConnectedComponents():
+internal fun <V : Comparable<V>> Map<V, List<V>>.computeStronglyConnectedComponents():
   Pair<List<Component<V>>, Map<V, Int>> {
   var nextIndex = 0
   var nextComponentId = 0
@@ -279,7 +269,7 @@ internal fun <V> Map<V, Set<V>>.computeStronglyConnectedComponents():
     stack += v
     onStack += v
 
-    for (w in this[v].orEmpty()) {
+    for (w in this[v].orEmpty().sorted()) {
       if (w !in indexMap) {
         // Successor w has not yet been visited; recurse on it
         strongConnect(w)
@@ -310,7 +300,7 @@ internal fun <V> Map<V, Set<V>>.computeStronglyConnectedComponents():
   }
 
   // Sorted for determinism
-  for (v in keys) {
+  for (v in keys.sorted()) {
     if (v !in indexMap) {
       strongConnect(v)
     }
@@ -333,7 +323,7 @@ internal fun <V> Map<V, Set<V>>.computeStronglyConnectedComponents():
  *   SCCs it depends on.
  */
 private fun <V> buildComponentDag(
-  originalEdges: Map<V, Set<V>>,
+  originalEdges: Map<V, List<V>>,
   componentOf: Map<V, Int>,
 ): Map<Int, Set<Int>> {
   val dag = mutableMapOf<Int, MutableSet<Int>>()

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/SccTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/SccTest.kt
@@ -10,7 +10,7 @@ class SccTest {
 
   @Test
   fun singleNodeNoEdges() {
-    val graph = mapOf<Int, Set<Int>>()
+    val graph = mapOf<Int, List<Int>>()
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(0, components.size)
@@ -19,7 +19,7 @@ class SccTest {
 
   @Test
   fun singleNodeSelfLoop() {
-    val graph = mapOf(1 to setOf(1))
+    val graph = mapOf(1 to listOf(1))
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(1, components.size)
@@ -29,7 +29,7 @@ class SccTest {
 
   @Test
   fun multipleDisconnectedNodes() {
-    val graph = mapOf(1 to emptySet<Int>(), 2 to emptySet(), 3 to emptySet())
+    val graph = mapOf(1 to emptyList<Int>(), 2 to emptyList(), 3 to emptyList())
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(3, components.size)
@@ -41,7 +41,7 @@ class SccTest {
 
   @Test
   fun simpleGraph() {
-    val graph = mapOf(1 to setOf(2), 2 to setOf(3), 3 to setOf(1))
+    val graph = mapOf(1 to listOf(2), 2 to listOf(3), 3 to listOf(1))
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(1, components.size)
@@ -55,12 +55,12 @@ class SccTest {
   fun multipleComponents() {
     val graph =
       mapOf(
-        1 to setOf(2),
-        2 to setOf(1),
-        3 to setOf(4),
-        4 to setOf(5),
-        5 to setOf(3),
-        6 to emptySet(),
+        1 to listOf(2),
+        2 to listOf(1),
+        3 to listOf(4),
+        4 to listOf(5),
+        5 to listOf(3),
+        6 to emptyList(),
       )
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
@@ -79,7 +79,7 @@ class SccTest {
 
   @Test
   fun graphWithMultipleSelfLoops() {
-    val graph = mapOf(1 to setOf(1), 2 to setOf(2), 3 to setOf(4), 4 to setOf(3))
+    val graph = mapOf(1 to listOf(1), 2 to listOf(2), 3 to listOf(4), 4 to listOf(3))
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(3, components.size)
@@ -95,7 +95,7 @@ class SccTest {
 
   @Test
   fun throwsOnInvalidGraph() {
-    val graph = mapOf(1 to setOf(2))
+    val graph = mapOf(1 to listOf(2))
 
     assertFailsWith<NoSuchElementException> {
       graph.computeStronglyConnectedComponents()

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/TopologicalSortTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/TopologicalSortTest.kt
@@ -201,8 +201,8 @@ class TopologicalSortTest {
   fun verticesInsideComponentComeOutInNaturalOrder() {
     val full =
       mapOf(
-        "a" to setOf("b"), // deferrable
-        "b" to setOf("a"), // strict
+        "a" to listOf("b"), // deferrable
+        "b" to listOf("a"), // strict
       )
     val isDeferrable = { f: String, t: String -> f == "a" && t == "b" }
 

--- a/metrow
+++ b/metrow
@@ -53,15 +53,15 @@ case "$1" in
 
    "format")
        echo "Applying formatting..."
-       ./gradlew spotlessApply
-       ./gradlew -p samples spotlessApply
+       ./gradlew spotlessApply --no-configuration-cache
+       ./gradlew -p samples spotlessApply --no-configuration-cache
        ;;
 
    "regen")
        echo "Applying formatting and API gen..."
        # Annoyingly, the apiDump task has some caching issues
-       ./gradlew spotlessApply apiDump kotlinUpgradeYarnLock --rerun-tasks --no-build-cache
-       ./gradlew -p samples spotlessApply kotlinUpgradeYarnLock
+       ./gradlew spotlessApply apiDump kotlinUpgradeYarnLock --rerun-tasks --no-build-cache --no-configuration-cache
+       ./gradlew -p samples spotlessApply kotlinUpgradeYarnLock --no-configuration-cache
        ;;
 
    *)


### PR DESCRIPTION
This reverts commit 877e177. Resolves #513. Will revisit after more debugging, but fortunately it was already fast before