### PR TITLE
Fix static inject function calls in IC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- **Fix:** Record lookups of generated static member inject functions for IC.
+
 0.3.6
 -----
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrGraphGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrGraphGenerator.kt
@@ -765,6 +765,8 @@ internal class IrGraphGenerator(
               val generatedInjector =
                 membersInjectorTransformer.getOrGenerateInjector(clazz) ?: continue
               for ((function, parameters) in generatedInjector.injectFunctions) {
+                // Record for IC
+                trackFunctionCall(this@apply, function)
                 +irInvoke(
                   dispatchReceiver = irGetObject(function.parentAsClass.symbol),
                   callee = function.symbol,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectConstructorTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectConstructorTransformer.kt
@@ -24,6 +24,7 @@ import dev.zacsweers.metro.compiler.ir.parametersAsProviderArguments
 import dev.zacsweers.metro.compiler.ir.regularParameters
 import dev.zacsweers.metro.compiler.ir.requireSimpleFunction
 import dev.zacsweers.metro.compiler.ir.thisReceiverOrFail
+import dev.zacsweers.metro.compiler.ir.trackFunctionCall
 import dev.zacsweers.metro.compiler.ir.typeAsProviderArgument
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.ir.builders.IrBuilderWithScope
@@ -283,6 +284,8 @@ internal class InjectConstructorTransformer(
           val instance = irTemporary(newInstance)
           for (injector in injectors) {
             for ((function, parameters) in injector.injectFunctions) {
+              // Record for IC
+              trackFunctionCall(invokeFunction, function)
               +irInvoke(
                 dispatchReceiver = irGetObject(function.parentAsClass.symbol),
                 callee = function.symbol,

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
@@ -859,4 +859,85 @@ class ICTests : BaseIncrementalCompilationTest() {
         "ContributedInterface.kt:9:11 DependencyGraph declarations may not extend declarations with narrower visibility. Contributed supertype 'test.ContributedInterfaceImpl' is internal but graph declaration 'test.ExampleGraph' is public."
       )
   }
+
+  @Test
+  fun fieldWrappedWithLazyIsDetected() {
+    val fixture =
+      object : MetroProject() {
+        override fun sources() = listOf(exampleGraph, exampleClass, main)
+
+        private val exampleGraph =
+          source(
+            """
+          @DependencyGraph
+          interface ExampleGraph {
+            fun inject(exampleClass: ExampleClass)
+
+            @Provides fun provideString(): String = "Hello, world!"
+          }
+            """
+              .trimIndent()
+          )
+
+        val exampleClass =
+          source(
+            """
+          class ExampleClass {
+            @Inject lateinit var string: String
+          }
+          """
+              .trimIndent()
+          )
+
+        val main =
+          source(
+            """
+            fun main(): String {
+              val graph = createGraph<ExampleGraph>()
+              val exampleClass = ExampleClass()
+              graph.inject(exampleClass)
+              return exampleClass.string
+            }
+            """
+              .trimIndent()
+          )
+      }
+    val project = fixture.gradleProject
+
+    fun buildAndAssertOutput() {
+      val firstBuildResult = build(project.rootDir, "compileKotlin")
+      assertThat(firstBuildResult.task(":compileKotlin")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+      val mainClass = project.classLoader().loadClass("test.MainKt")
+      val string = mainClass.declaredMethods.first { it.name == "main" }.invoke(null) as String
+      assertThat(string).isEqualTo("Hello, world!")
+    }
+
+    buildAndAssertOutput()
+
+    project.modify(
+      fixture.exampleClass,
+      """
+      class ExampleClass {
+        @Inject lateinit var string: Lazy<String>
+      }
+      """
+        .trimIndent(),
+    )
+
+    project.modify(
+      fixture.main,
+      """
+      fun main(): String {
+        val graph = createGraph<ExampleGraph>()
+        val exampleClass = ExampleClass()
+        graph.inject(exampleClass)
+        return exampleClass.string.value
+      }
+      """
+        .trimIndent(),
+    )
+
+    buildAndAssertOutput()
+  }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
@@ -905,8 +905,8 @@ class ICTests : BaseIncrementalCompilationTest() {
     val project = fixture.gradleProject
 
     fun buildAndAssertOutput() {
-      val firstBuildResult = build(project.rootDir, "compileKotlin")
-      assertThat(firstBuildResult.task(":compileKotlin")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+      val buildResult = build(project.rootDir, "compileKotlin")
+      assertThat(buildResult.task(":compileKotlin")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
       val mainClass = project.classLoader().loadClass("test.MainKt")
       val string = mainClass.declaredMethods.first { it.name == "main" }.invoke(null) as String


### PR DESCRIPTION
I ran into a runtime crash today related to IC, if I wrap a field with Lazy, looks like the change is not picked up, and it crashes on runtime with `NoSuchMethodError`. Managed to make a test failing successfully 🙏 

```
'void test.ExampleClass$$$MetroMembersInjector$Companion.injectString(test.ExampleClass, java.lang.String)'
java.lang.NoSuchMethodError: 'void test.ExampleClass$$$MetroMembersInjector$Companion.injectString(test.ExampleClass, java.lang.String)'
	at test.ExampleGraph$$$MetroGraph.inject(ExampleGraph.kt:6)
	at test.MainKt.main(Main.kt:9)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at dev.zacsweers.metro.gradle.incremental.ICTests.fieldWrappedWithLazyIsDetected$buildAndAssertOutput(ICTests.kt:912)
	at dev.zacsweers.metro.gradle.incremental.ICTests.fieldWrappedWithLazyIsDetected(ICTests.kt:941)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
```