### PR TITLE
Allow empty multibinding for Dagger's `@Multibinds` interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 - **Enhancement:** Remove `Any` constraint from `binding<T>()`, allowing bindings to satisfy nullable variants.
 - **Enhancement:** Add diagnostic to check for scoped `@Binds` declarations. These are simple pipes and should not have scope annotations.
 - **Enhancement:** Move graph dependency cycle checks to earlier in validation.
+- **Enhancement:** Allow empty multibinding for Dagger's `@Multibinds` interop.
 - **Fix:** Report the original location of declarations in fake overrides in error reporting.
 - **Fix:** Handle default values on provides parameters with absent bindings during graph population.
 - **Fix:** Don't try to read private accessors of `@Includes` parameters.

--- a/compiler-tests/src/test/data/box/interop/dagger/DaggerMultibindsAllowEmptyByDefault.kt
+++ b/compiler-tests/src/test/data/box/interop/dagger/DaggerMultibindsAllowEmptyByDefault.kt
@@ -1,0 +1,15 @@
+// WITH_DAGGER
+import dagger.multibindings.Multibinds
+
+@DependencyGraph
+interface ExampleGraph {
+  @Multibinds fun emptySet(): Set<Int>
+  @Multibinds fun emptyMap(): Map<String, Int>
+}
+
+fun box(): String {
+  val graph = createGraph<ExampleGraph>()
+  assertTrue(graph.emptySet().isEmpty())
+  assertTrue(graph.emptyMap().isEmpty())
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -337,6 +337,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("DaggerMultibindsAllowEmptyByDefault.kt")
+      public void testDaggerMultibindsAllowEmptyByDefault() {
+        runTest("compiler-tests/src/test/data/box/interop/dagger/DaggerMultibindsAllowEmptyByDefault.kt");
+      }
+
+      @Test
       @TestMetadata("GenericDaggerFactoryClassCanBeLoaded.kt")
       public void testGenericDaggerFactoryClassCanBeLoaded() {
         runTest("compiler-tests/src/test/data/box/interop/dagger/GenericDaggerFactoryClassCanBeLoaded.kt");

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroExtensionRegistrarConfigurator.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroExtensionRegistrarConfigurator.kt
@@ -148,7 +148,7 @@ class MetroExtensionRegistrarConfigurator(testServices: TestServices) :
             if (addDaggerAnnotations) {
               add(ClassId.fromString("dagger/multibindings/Multibinds"))
             }
-          }
+          },
         // TODO other dagger annotations/types not yet implemented
       )
     val classIds = ClassIds.fromOptions(options)

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroExtensionRegistrarConfigurator.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroExtensionRegistrarConfigurator.kt
@@ -143,6 +143,12 @@ class MetroExtensionRegistrarConfigurator(testServices: TestServices) :
               add(ClassId.fromString("dagger/Module"))
             }
           },
+        customMultibindsAnnotations =
+          buildSet {
+            if (addDaggerAnnotations) {
+              add(ClassId.fromString("dagger/multibindings/Multibinds"))
+            }
+          }
         // TODO other dagger annotations/types not yet implemented
       )
     val classIds = ClassIds.fromOptions(options)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/Binding.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/Binding.kt
@@ -13,8 +13,8 @@ import dev.zacsweers.metro.compiler.ir.parameters.Parameters
 import dev.zacsweers.metro.compiler.isWordPrefixRegex
 import dev.zacsweers.metro.compiler.render
 import dev.zacsweers.metro.compiler.unsafeLazy
-import org.jetbrains.kotlin.backend.jvm.ir.parentClassId
 import java.util.TreeSet
+import org.jetbrains.kotlin.backend.jvm.ir.parentClassId
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
@@ -465,18 +465,20 @@ internal sealed interface Binding : BaseBinding<IrType, IrTypeKey, IrContextualT
         multibinds: IrAnnotation,
         contextualTypeKey: IrContextualTypeKey,
       ): Multibinding {
-        val isDaggerMultibinds = multibinds.ir.symbol.owner.parentClassId?.asSingleFqName() ==
-          FqName("dagger.multibindings.Multibinds")
+        val isDaggerMultibinds =
+          multibinds.ir.symbol.owner.parentClassId?.asSingleFqName() ==
+            FqName("dagger.multibindings.Multibinds")
         return create(
           metroContext = metroContext,
           typeKey = contextualTypeKey.typeKey,
           declaration = getter.ir,
-          allowEmpty = if (isDaggerMultibinds) {
-            // Retain Dagger's behavior for interop
-            true
-          } else {
-            multibinds.ir.getSingleConstBooleanArgumentOrNull() ?: false
-          },
+          allowEmpty =
+            if (isDaggerMultibinds) {
+              // Retain Dagger's behavior for interop
+              true
+            } else {
+              multibinds.ir.getSingleConstBooleanArgumentOrNull() ?: false
+            },
         )
       }
 

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
@@ -11,7 +11,6 @@ import dagger.internal.codegen.KspComponentProcessor
 import dev.zacsweers.metro.compiler.ExampleGraph
 import dev.zacsweers.metro.compiler.MetroCompilerTest
 import dev.zacsweers.metro.compiler.MetroOptions
-import dev.zacsweers.metro.compiler.assertDiagnostics
 import dev.zacsweers.metro.compiler.assertNoWarningsOrErrors
 import dev.zacsweers.metro.compiler.callProperty
 import dev.zacsweers.metro.compiler.createGraphWithNoArgs

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/DaggerInteropTest.kt
@@ -384,16 +384,9 @@ class DaggerInteropTest : MetroCompilerTest() {
         """
           .trimIndent()
       ),
-      expectedExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
+      expectedExitCode = KotlinCompilation.ExitCode.OK,
     ) {
-      assertDiagnostics(
-        """
-          e: ExampleGraph.kt:8:41 [Metro/EmptyMultibinding] Multibinding 'kotlin.collections.Set<kotlin.Int>' was unexpectedly empty.
-
-          If you expect this multibinding to possibly be empty, annotate its declaration with `@Multibinds(allowEmpty = true)`.
-        """
-          .trimIndent()
-      )
+      assertNoWarningsOrErrors()
     }
   }
 


### PR DESCRIPTION
In metro, `Multibinds.allowEmpty` is default to false, but the behavior in Dagger is actually true, I found it during migration and needed to migrate to metro's annotation. In this PR, I made Dagger interop's value default to true to make the migration smoother.