### PR TITLE
Failing test: Includes a deep inherited interface results in duplicated bindings

### DIFF
--- a/compiler-tests/src/test/data/box/dependencygraph/IncludesDeepInheritedInterfacesWork.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/IncludesDeepInheritedInterfacesWork.kt
@@ -1,0 +1,28 @@
+@DependencyGraph
+interface ExampleGraph {
+  val int: Int
+
+  @DependencyGraph.Factory
+  interface Factory {
+    fun create(@Includes serviceProvider: FinalServiceProvider): ExampleGraph
+  }
+}
+
+@ContributesTo(AppScope::class)
+interface FinalServiceProvider : ScreenServiceProvider
+
+interface ScreenServiceProvider : ChildServiceProvider
+
+interface ChildServiceProvider {
+  val int: Int
+}
+
+fun box(): String {
+  val graphFactory = createGraphFactory<ExampleGraph.Factory>()
+  val serviceProvider = object : FinalServiceProvider {
+    override val int: Int get() = 3
+  }
+  val graph = graphFactory.create(serviceProvider)
+  assertEquals(graph.int, 3)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -138,6 +138,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     public void testOverrideCompatibleBindingAccessors() {
       runTest("compiler-tests/src/test/data/box/dependencygraph/OverrideCompatibleBindingAccessors.kt");
     }
+
+    @Test
+    @TestMetadata("IncludesDeepInheritedInterfacesWork.kt")
+    public void testIncludesDeepInheritedInterfacesWork() {
+      runTest("compiler-tests/src/test/data/box/dependencygraph/IncludesDeepInheritedInterfacesWork.kt");
+    }
   }
 
   @Nested

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
@@ -244,7 +244,7 @@ internal class DependencyGraphTransformer(
                   getterSymbol != null && getterSymbol !in seenSymbols
                 },
               )
-              .onEach { seenSymbols += it.ir.overriddenSymbols }
+              .onEach { seenSymbols += it.ir.overriddenSymbolsSequence() }
           }
         }
 


### PR DESCRIPTION
Found an issue that was introduced during https://github.com/ZacSweers/metro/pull/547

The test failed with duplicated bindings:

```
file:///Users/kevin/Documents/metro/compiler-tests/src/test/data/box/dependencygraph/IncludesDeepInheritedInterfacesWork.kt:3:1: error: [Metro/DuplicateBinding] Duplicate binding for kotlin.Int
├─ Binding 1: file:///IncludesDeepInheritedInterfacesWork.kt:13:1 
├─ Binding 2: file:///IncludesDeepInheritedInterfacesWork.kt:19:3 
```