### PR TITLE
Failing test for using javax provider in multibinding map

### DIFF
--- a/compiler-tests/src/test/data/box/interop/dagger/JavaxProviderShouldWorkInMap.kt
+++ b/compiler-tests/src/test/data/box/interop/dagger/JavaxProviderShouldWorkInMap.kt
@@ -1,0 +1,24 @@
+// WITH_DAGGER
+import javax.inject.Provider
+
+@DependencyGraph(AppScope::class)
+interface AppGraph {
+  val urlHandlers: Map<String, Provider<UrlHandler>>
+}
+
+interface UrlHandler
+
+@Inject
+@ContributesIntoMap(AppScope::class)
+@StringKey("post")
+class PostUrlHandler : UrlHandler {
+  fun handle(url: String) {
+    url.toString()
+  }
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertNotNull(graph.urlHandlers["post"]?.get())
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -319,6 +319,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       public void testGenericDaggerFactoryClassCanBeLoaded() {
         runTest("compiler-tests/src/test/data/box/interop/dagger/GenericDaggerFactoryClassCanBeLoaded.kt");
       }
+
+      @Test
+      @TestMetadata("JavaxProviderShouldWorkInMap.kt")
+      public void testJavaxProviderShouldWorkInMap() {
+        runTest("compiler-tests/src/test/data/box/interop/dagger/JavaxProviderShouldWorkInMap.kt");
+      }
     }
   }
 


### PR DESCRIPTION
Ran into this runtime crash during migration, migrated from javax Provider to Metro's Provider helped.

```
class PostUrlHandler$$$MetroFactory cannot be cast to class javax.inject.Provider (PostUrlHandler$$$MetroFactory and javax.inject.Provider are in unnamed module of loader org.jetbrains.kotlin.codegen.GeneratedClassLoader @5fcd6080)
java.lang.ClassCastException: class PostUrlHandler$$$MetroFactory cannot be cast to class javax.inject.Provider (PostUrlHandler$$$MetroFactory and javax.inject.Provider are in unnamed module of loader org.jetbrains.kotlin.codegen.GeneratedClassLoader @5fcd6080)
	at JavaxProviderShouldWorkInMapKt.box(JavaxProviderShouldWorkInMap.kt:24)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.jetbrains.kotlin.test.backend.handlers.JvmBoxRunner.runBoxInCurrentProcess(JvmBoxRunner.kt:169)
	at org.jetbrains.kotlin.test.backend.handlers.JvmBoxRunner.callBoxMethodAndCheckResult(JvmBoxRunner.kt:140)
	at org.jetbrains.kotlin.test.backend.handlers.JvmBoxRunner.callBoxMethodAndCheckResultWithCleanup(JvmBoxRunner.kt:91)
	at org.jetbrains.kotlin.test.backend.handlers.JvmBoxRunner.processModule(JvmBoxRunner.kt:66)
	at org.jetbrains.kotlin.test.backend.handlers.JvmBoxRunner.processModule(JvmBoxRunner.kt:43)
	at org.jetbrains.kotlin.test.TestStep$HandlersStep.processModule(TestStep.kt:78)
	at org.jetbrains.kotlin.test.TestStep$HandlersStep.processModule(TestStep.kt:56)
	at org.jetbrains.kotlin.test.TestRunner.processModule(TestRunner.kt:205)
	at org.jetbrains.kotlin.test.TestRunner.hackyProcessModule(TestRunner.kt:196)
	at org.jetbrains.kotlin.test.TestRunner.processModule(TestRunner.kt:140)
	at org.jetbrains.kotlin.test.TestRunner.runTestPipeline(TestRunner.kt:91)
	at org.jetbrains.kotlin.test.TestRunner.runTestImpl(TestRunner.kt:69)
	at org.jetbrains.kotlin.test.TestRunner.runTest(TestRunner.kt:29)
	at org.jetbrains.kotlin.test.TestRunner.runTest$default(TestRunner.kt:27)
	at org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerTest.runTest(AbstractKotlinCompilerTest.kt:110)
	at dev.zacsweers.metro.compiler.BoxTestGenerated$Interop$Dagger.testJavaxProviderShouldWorkInMap(BoxTestGenerated.java:326)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1460)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2036)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:189)
```