### PR TITLE
Failing test for injecting constructor parameters with generics

### DIFF
--- a/compiler-tests/src/test/data/box/inject/InjectedConstructorParametersWithGenericsWork.kt
+++ b/compiler-tests/src/test/data/box/inject/InjectedConstructorParametersWithGenericsWork.kt
@@ -1,0 +1,20 @@
+class ExampleClass<T> @Inject constructor(
+  val value: T,
+  val values: List<T>
+)
+
+@DependencyGraph
+interface AppGraph {
+  val exampleClass: ExampleClass<Int>
+
+  @Provides fun provideInt(): Int = 3
+  @Provides fun provideInts(): List<Int> = listOf(3)
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  val exampleClass = graph.exampleClass
+  assertEquals(exampleClass.value, 3)
+  assertEquals(exampleClass.values, listOf(3))
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -154,6 +154,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     public void testInjectedFunctionParametersWithLambdaDefaultsWork() {
       runTest("compiler-tests/src/test/data/box/inject/InjectedFunctionParametersWithLambdaDefaultsWork.kt");
     }
+
+    @Test
+    @TestMetadata("InjectedConstructorParametersWithGenericsWork.kt")
+    public void testInjectedConstructorParametersWithGenericsWork() {
+      runTest("compiler-tests/src/test/data/box/inject/InjectedConstructorParametersWithGenericsWork.kt");
+    }
   }
 
   @Nested


### PR DESCRIPTION
Ran into another generic issue with constructor injection while migrating from Dagger