### PR TITLE
Failing test for graph inheritance from different modules

### DIFF
--- a/compiler-tests/src/test/data/box/dependencygraph/GraphInheritanceFromDifferentModule.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/GraphInheritanceFromDifferentModule.kt
@@ -1,0 +1,18 @@
+// MODULE: lib
+@DependencyGraph(AppScope::class)
+interface ChildGraph {
+  val value: Int
+
+  @Provides
+  fun provideInt(): Int = 3
+}
+
+// MODULE: main(lib)
+@DependencyGraph(AppScope::class)
+interface ParentGraph : ChildGraph
+
+fun box(): String {
+  val graph = createGraph<ParentGraph>()
+  assertEquals(graph.value, 3)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -146,6 +146,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("GraphInheritanceFromDifferentModule.kt")
+    public void testGraphInheritanceFromDifferentModule() {
+      runTest("compiler-tests/src/test/data/box/dependencygraph/GraphInheritanceFromDifferentModule.kt");
+    }
+
+    @Test
     @TestMetadata("IncludesDeepInheritedInterfacesWork.kt")
     public void testIncludesDeepInheritedInterfacesWork() {
       runTest("compiler-tests/src/test/data/box/dependencygraph/IncludesDeepInheritedInterfacesWork.kt");


### PR DESCRIPTION
The test fails with the following error, but it passes if I put those graphs in the same module.

```
No metadata found for ChildGraph.$$MetroGraph from another module. Did you run the Metro compiler plugin on this module?
java.lang.IllegalStateException: No metadata found for ChildGraph.$$MetroGraph from another module. Did you run the Metro compiler plugin on this module?
	at dev.zacsweers.metro.compiler.ir.transformers.BindingContainerTransformer.visitClass(BindingContainerTransformer.kt:112)
	at dev.zacsweers.metro.compiler.ir.transformers.BindingContainerTransformer.factoryClassesFor(BindingContainerTransformer.kt:547)
	at dev.zacsweers.metro.compiler.ir.DependencyGraphNodeCache$DependencyGraphNodeBuilder.build(DependencyGraphNodeCache.kt:346)
	at dev.zacsweers.metro.compiler.ir.DependencyGraphNodeCache.getOrComputeDependencyGraphNode$lambda$1$lambda$0(DependencyGraphNodeCache.kt:77)
	at dev.zacsweers.metro.compiler.tracing.TracerKt.trace(Tracer.kt:86)
	at dev.zacsweers.metro.compiler.tracing.TracerKt.traceNested(Tracer.kt:79)
	at dev.zacsweers.metro.compiler.tracing.TracerKt.traceNested$default(Tracer.kt:73)
	at dev.zacsweers.metro.compiler.ir.DependencyGraphNodeCache.getOrComputeDependencyGraphNode(DependencyGraphNodeCache.kt:68)
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.transformDependencyGraph(DependencyGraphTransformer.kt:172)
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.tryTransformDependencyGraph$lambda$3(DependencyGraphTransformer.kt:152)
	at dev.zacsweers.metro.compiler.tracing.TracerKt.trace(Tracer.kt:86)
	at dev.zacsweers.metro.compiler.tracing.TracerKt.traceNested(Tracer.kt:79)
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.tryTransformDependencyGraph(DependencyGraphTransformer.kt:148)
	at dev.zacsweers.metro.compiler.ir.transformers.DependencyGraphTransformer.visitClass(DependencyGraphTransformer.kt:123)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:57)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:19)
	at org.jetbrains.kotlin.ir.declarations.IrClass.accept(IrClass.kt:72)
	at org.jetbrains.kotlin.ir.IrElementBase.transform(IrElementBase.kt:33)
	at org.jetbrains.kotlin.ir.util.TransformKt.transformInPlace(transform.kt:35)
	at org.jetbrains.kotlin.ir.declarations.IrPackageFragment.transformChildren(IrPackageFragment.kt:31)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitPackageFragment(IrElementTransformerVoid.kt:146)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:160)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:163)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:19)
	at org.jetbrains.kotlin.ir.declarations.IrFile.accept(IrFile.kt:27)
	at org.jetbrains.kotlin.ir.declarations.IrFile.transform(IrFile.kt:30)
	at org.jetbrains.kotlin.ir.declarations.IrFile.transform(IrFile.kt:19)
	at org.jetbrains.kotlin.ir.util.TransformKt.transformInPlace(transform.kt:35)
	at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.transformChildren(IrModuleFragment.kt:46)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitModuleFragment(IrElementTransformerVoid.kt:102)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitModuleFragment(IrElementTransformerVoid.kt:107)
	at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitModuleFragment(IrElementTransformerVoid.kt:19)
	at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.accept(IrModuleFragment.kt:36)
	at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.transform(IrModuleFragment.kt:39)
	at dev.zacsweers.metro.compiler.ir.MetroIrGenerationExtension.generate$lambda$3$lambda$2(MetroIrGenerationExtension.kt:58)
	at dev.zacsweers.metro.compiler.tracing.TracerKt.trace(Tracer.kt:86)
	at dev.zacsweers.metro.compiler.tracing.TracerKt.traceNested(Tracer.kt:79)
	at dev.zacsweers.metro.compiler.tracing.TracerKt.traceNested$default(Tracer.kt:73)
	at dev.zacsweers.metro.compiler.ir.MetroIrGenerationExtension.generate$lambda$3(MetroIrGenerationExtension.kt:50)
	at dev.zacsweers.metro.compiler.tracing.TracerKt.trace(Tracer.kt:86)
	at dev.zacsweers.metro.compiler.ir.MetroIrGenerationExtension.generate(MetroIrGenerationExtension.kt:37)
	at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.applyIrGenerationExtensions(convertToIr.kt:468)
	at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.runActualizationPipeline(convertToIr.kt:245)
	at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.convertToIrAndActualize(convertToIr.kt:128)
	at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize(convertToIr.kt:97)
	at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize$default(convertToIr.kt:72)
	at org.jetbrains.kotlin.cli.jvm.compiler.legacy.pipeline.JvmCompilerPipelineKt.convertToIrAndActualizeForJvm(jvmCompilerPipeline.kt:109)
	at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:26)
	at org.jetbrains.kotlin.test.frontend.fir.Fir2IrCliJvmFacade.transform(Fir2IrCliJvmFacade.kt:41)
	at org.jetbrains.kotlin.test.frontend.fir.Fir2IrCliJvmFacade.transform(Fir2IrCliJvmFacade.kt:23)
	at org.jetbrains.kotlin.test.TestStep$FacadeStep.processModule(TestStep.kt:47)
	at org.jetbrains.kotlin.test.TestRunner.processModule(TestRunner.kt:205)
	at org.jetbrains.kotlin.test.TestRunner.hackyProcessModule(TestRunner.kt:196)
	at org.jetbrains.kotlin.test.TestRunner.processModule(TestRunner.kt:140)
	at org.jetbrains.kotlin.test.TestRunner.runTestPipeline(TestRunner.kt:91)
	at org.jetbrains.kotlin.test.TestRunner.runTestImpl(TestRunner.kt:69)
	at org.jetbrains.kotlin.test.TestRunner.runTest(TestRunner.kt:29)
	at org.jetbrains.kotlin.test.TestRunner.runTest$default(TestRunner.kt:27)
	at org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerTest.runTest(AbstractKotlinCompilerTest.kt:110)
	at dev.zacsweers.metro.compiler.BoxTestGenerated$Dependencygraph.testGraphInheritanceFromDifferentModule(BoxTestGenerated.java:151)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1460)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2036)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:189)
```