### PR TITLE
Log function name for IR param size difference error

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -294,7 +294,7 @@ internal fun IrBuilderWithScope.irInvoke(
   if (finalReceiverExpression != null) argSize++
   if (extensionReceiver != null) argSize++
   check(callee.owner.parameters.size == argSize) {
-    "Expected ${callee.owner.parameters.size} arguments but got ${args.size}"
+    "Expected ${callee.owner.parameters.size} arguments but got ${args.size} for function: ${callee.owner.kotlinFqName}"
   }
 
   var index = 0


### PR DESCRIPTION
The current log message prints out the sizes, but not the problematic function.