### PR TITLE
Handle absent bindings during graph population

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Changelog
 **Unreleased**
 --------------
 
-- Remove `Any` constraint from `binding<T>()`, allowing bindings to satisfy nullable variants.
-- Report the original location of declarations in fake overrides in error reporting.
+- **Enhancement:** Remove `Any` constraint from `binding<T>()`, allowing bindings to satisfy nullable variants.
+- **Fix:** Report the original location of declarations in fake overrides in error reporting.
+- **Fix:** Handle default values on provides parameters with absent bindings during graph population.
 
 0.4.0
 -----

--- a/compiler-tests/src/test/data/box/inject/member/CustomMembersInjectorInstancesCanSatisfyBindings.kt
+++ b/compiler-tests/src/test/data/box/inject/member/CustomMembersInjectorInstancesCanSatisfyBindings.kt
@@ -1,0 +1,26 @@
+// Repro https://github.com/ZacSweers/metro/issues/659
+class ClassWithoutMembersInjector
+
+class NoOpMembersInjector<T : Any> : MembersInjector<T> {
+  override fun injectMembers(instance: T) {
+  }
+}
+
+@DependencyGraph(AppScope::class)
+interface TestGraph {
+
+  val injector: MembersInjector<*>
+
+  @Provides
+  fun provideNoOpMembersInjector(
+    instance: MembersInjector<ClassWithoutMembersInjector> = NoOpMembersInjector<ClassWithoutMembersInjector>()
+  ): MembersInjector<*> {
+    return instance
+  }
+}
+
+fun box(): String {
+  val graph = createGraph<TestGraph>()
+  assertTrue(graph.injector is NoOpMembersInjector<*>)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/inject/member/CustomMembersInjectorInstancesIntoMap.kt
+++ b/compiler-tests/src/test/data/box/inject/member/CustomMembersInjectorInstancesIntoMap.kt
@@ -1,0 +1,35 @@
+// https://github.com/ZacSweers/metro/issues/659
+import kotlin.reflect.KClass
+
+class ClassWithoutMembersInjector
+
+class NoOpMembersInjector<T : Any> : MembersInjector<T> {
+  override fun injectMembers(instance: T) {
+  }
+}
+
+@ContributesTo(AppScope::class)
+interface Contribution {
+
+  @Provides
+  @IntoMap
+  @ClassKey(ClassWithoutMembersInjector::class)
+  fun provideClassWithoutMembersInjector(
+    instance: MembersInjector<ClassWithoutMembersInjector> = NoOpMembersInjector<ClassWithoutMembersInjector>()
+  ): MembersInjector<*> {
+    return instance
+  }
+}
+
+@DependencyGraph(AppScope::class)
+interface TestGraph {
+
+  @Multibinds
+  val membersInjectors: Map<KClass<*>, MembersInjector<*>>
+}
+
+fun box(): String {
+  val graph = createGraph<TestGraph>()
+  assertTrue(graph.membersInjectors.size == 1)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/provides/ProvidesParametersCanHaveDefaults.kt
+++ b/compiler-tests/src/test/data/box/provides/ProvidesParametersCanHaveDefaults.kt
@@ -1,0 +1,26 @@
+// Repro https://github.com/ZacSweers/metro/issues/659
+class ClassWithoutMembersInjector
+
+class NoOpMembersInjector<T : Any> : MembersInjector<T> {
+  override fun injectMembers(instance: T) {
+  }
+}
+
+@DependencyGraph(AppScope::class)
+interface TestGraph {
+
+  val injector: MembersInjector<*>
+
+  @Provides
+  fun provideNoOpMembersInjector(
+    instance: MembersInjector<ClassWithoutMembersInjector> = NoOpMembersInjector<ClassWithoutMembersInjector>()
+  ): MembersInjector<*> {
+    return instance
+  }
+}
+
+fun box(): String {
+  val graph = createGraph<TestGraph>()
+  assertTrue(graph.injector is NoOpMembersInjector<*>)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/diagnostic/ir/MembersInjectorParameterWithNoDefaultShouldError.fir.ir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/ir/MembersInjectorParameterWithNoDefaultShouldError.fir.ir.diag.txt
@@ -1,0 +1,9 @@
+/MembersInjectorParameterWithNoDefaultShouldError.kt:(320,374): error: [Metro/MissingBinding] Cannot find an @Inject constructor or @Provides-annotated function/property for: dev.zacsweers.metro.MembersInjector<ClassWithoutMembersInjector>
+
+    dev.zacsweers.metro.MembersInjector<ClassWithoutMembersInjector> is injected at
+        [TestGraph] TestGraph#provideGenericMembersInjector(…, instance)
+    dev.zacsweers.metro.MembersInjector<*> is requested at
+        [TestGraph] TestGraph#injector
+
+Similar bindings:
+  - MembersInjector<*> (Supertype). Type: Provided. Source: MembersInjectorParameterWithNoDefaultShouldError.kt:10:3

--- a/compiler-tests/src/test/data/diagnostic/ir/MembersInjectorParameterWithNoDefaultShouldError.kt
+++ b/compiler-tests/src/test/data/diagnostic/ir/MembersInjectorParameterWithNoDefaultShouldError.kt
@@ -9,7 +9,7 @@ interface TestGraph {
   @Provides
   fun provideGenericMembersInjector(
     // No default value, we should report this missing
-    instance: MembersInjector<ClassWithoutMembersInjector>
+    <!METRO_ERROR!>instance: MembersInjector<ClassWithoutMembersInjector><!>
   ): MembersInjector<*> {
     return instance
   }

--- a/compiler-tests/src/test/data/diagnostic/ir/MembersInjectorParameterWithNoDefaultShouldError.kt
+++ b/compiler-tests/src/test/data/diagnostic/ir/MembersInjectorParameterWithNoDefaultShouldError.kt
@@ -1,0 +1,16 @@
+// Repro https://github.com/ZacSweers/metro/issues/659
+class ClassWithoutMembersInjector
+
+@DependencyGraph(AppScope::class)
+interface TestGraph {
+
+  val injector: MembersInjector<*>
+
+  @Provides
+  fun provideGenericMembersInjector(
+    // No default value, we should report this missing
+    instance: MembersInjector<ClassWithoutMembersInjector>
+  ): MembersInjector<*> {
+    return instance
+  }
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -223,6 +223,18 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("CustomMembersInjectorInstancesCanSatisfyBindings.kt")
+      public void testCustomMembersInjectorInstancesCanSatisfyBindings() {
+        runTest("compiler-tests/src/test/data/box/inject/member/CustomMembersInjectorInstancesCanSatisfyBindings.kt");
+      }
+
+      @Test
+      @TestMetadata("CustomMembersInjectorInstancesIntoMap.kt")
+      public void testCustomMembersInjectorInstancesIntoMap() {
+        runTest("compiler-tests/src/test/data/box/inject/member/CustomMembersInjectorInstancesIntoMap.kt");
+      }
+
+      @Test
       @TestMetadata("GenericMemberInjection.kt")
       public void testGenericMemberInjection() {
         runTest("compiler-tests/src/test/data/box/inject/member/GenericMemberInjection.kt");
@@ -361,6 +373,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     @TestMetadata("ExplicitlyPrivateProviderAnnotationsArePropagated.kt")
     public void testExplicitlyPrivateProviderAnnotationsArePropagated() {
       runTest("compiler-tests/src/test/data/box/provides/ExplicitlyPrivateProviderAnnotationsArePropagated.kt");
+    }
+
+    @Test
+    @TestMetadata("ProvidesParametersCanHaveDefaults.kt")
+    public void testProvidesParametersCanHaveDefaults() {
+      runTest("compiler-tests/src/test/data/box/provides/ProvidesParametersCanHaveDefaults.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrDiagnosticTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrDiagnosticTestGenerated.java
@@ -23,6 +23,12 @@ public class IrDiagnosticTestGenerated extends AbstractIrDiagnosticTest {
   }
 
   @Test
+  @TestMetadata("MembersInjectorParameterWithNoDefaultShouldError.kt")
+  public void testMembersInjectorParameterWithNoDefaultShouldError() {
+    runTest("compiler-tests/src/test/data/diagnostic/ir/MembersInjectorParameterWithNoDefaultShouldError.kt");
+  }
+
+  @Test
   @TestMetadata("MissingMemberInjectionShouldFailBinding1.kt")
   public void testMissingMemberInjectionShouldFailBinding1() {
     runTest("compiler-tests/src/test/data/diagnostic/ir/MissingMemberInjectionShouldFailBinding1.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
@@ -216,6 +216,8 @@ internal open class MutableBindingGraph<
                 for (binding in bindings) {
                   bindingQueue.addLast(binding)
                 }
+              } else if (depKey.hasDefault) {
+                // Do nothing here, it has a default value and missing is ok
               } else {
                 missingBindings[typeKey] = stack.copy()
               }


### PR DESCRIPTION
Resolves #659