### PR TITLE
Fix generating binding functions with names that contain -

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionBindsFunctionsIrTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionBindsFunctionsIrTransformer.kt
@@ -160,8 +160,8 @@ internal class ContributionBindsFunctionsIrTransformer(private val context: IrMe
               .joinSimpleNames(separator = "", camelCase = true)
               .shortClassName
               .let(::append)
-            qualifier?.hashCode()?.let(::append)
-            mapKey?.hashCode()?.let(::append)
+            qualifier?.hashCode()?.toUInt()?.let(::append)
+            mapKey?.hashCode()?.toUInt()?.let(::append)
           }
 
           // We need a unique name because addFakeOverrides() doesn't handle overloads with


### PR DESCRIPTION
When there's some `@ContributeIntoMap`/`@ContributeIntoSet` in the code, binding functions are generated which are built with hash codes in their names. Hash codes being `Int`s can be negative and thus the name may contain `-`. This is valid for JVM but not for iOS target (the ObjC header file will not compile with an error like `Expected ';' after method prototype`).

This is a quick fix to use unsigned ints to avoid the minus sign. I noticed that there are also usages elsewhere of `md5base64` for some symbol names which uses `Base64.getUrlEncoder()` which may also give names containing `-` - it's possible this could also be an issue elsewhere depending on how unlucky you are. I don't know enough of the code base to investigate this.

I tested this with a local build in my project where I saw the problem and it was fixed there. It might be nice for the project to have an integration test for an iOS build with some multibinds (among other things) in the future.