### PR TITLE
Deterministic IrType.render + sorted sets/maps again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 **Unreleased**
 --------------
 
+- **Enhancement:** Improve graph validation performance by avoiding unnecessary intermediate sorts (again).
 - [internal] Make internal renderings of `IrType` more deterministic.
 
 0.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 --------------
 
 - **Enhancement:** Improve graph validation performance by avoiding unnecessary intermediate sorts (again).
+- **Fix:** Support constructing nested function return types for provider functions.
 - [internal] Make internal renderings of `IrType` more deterministic.
 
 0.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- [internal] Make internal renderings of `IrType` more deterministic.
+
 0.3.5
 -----
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ProvidesFactoryFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ProvidesFactoryFirGenerator.kt
@@ -420,6 +420,7 @@ internal class ProvidesFactorySupertypeGenerator(session: FirSession) :
     return when (this) {
       is FirUserTypeRef ->
         typeResolver.resolveUserType(this).takeUnless { it is FirErrorTypeRef }?.coneType
+      is FirFunctionTypeRef -> createFunctionType(this, typeResolver)
       else -> coneTypeOrNull
     }
   }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
@@ -7,6 +7,7 @@ import dev.zacsweers.metro.compiler.ir.appendBindingStackEntries
 import dev.zacsweers.metro.compiler.ir.withEntry
 import dev.zacsweers.metro.compiler.tracing.Tracer
 import dev.zacsweers.metro.compiler.tracing.traceNested
+import java.util.SortedMap
 import java.util.SortedSet
 
 internal interface BindingGraph<
@@ -208,7 +209,7 @@ internal open class MutableBindingGraph<
 
   private fun sortAndValidate(
     roots: Map<ContextualTypeKey, BindingStackEntry>,
-    fullAdjacency: Map<TypeKey, SortedSet<TypeKey>>,
+    fullAdjacency: SortedMap<TypeKey, SortedSet<TypeKey>>,
     stack: BindingStack,
     parentTracer: Tracer,
   ): TopoSortResult<TypeKey> {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
@@ -7,6 +7,7 @@ import dev.zacsweers.metro.compiler.ir.appendBindingStackEntries
 import dev.zacsweers.metro.compiler.ir.withEntry
 import dev.zacsweers.metro.compiler.tracing.Tracer
 import dev.zacsweers.metro.compiler.tracing.traceNested
+import java.util.SortedSet
 
 internal interface BindingGraph<
   Type : Any,
@@ -87,7 +88,7 @@ internal open class MutableBindingGraph<
         Binding,
         BindingStack,
         roots: Map<ContextualTypeKey, BindingStackEntry>,
-        adjacency: Map<TypeKey, List<TypeKey>>,
+        adjacency: Map<TypeKey, Set<TypeKey>>,
       ) -> Unit =
       { binding, stack, roots, adjacency -> /* noop */
       },
@@ -207,7 +208,7 @@ internal open class MutableBindingGraph<
 
   private fun sortAndValidate(
     roots: Map<ContextualTypeKey, BindingStackEntry>,
-    fullAdjacency: Map<TypeKey, List<TypeKey>>,
+    fullAdjacency: Map<TypeKey, SortedSet<TypeKey>>,
     stack: BindingStack,
     parentTracer: Tracer,
   ): TopoSortResult<TypeKey> {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
@@ -80,23 +80,30 @@ internal open class MutableBindingGraph<
    *
    * Calls [onError] if a strict dependency cycle or missing binding is encountered during
    * validation.
+   *
+   * @param onPopulated a callback for when the graph is fully populated but not yet validated.
+   * @param validateBinding a callback to perform optional extra validation on a given binding in
+   *   context.
    */
   fun seal(
     roots: Map<ContextualTypeKey, BindingStackEntry> = emptyMap(),
     tracer: Tracer = Tracer.NONE,
+    onPopulated: () -> Unit = {},
     validateBinding:
       (
-        Binding,
-        BindingStack,
+        binding: Binding,
+        stack: BindingStack,
         roots: Map<ContextualTypeKey, BindingStackEntry>,
         adjacency: Map<TypeKey, Set<TypeKey>>,
       ) -> Unit =
-      { binding, stack, roots, adjacency -> /* noop */
+      { _, _, _, _ -> /* noop */
       },
   ): TopoSortResult<TypeKey> {
     val stack = newBindingStack()
 
     val missingBindings = populateGraph(roots, stack, tracer)
+
+    onPopulated()
 
     sealed = true
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
@@ -19,6 +19,7 @@ package dev.zacsweers.metro.compiler.graph
 import dev.zacsweers.metro.compiler.tracing.Tracer
 import dev.zacsweers.metro.compiler.tracing.traceNested
 import java.util.PriorityQueue
+import java.util.SortedSet
 
 /**
  * Returns a new list where each element is preceded by its results in [sourceToTarget]. The first
@@ -70,15 +71,19 @@ internal fun <T> List<T>.isTopologicallySorted(sourceToTarget: (T) -> Iterable<T
   return true
 }
 
-internal fun <T> Iterable<T>.buildFullAdjacency(
+internal fun <T : Comparable<T>> Iterable<T>.buildFullAdjacency(
   sourceToTarget: (T) -> Iterable<T>,
   onMissing: (source: T, missing: T) -> Unit,
-): Map<T, List<T>> {
+): Map<T, SortedSet<T>> {
   val set = toSet()
-  val adjacency = mutableMapOf<T, MutableList<T>>()
+  /**
+   * Sort our map keys and list values here for better performance later (avoiding needing to
+   * defensively sort in [computeStronglyConnectedComponents]).
+   */
+  val adjacency = mutableMapOf<T, SortedSet<T>>()
 
   for (key in set) {
-    val dependencies = adjacency.getOrPut(key, ::mutableListOf)
+    val dependencies = adjacency.getOrPut(key, ::sortedSetOf)
 
     for (targetKey in sourceToTarget(key)) {
       if (targetKey !in set) {
@@ -102,7 +107,7 @@ internal fun <TypeKey : Comparable<TypeKey>, Binding> buildFullAdjacency(
   bindings: Map<TypeKey, Binding>,
   dependenciesOf: (Binding) -> Iterable<TypeKey>,
   onMissing: (source: TypeKey, missing: TypeKey) -> Unit,
-): Map<TypeKey, List<TypeKey>> {
+): Map<TypeKey, SortedSet<TypeKey>> {
   return bindings.keys.buildFullAdjacency(
     sourceToTarget = { key -> dependenciesOf(bindings.getValue(key)) },
     onMissing = onMissing,
@@ -153,7 +158,7 @@ internal data class TopoSortResult<T>(val sortedKeys: List<T>, val deferredTypes
  * @param onCycle called with the offending cycle if no deferrable edge
  */
 internal fun <V : Comparable<V>> topologicalSort(
-  fullAdjacency: Map<V, List<V>>,
+  fullAdjacency: Map<V, SortedSet<V>>,
   isDeferrable: (from: V, to: V) -> Boolean,
   onCycle: (List<V>) -> Nothing,
   parentTracer: Tracer = Tracer.NONE,
@@ -226,13 +231,17 @@ internal fun <V : Comparable<V>> topologicalSort(
   )
 }
 
+// TODO can this move to a set of vertices
 internal data class Component<V>(val id: Int, val vertices: MutableList<V> = mutableListOf())
 
 /**
  * Computes the strongly connected components (SCCs) of a directed graph using Tarjan's algorithm.
  *
+ * NOTE: For performance and determinism, this implementation assumes [this] adjacency is already
+ * sorted (both keys and each set of values).
+ *
  * @param this A map representing the directed graph where the keys are vertices of type [V] and the
- *   values are lists of vertices to which each key vertex has outgoing edges.
+ *   values are sets of vertices to which each key vertex has outgoing edges.
  * @return A pair where the first element is a list of components (each containing an ID and its
  *   associated vertices) and the second element is a map that associates each vertex with the ID of
  *   its component.
@@ -240,7 +249,7 @@ internal data class Component<V>(val id: Int, val vertices: MutableList<V> = mut
  *   href="https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm">Tarjan's
  *   algorithm</a>
  */
-internal fun <V : Comparable<V>> Map<V, List<V>>.computeStronglyConnectedComponents():
+internal fun <V : Comparable<V>> Map<V, SortedSet<V>>.computeStronglyConnectedComponents():
   Pair<List<Component<V>>, Map<V, Int>> {
   var nextIndex = 0
   var nextComponentId = 0
@@ -269,7 +278,7 @@ internal fun <V : Comparable<V>> Map<V, List<V>>.computeStronglyConnectedCompone
     stack += v
     onStack += v
 
-    for (w in this[v].orEmpty().sorted()) {
+    for (w in this[v].orEmpty()) {
       if (w !in indexMap) {
         // Successor w has not yet been visited; recurse on it
         strongConnect(w)
@@ -323,7 +332,7 @@ internal fun <V : Comparable<V>> Map<V, List<V>>.computeStronglyConnectedCompone
  *   SCCs it depends on.
  */
 private fun <V> buildComponentDag(
-  originalEdges: Map<V, List<V>>,
+  originalEdges: Map<V, Set<V>>,
   componentOf: Map<V, Int>,
 ): Map<Int, Set<Int>> {
   val dag = mutableMapOf<Int, MutableSet<Int>>()

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/topologicalSort.kt
@@ -231,7 +231,6 @@ internal fun <V : Comparable<V>> topologicalSort(
   )
 }
 
-// TODO can this move to a set of vertices
 internal data class Component<V>(val id: Int, val vertices: MutableList<V> = mutableListOf())
 
 /**

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrAnnotation.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrAnnotation.kt
@@ -52,7 +52,21 @@ private fun StringBuilder.renderAsAnnotation(irAnnotation: IrConstructorCall, sh
       ?.let { if (short) it.name.asString() else it.kotlinFqName.asString() } ?: "<unbound>"
   append(annotationClassName)
 
-  // TODO type args not supported
+  if (irAnnotation.typeArguments.isNotEmpty()) {
+    appendIterableWith(
+      0 until irAnnotation.typeArguments.size,
+      separator = ", ",
+      prefix = "<",
+      postfix = ">",
+    ) { index ->
+      val typeArg = irAnnotation.typeArguments[index]
+      if (typeArg == null) {
+        append("null")
+      } else {
+        typeArg.renderTo(this, short = short)
+      }
+    }
+  }
 
   if (irAnnotation.arguments.isEmpty()) return
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindingGraph.kt
@@ -164,14 +164,23 @@ internal class IrBindingGraph(
   fun validate(parentTracer: Tracer, onError: (List<GraphError>) -> Nothing): BindingGraphResult {
     val (sortedKeys, deferredTypes) =
       parentTracer.traceNested("seal graph") { tracer ->
-        realGraph.seal(accessors, tracer, validateBinding = ::checkScope)
+        realGraph.seal(
+          roots = accessors,
+          tracer = tracer,
+          onPopulated = {
+            metroContext.writeDiagnostic("keys-populated-${parentTracer.tag}.txt") {
+              realGraph.bindings.keys.sorted().joinToString("\n")
+            }
+          },
+          validateBinding = ::checkScope,
+        )
       }
 
-    metroContext.writeDiagnostic("validatedKeys-${parentTracer.tag}.txt") {
-      buildString { sortedKeys.joinTo(this, separator = "\n") { it.render(short = false) } }
+    metroContext.writeDiagnostic("keys-validated-${parentTracer.tag}.txt") {
+      sortedKeys.joinToString(separator = "\n")
     }
-    metroContext.writeDiagnostic("deferredTypes-${parentTracer.tag}.txt") {
-      buildString { deferredTypes.joinTo(this, separator = "\n") { it.render(short = false) } }
+    metroContext.writeDiagnostic("keys-deferred-${parentTracer.tag}.txt") {
+      deferredTypes.joinToString(separator = "\n")
     }
 
     parentTracer.traceNested("check empty multibindings") { checkEmptyMultibindings(onError) }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindingGraph.kt
@@ -371,7 +371,7 @@ internal class IrBindingGraph(
     binding: Binding,
     stack: IrBindingStack,
     roots: Map<IrContextualTypeKey, IrBindingStack.Entry>,
-    adjacency: Map<IrTypeKey, List<IrTypeKey>>,
+    adjacency: Map<IrTypeKey, Set<IrTypeKey>>,
   ) {
     val bindingScope = binding.scope
     if (bindingScope != null) {
@@ -434,7 +434,7 @@ internal class IrBindingGraph(
   private fun buildRouteToRoot(
     key: IrTypeKey,
     roots: Map<IrContextualTypeKey, IrBindingStack.Entry>,
-    adjacency: Map<IrTypeKey, List<IrTypeKey>>,
+    adjacency: Map<IrTypeKey, Set<IrTypeKey>>,
   ): List<IrBindingStack.Entry> {
     // Build who depends on what
     val dependents = mutableMapOf<IrTypeKey, MutableSet<IrTypeKey>>()

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContextualTypeKey.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContextualTypeKey.kt
@@ -7,16 +7,10 @@ import dev.zacsweers.metro.compiler.expectAs
 import dev.zacsweers.metro.compiler.graph.BaseContextualTypeKey
 import dev.zacsweers.metro.compiler.graph.WrappedType
 import dev.zacsweers.metro.compiler.ir.parameters.wrapInProvider
-import org.jetbrains.kotlin.backend.jvm.JvmSymbols
-import org.jetbrains.kotlin.backend.jvm.codegen.AnnotationCodegen.Companion.annotationClass
-import org.jetbrains.kotlin.backend.jvm.ir.isWithFlexibleNullability
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.isClassWithFqName
-import org.jetbrains.kotlin.ir.types.makeNotNull
-import org.jetbrains.kotlin.ir.types.removeAnnotations
 import org.jetbrains.kotlin.ir.types.typeOrFail
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.classId
@@ -243,15 +237,5 @@ private fun IrSimpleType.asWrappedType(context: IrMetroContext): WrappedType<IrT
   }
 
   // If it's not a special type, it's a canonical type
-  val adjustedType =
-    if (isWithFlexibleNullability()) {
-      // Java types may be "Flexible" nullable types, assume not null here
-      makeNotNull().removeAnnotations {
-        it.annotationClass.isClassWithFqName(JvmSymbols.FLEXIBLE_NULLABILITY_ANNOTATION_FQ_NAME)
-      }
-    } else {
-      this
-    }
-
-  return WrappedType.Canonical(adjustedType)
+  return WrappedType.Canonical(canonicalize())
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContextualTypeKey.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContextualTypeKey.kt
@@ -13,11 +13,8 @@ import org.jetbrains.kotlin.backend.jvm.ir.isWithFlexibleNullability
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.types.IrSimpleType
-import org.jetbrains.kotlin.ir.types.IrStarProjection
 import org.jetbrains.kotlin.ir.types.IrType
-import org.jetbrains.kotlin.ir.types.IrTypeProjection
 import org.jetbrains.kotlin.ir.types.isClassWithFqName
-import org.jetbrains.kotlin.ir.types.isMarkedNullable
 import org.jetbrains.kotlin.ir.types.makeNotNull
 import org.jetbrains.kotlin.ir.types.removeAnnotations
 import org.jetbrains.kotlin.ir.types.typeOrFail
@@ -47,11 +44,7 @@ internal class IrContextualTypeKey(
         if (type == typeKey.type) {
           typeKey.render(short, includeQualifier)
         } else {
-          if (short) {
-            type.renderShort()
-          } else {
-            type.render()
-          }
+          type.render(short)
         }
       }
     )
@@ -261,24 +254,4 @@ private fun IrSimpleType.asWrappedType(context: IrMetroContext): WrappedType<IrT
     }
 
   return WrappedType.Canonical(adjustedType)
-}
-
-private fun IrType.renderShort(): String = buildString {
-  append(simpleName)
-  if (isMarkedNullable()) {
-    append("?")
-  }
-  if (this@renderShort is IrSimpleType) {
-    arguments
-      .takeUnless { it.isEmpty() }
-      ?.joinToString(", ", prefix = "<", postfix = ">") {
-        when (it) {
-          is IrStarProjection -> "*"
-          is IrTypeProjection -> {
-            it.type.renderShort()
-          }
-        }
-      }
-      ?.let { append(it) }
-  }
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrGraphGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrGraphGenerator.kt
@@ -300,7 +300,7 @@ internal class IrGraphGenerator(
                             it
                           }
                         }
-                        .let(::IrTypeKey)
+                        .let(IrTypeKey.Companion::invoke)
                     irExprBody(
                       irInvoke(
                         dispatchReceiver =

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrTypeKey.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrTypeKey.kt
@@ -12,7 +12,8 @@ import org.jetbrains.kotlin.ir.types.typeOrFail
 
 // TODO cache these in DependencyGraphTransformer or shared transformer data
 @Poko
-internal class IrTypeKey(override val type: IrType, override val qualifier: IrAnnotation? = null) :
+internal class IrTypeKey
+private constructor(override val type: IrType, override val qualifier: IrAnnotation?) :
   BaseTypeKey<IrType, IrAnnotation, IrTypeKey> {
 
   private val cachedRender by unsafeLazy { render(short = false, includeQualifier = true) }
@@ -36,6 +37,13 @@ internal class IrTypeKey(override val type: IrType, override val qualifier: IrAn
       }
     }
     type.renderTo(this, short)
+  }
+
+  companion object {
+    operator fun invoke(type: IrType, qualifier: IrAnnotation? = null): IrTypeKey {
+      // Canonicalize on the way through
+      return IrTypeKey(type.canonicalize(), qualifier)
+    }
   }
 }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrTypeKey.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrTypeKey.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.ir.util.render
 internal class IrTypeKey(override val type: IrType, override val qualifier: IrAnnotation? = null) :
   BaseTypeKey<IrType, IrAnnotation, IrTypeKey> {
 
-  private val cachedRender by unsafeLazy { render(short = false, includeQualifier = true) }
+  private val cachedRender by unsafeLazy { render(short = true, includeQualifier = true) }
 
   override fun copy(type: IrType, qualifier: IrAnnotation?): IrTypeKey {
     return IrTypeKey(type, qualifier)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrTypeKey.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrTypeKey.kt
@@ -28,7 +28,7 @@ internal class IrTypeKey(override val type: IrType, override val qualifier: IrAn
 
   override fun compareTo(other: IrTypeKey): Int {
     if (this == other) return 0
-    return cachedRender.compareTo(other.cachedRender)
+    return COMPARATOR.compare(this, other)
   }
 
   override fun render(short: Boolean, includeQualifier: Boolean): String = buildString {
@@ -60,6 +60,12 @@ internal class IrTypeKey(override val type: IrType, override val qualifier: IrAn
         }
         ?.let { append(it) }
     }
+  }
+
+  private companion object {
+    private val COMPARATOR = compareBy<IrTypeKey> { it.cachedRender }
+      .thenBy { it.type.hashCode() }
+      .thenBy { it.qualifier?.hashCode() ?: 0 }
   }
 }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrTypeKey.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrTypeKey.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.ir.util.render
 internal class IrTypeKey(override val type: IrType, override val qualifier: IrAnnotation? = null) :
   BaseTypeKey<IrType, IrAnnotation, IrTypeKey> {
 
-  private val cachedRender by unsafeLazy { render(short = true, includeQualifier = true) }
+  private val cachedRender by unsafeLazy { render(short = false, includeQualifier = true) }
 
   override fun copy(type: IrType, qualifier: IrAnnotation?): IrTypeKey {
     return IrTypeKey(type, qualifier)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -78,13 +78,19 @@ import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrScriptSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.symbols.IrTypeParameterSymbol
+import org.jetbrains.kotlin.ir.types.IrDynamicType
+import org.jetbrains.kotlin.ir.types.IrErrorType
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.IrStarProjection
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.IrTypeArgument
+import org.jetbrains.kotlin.ir.types.IrTypeProjection
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.classifierOrFail
 import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.createType
 import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.types.isMarkedNullable
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.classId
@@ -107,6 +113,7 @@ import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.types.Variance
 
 /** Finds the line and column of [this] within its file. */
 internal fun IrDeclaration.location(): CompilerMessageSourceLocation {
@@ -705,20 +712,73 @@ internal fun IrFunction.buildBlockBody(
   body = context.createIrBuilder(symbol).irBlockBody(body = blockBody)
 }
 
-internal val IrType.simpleName: String
-  get() =
-    when (val classifier = classifierOrNull) {
-      is IrClassSymbol -> {
-        classifier.owner.name.asString()
-      }
+internal fun IrType.render(short: Boolean, includeAnnotations: Boolean = false): String {
+  return StringBuilder().also { renderTo(it, short, includeAnnotations) }.toString()
+}
 
-      is IrScriptSymbol -> error("No simple name for script symbol: ${dumpKotlinLike()}")
-      is IrTypeParameterSymbol -> {
-        classifier.owner.name.asString()
-      }
-
-      null -> error("No classifier for ${dumpKotlinLike()}")
+internal fun IrType.renderTo(
+  appendable: Appendable,
+  short: Boolean,
+  includeAnnotations: Boolean = false,
+) {
+  val type = this
+  if (includeAnnotations && type.annotations.isNotEmpty()) {
+    type.annotations.joinTo(appendable, separator = " ", postfix = " ") {
+      IrAnnotation(it).render(short)
     }
+  }
+  when (type) {
+    is IrDynamicType -> appendable.append("dynamic")
+    is IrErrorType -> {
+      // TODO IrErrorType.symbol?
+      appendable.append("<error>")
+    }
+    is IrSimpleType -> {
+      val name =
+        when (val classifier = type.classifier) {
+          is IrClassSymbol ->
+            if (short) {
+              classifier.owner.name.asString()
+            } else {
+              classifier.owner.kotlinFqName.asString()
+            }
+          is IrScriptSymbol -> error("No simple name for script symbol: ${type.dumpKotlinLike()}")
+          is IrTypeParameterSymbol -> {
+            classifier.owner.name.asString()
+          }
+        }
+      appendable.append(name)
+      if (type.arguments.isNotEmpty()) {
+        var first = true
+        appendable.append('<')
+        for (typeArg in type.arguments) {
+          if (first) {
+            first = false
+          } else {
+            appendable.append(", ")
+          }
+          when (typeArg) {
+            is IrStarProjection -> appendable.append("*")
+            is IrTypeProjection -> {
+              when (typeArg.variance) {
+                Variance.INVARIANT -> {
+                  // do nothing
+                }
+                Variance.IN_VARIANCE -> appendable.append("in ")
+                Variance.OUT_VARIANCE -> appendable.append("out ")
+              }
+              typeArg.type.renderTo(appendable, short)
+            }
+          }
+        }
+        appendable.append('>')
+      }
+    }
+  }
+  if (type.isMarkedNullable()) {
+    appendable.append("?")
+  }
+}
 
 internal val IrProperty.allAnnotations: List<IrConstructorCall>
   get() {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.ir.createExtensionReceiver
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.backend.jvm.ir.isWithFlexibleNullability
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocationWithRange
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
@@ -91,6 +92,8 @@ import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.createType
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.isMarkedNullable
+import org.jetbrains.kotlin.ir.types.makeNotNull
+import org.jetbrains.kotlin.ir.types.removeAnnotations
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.SYNTHETIC_OFFSET
 import org.jetbrains.kotlin.ir.util.classId
@@ -778,6 +781,21 @@ internal fun IrType.renderTo(
   if (type.isMarkedNullable()) {
     appendable.append("?")
   }
+}
+
+/**
+ * Canonicalizes an [IrType].
+ * - If it's seen as a flexible nullable type from java, assume not null here
+ * - Remove annotations
+ */
+internal fun IrType.canonicalize(): IrType {
+  return if (type.isWithFlexibleNullability()) {
+      // Java types may be "Flexible" nullable types, assume not null here
+      type.makeNotNull()
+    } else {
+      type
+    }
+    .removeAnnotations()
 }
 
 internal val IrProperty.allAnnotations: List<IrConstructorCall>

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraphTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraphTest.kt
@@ -352,7 +352,7 @@ private fun newStringBindingGraph(
 ): StringGraph {
   return StringGraph(
     newBindingStack = { StringBindingStack(graph) },
-    newBindingStackEntry = { contextKey, binding, roots -> StringBindingStack.Entry(contextKey) },
+    newBindingStackEntry = { contextKey, _, _ -> StringBindingStack.Entry(contextKey) },
     computeBinding = computeBinding,
   )
 }

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/SccTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/SccTest.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.compiler.graph
 
+import dev.zacsweers.metro.compiler.graph.computeStronglyConnectedComponents
 import java.util.SortedSet
 import java.util.TreeSet
 import kotlin.test.Test
@@ -12,7 +13,7 @@ class SccTest {
 
   @Test
   fun singleNodeNoEdges() {
-    val graph = mapOf<Int, SortedSet<Int>>()
+    val graph = sortedMapOf<Int, SortedSet<Int>>()
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(0, components.size)
@@ -21,7 +22,7 @@ class SccTest {
 
   @Test
   fun singleNodeSelfLoop() {
-    val graph = mapOf(1 to sortedSetOf(1))
+    val graph = sortedMapOf(1 to untypedSortedSetOf(1))
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(1, components.size)
@@ -31,7 +32,7 @@ class SccTest {
 
   @Test
   fun multipleDisconnectedNodes() {
-    val graph = mapOf(1 to TreeSet<Int>(), 2 to TreeSet(), 3 to TreeSet())
+    val graph = sortedMapOf(1 to untypedSortedSetOf<Int>(), 2 to untypedSortedSetOf(), 3 to untypedSortedSetOf())
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(3, components.size)
@@ -43,7 +44,7 @@ class SccTest {
 
   @Test
   fun simpleGraph() {
-    val graph = mapOf(1 to sortedSetOf(2), 2 to sortedSetOf(3), 3 to sortedSetOf(1))
+    val graph = sortedMapOf(1 to untypedSortedSetOf(2), 2 to untypedSortedSetOf(3), 3 to untypedSortedSetOf(1))
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(1, components.size)
@@ -56,13 +57,13 @@ class SccTest {
   @Test
   fun multipleComponents() {
     val graph =
-      mapOf(
-        1 to sortedSetOf(2),
-        2 to sortedSetOf(1),
-        3 to sortedSetOf(4),
-        4 to sortedSetOf(5),
-        5 to sortedSetOf(3),
-        6 to sortedSetOf(),
+      sortedMapOf(
+        1 to untypedSortedSetOf(2),
+        2 to untypedSortedSetOf(1),
+        3 to untypedSortedSetOf(4),
+        4 to untypedSortedSetOf(5),
+        5 to untypedSortedSetOf(3),
+        6 to untypedSortedSetOf(),
       )
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
@@ -81,7 +82,7 @@ class SccTest {
 
   @Test
   fun graphWithMultipleSelfLoops() {
-    val graph = mapOf(1 to sortedSetOf(1), 2 to sortedSetOf(2), 3 to sortedSetOf(4), 4 to sortedSetOf(3))
+    val graph = sortedMapOf(1 to untypedSortedSetOf(1), 2 to untypedSortedSetOf(2), 3 to untypedSortedSetOf(4), 4 to untypedSortedSetOf(3))
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(3, components.size)
@@ -97,11 +98,15 @@ class SccTest {
 
   @Test
   fun throwsOnInvalidGraph() {
-    val graph = mapOf(1 to sortedSetOf(2))
+    val graph = sortedMapOf(1 to untypedSortedSetOf(2))
 
     assertFailsWith<NoSuchElementException> {
       graph.computeStronglyConnectedComponents()
       graph.getValue(2)
     }
+  }
+
+  private fun <T : Comparable<T>> untypedSortedSetOf(vararg elements: T): SortedSet<T> {
+    return elements.toSortedSet()
   }
 }

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/SccTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/SccTest.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.compiler.graph
 
+import java.util.SortedSet
+import java.util.TreeSet
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -10,7 +12,7 @@ class SccTest {
 
   @Test
   fun singleNodeNoEdges() {
-    val graph = mapOf<Int, List<Int>>()
+    val graph = mapOf<Int, SortedSet<Int>>()
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(0, components.size)
@@ -19,7 +21,7 @@ class SccTest {
 
   @Test
   fun singleNodeSelfLoop() {
-    val graph = mapOf(1 to listOf(1))
+    val graph = mapOf(1 to sortedSetOf(1))
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(1, components.size)
@@ -29,7 +31,7 @@ class SccTest {
 
   @Test
   fun multipleDisconnectedNodes() {
-    val graph = mapOf(1 to emptyList<Int>(), 2 to emptyList(), 3 to emptyList())
+    val graph = mapOf(1 to TreeSet<Int>(), 2 to TreeSet(), 3 to TreeSet())
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(3, components.size)
@@ -41,7 +43,7 @@ class SccTest {
 
   @Test
   fun simpleGraph() {
-    val graph = mapOf(1 to listOf(2), 2 to listOf(3), 3 to listOf(1))
+    val graph = mapOf(1 to sortedSetOf(2), 2 to sortedSetOf(3), 3 to sortedSetOf(1))
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(1, components.size)
@@ -55,12 +57,12 @@ class SccTest {
   fun multipleComponents() {
     val graph =
       mapOf(
-        1 to listOf(2),
-        2 to listOf(1),
-        3 to listOf(4),
-        4 to listOf(5),
-        5 to listOf(3),
-        6 to emptyList(),
+        1 to sortedSetOf(2),
+        2 to sortedSetOf(1),
+        3 to sortedSetOf(4),
+        4 to sortedSetOf(5),
+        5 to sortedSetOf(3),
+        6 to sortedSetOf(),
       )
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
@@ -79,7 +81,7 @@ class SccTest {
 
   @Test
   fun graphWithMultipleSelfLoops() {
-    val graph = mapOf(1 to listOf(1), 2 to listOf(2), 3 to listOf(4), 4 to listOf(3))
+    val graph = mapOf(1 to sortedSetOf(1), 2 to sortedSetOf(2), 3 to sortedSetOf(4), 4 to sortedSetOf(3))
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(3, components.size)
@@ -95,7 +97,7 @@ class SccTest {
 
   @Test
   fun throwsOnInvalidGraph() {
-    val graph = mapOf(1 to listOf(2))
+    val graph = mapOf(1 to sortedSetOf(2))
 
     assertFailsWith<NoSuchElementException> {
       graph.computeStronglyConnectedComponents()

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/SccTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/SccTest.kt
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.compiler.graph
 
-import dev.zacsweers.metro.compiler.graph.computeStronglyConnectedComponents
 import java.util.SortedSet
-import java.util.TreeSet
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -32,7 +30,12 @@ class SccTest {
 
   @Test
   fun multipleDisconnectedNodes() {
-    val graph = sortedMapOf(1 to untypedSortedSetOf<Int>(), 2 to untypedSortedSetOf(), 3 to untypedSortedSetOf())
+    val graph =
+      sortedMapOf(
+        1 to untypedSortedSetOf<Int>(),
+        2 to untypedSortedSetOf(),
+        3 to untypedSortedSetOf(),
+      )
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(3, components.size)
@@ -44,7 +47,12 @@ class SccTest {
 
   @Test
   fun simpleGraph() {
-    val graph = sortedMapOf(1 to untypedSortedSetOf(2), 2 to untypedSortedSetOf(3), 3 to untypedSortedSetOf(1))
+    val graph =
+      sortedMapOf(
+        1 to untypedSortedSetOf(2),
+        2 to untypedSortedSetOf(3),
+        3 to untypedSortedSetOf(1),
+      )
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(1, components.size)
@@ -82,7 +90,13 @@ class SccTest {
 
   @Test
   fun graphWithMultipleSelfLoops() {
-    val graph = sortedMapOf(1 to untypedSortedSetOf(1), 2 to untypedSortedSetOf(2), 3 to untypedSortedSetOf(4), 4 to untypedSortedSetOf(3))
+    val graph =
+      sortedMapOf(
+        1 to untypedSortedSetOf(1),
+        2 to untypedSortedSetOf(2),
+        3 to untypedSortedSetOf(4),
+        4 to untypedSortedSetOf(3),
+      )
     val (components, componentOf) = graph.computeStronglyConnectedComponents()
 
     assertEquals(3, components.size)

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/TopologicalSortTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/TopologicalSortTest.kt
@@ -17,6 +17,7 @@
 package dev.zacsweers.metro.compiler.graph
 
 import com.google.common.truth.Truth.assertThat
+import java.util.SortedSet
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -200,9 +201,9 @@ class TopologicalSortTest {
   @Test
   fun verticesInsideComponentComeOutInNaturalOrder() {
     val full =
-      mapOf(
-        "a" to sortedSetOf("b"), // deferrable
-        "b" to sortedSetOf("a"), // strict
+      sortedMapOf(
+        "a" to sortedSetOf("b") as SortedSet<String>, // deferrable
+        "b" to sortedSetOf("a") as SortedSet<String>, // strict
       )
     val isDeferrable = { f: String, t: String -> f == "a" && t == "b" }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/TopologicalSortTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/graph/TopologicalSortTest.kt
@@ -201,8 +201,8 @@ class TopologicalSortTest {
   fun verticesInsideComponentComeOutInNaturalOrder() {
     val full =
       mapOf(
-        "a" to listOf("b"), // deferrable
-        "b" to listOf("a"), // strict
+        "a" to sortedSetOf("b"), // deferrable
+        "b" to sortedSetOf("a"), // strict
       )
     val isDeferrable = { f: String, t: String -> f == "a" && t == "b" }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/ir/RenderingTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/ir/RenderingTest.kt
@@ -1,0 +1,101 @@
+package dev.zacsweers.metro.compiler.ir
+
+import com.google.common.truth.Truth.assertThat
+import dev.zacsweers.metro.compiler.MetroCompilerTest
+import kotlin.io.path.readText
+import org.junit.Test
+
+class RenderingTest : MetroCompilerTest() {
+  // TODO add context parameters
+  @Test
+  fun `typekey rendering`() {
+    val reportsDir = temporaryFolder.newFolder("reports").toPath()
+    compile(
+      source(
+        """
+            @DependencyGraph(AppScope::class)
+            interface ExampleGraph {
+              @Provides val string: String get() = "Hello World!"
+              @Provides val int: Int get() = 0
+              @Provides val list: List<Int> get() = listOf(1)
+              @Provides @Named("star") val listStar: List<*> get() = emptyList<Int>()
+              @Provides val callableIn: Callable<in Number> get() = error("not called")
+              @Provides val callableOut: Callable<out CharSequence> get() = error("not called")
+              @Provides @Named("suppressed") val callableOutSuppressed: @JvmSuppressWildcards Callable<out CharSequence> get() = error("not called")
+              @Provides val set: @JvmSuppressWildcards Set<CharSequence> get() = setOf("1")
+              @Provides val map: Map<String, @JvmSuppressWildcards CharSequence> get() = mapOf("1" to "2")
+              @Provides val functionString: () -> String get() = error("not called")
+              @Provides val functionStringWithParams: (Int, String) -> String get() = error("not called")
+              @Provides val functionStringWithReceiverParams: String.(Int, String) -> String get() = error("not called")
+              @Provides val suspendFunctionStringWithReceiverParams: suspend String.(Int, String) -> String get() = error("not called")
+              @Provides val utterlyUnhinged: suspend String?.(Int?, suspend (String) -> (Unit) -> String?) -> String get() = error("not called")
+              @Provides @ForScope(AppScope::class) val qualifiedString: String get() = "Hello World!"
+              @Provides @Named("qualified") val qualifiedString2: String get() = "Hello World!"
+              @Provides @ForScope(AppScope::class) val qualifiedInt: Int get() = 0
+              @Provides @ForScope(AppScope::class) val qualifiedList: List<Int> get() = listOf(1)
+              @Provides @ForScope(AppScope::class) val qualifiedSet: @JvmSuppressWildcards Set<CharSequence> get() = setOf("1")
+              @Provides @ForScope(AppScope::class) val qualifiedMap: Map<String, @JvmSuppressWildcards CharSequence> get() = mapOf("1" to "2")
+              @Provides
+              @ComplexQualifier<String>(
+                boolean = true,
+                int = 1,
+                string = const,
+                klass = Int::class,
+                classArray = [Int::class, String::class],
+                anotherAnnotation = ForScope(AppScope::class),
+                anotherAnnotationArray = [ForScope(AppScope::class), ForScope(Unit::class)],
+              )
+              val complexQualifier: String get() = "Hello World!"
+            }
+
+            const val const = "Hello World!"
+
+            @Qualifier
+            annotation class ComplexQualifier<T>(
+              val boolean: Boolean,
+              val int: Int,
+              val string: String,
+              val klass: KClass<*>,
+              val classArray: Array<KClass<*>>,
+              val anotherAnnotation: ForScope,
+              val anotherAnnotationArray: Array<ForScope>,
+            )
+          """
+          .trimIndent(),
+        extraImports = arrayOf("kotlin.reflect.KClass"),
+      ),
+      options = metroOptions.copy(reportsDestination = reportsDir),
+    ) {
+      val keysFile = reportsDir.resolve("keys-populated-ExampleGraph.txt").readText()
+      assertThat(keysFile)
+        .isEqualTo(
+          """
+          @dev.zacsweers.metro.ForScope(dev.zacsweers.metro.AppScope::class) kotlin.Int
+          @dev.zacsweers.metro.ForScope(dev.zacsweers.metro.AppScope::class) kotlin.String
+          @dev.zacsweers.metro.ForScope(dev.zacsweers.metro.AppScope::class) kotlin.collections.List<kotlin.Int>
+          @dev.zacsweers.metro.ForScope(dev.zacsweers.metro.AppScope::class) kotlin.collections.Map<kotlin.String, kotlin.CharSequence>
+          @dev.zacsweers.metro.ForScope(dev.zacsweers.metro.AppScope::class) kotlin.collections.Set<kotlin.CharSequence>
+          @dev.zacsweers.metro.Named("qualified") kotlin.String
+          @dev.zacsweers.metro.Named("star") kotlin.collections.List<*>
+          @dev.zacsweers.metro.Named("suppressed") java.util.concurrent.Callable<out kotlin.CharSequence>
+          @test.ComplexQualifier<kotlin.String>(true, 1, "Hello World!", kotlin.Int::class, [kotlin.Int::class, kotlin.String::class], dev.zacsweers.metro.ForScope(dev.zacsweers.metro.AppScope::class), [dev.zacsweers.metro.ForScope(dev.zacsweers.metro.AppScope::class), dev.zacsweers.metro.ForScope(kotlin.Unit::class)]) kotlin.String
+          java.util.concurrent.Callable<in kotlin.Number>
+          java.util.concurrent.Callable<out kotlin.CharSequence>
+          kotlin.Function0<kotlin.String>
+          kotlin.Function2<kotlin.Int, kotlin.String, kotlin.String>
+          kotlin.Function3<kotlin.String, kotlin.Int, kotlin.String, kotlin.String>
+          kotlin.Int
+          kotlin.String
+          kotlin.collections.List<kotlin.Int>
+          kotlin.collections.Map<kotlin.String, kotlin.CharSequence>
+          kotlin.collections.Set<kotlin.CharSequence>
+          kotlin.coroutines.SuspendFunction3<kotlin.String, kotlin.Int, kotlin.String, kotlin.String>
+          kotlin.coroutines.SuspendFunction3<kotlin.String?, kotlin.Int?, kotlin.coroutines.SuspendFunction1<kotlin.String, kotlin.Function1<kotlin.Unit, kotlin.String?>>, kotlin.String>
+          test.ExampleGraph
+          test.ExampleGraph.$${'$'}MetroGraph
+        """
+            .trimIndent()
+        )
+    }
+  }
+}

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/ir/RenderingTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/ir/RenderingTest.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2025 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.compiler.ir
 
 import com.google.common.truth.Truth.assertThat


### PR DESCRIPTION
This PR attempts to unrevert #515 and also improve (Contextual)IrTypeKey rendering by using a single, deterministic render. The hope is that the latter resolves the issues with the former