### PR TITLE
Fix factory class lookups in IC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changelog
 - **Fix:** Fix generating binding functions with names that contain dashes.
 - **Fix:** Treat interop'd Dagger/Anvil/KI components as implicitly extendable.
 - **Fix:** Record lookups of `@Binds` declarations for IC.
+- **Fix:** Record lookups of generated class factories and their constructor signatures for IC.
 
 0.4.0
 -----

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ClassBindingLookup.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ClassBindingLookup.kt
@@ -112,7 +112,7 @@ internal class ClassBindingLookup(
           irClass.computeMembersInjectorBindings(currentBindings, remapper)
         bindings += membersInjectBindings
 
-        bindings +=
+        val binding =
           Binding.ConstructorInjected(
             type = irClass,
             classFactory = mappedFactory,
@@ -121,6 +121,13 @@ internal class ClassBindingLookup(
             injectedMembers =
               membersInjectBindings.mapToSet { binding -> binding.contextualTypeKey },
           )
+        bindings += binding
+
+        // Record a lookup of the class in case its kind changes
+        trackClassLookup(sourceGraph, classFactory.factoryClass)
+        // Record a lookup of the signature in case its signature changes
+        // Doesn't appear to be necessary but juuuuust in case
+        trackFunctionCall(sourceGraph, classFactory.function)
       } else if (classAnnotations.isAssistedFactory) {
         val function = irClass.singleAbstractFunction(metroContext).asMemberOf(key.type)
         // Mark as wrapped for convenience in graph resolution to note that this whole node is

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ic.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ic.kt
@@ -64,6 +64,25 @@ internal fun IrMetroContext.trackFunctionCall(
   }
 }
 
+internal fun IrMetroContext.trackMemberDeclarationCall(
+  callingDeclaration: IrDeclaration,
+  containerFqName: FqName,
+  declarationName: String,
+) {
+  callingDeclaration.withAnalyzableKtFile { filePath ->
+    trackLookup(
+      container = containerFqName,
+      declarationName = declarationName,
+      scopeKind = ScopeKind.CLASSIFIER,
+      location =
+        object : LocationInfo {
+          override val filePath = filePath
+          override val position: Position = Position.NO_POSITION
+        },
+    )
+  }
+}
+
 internal fun IrMetroContext.trackLookup(
   container: FqName,
   declarationName: String,

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/BaseIncrementalCompilationTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/BaseIncrementalCompilationTest.kt
@@ -4,6 +4,7 @@ package dev.zacsweers.metro.gradle.incremental
 
 import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.Subproject
 import java.io.File
 import org.intellij.lang.annotations.Language
 
@@ -13,6 +14,17 @@ abstract class BaseIncrementalCompilationTest {
     val newSource = source.copy(content)
     val filePath = "src/main/kotlin/${newSource.path}/${newSource.name}.kt"
     rootDir.resolve(filePath).writeText(newSource.source)
+  }
+
+  protected fun Subproject.modify(
+    rootDir: File,
+    source: Source,
+    @Language("kotlin") content: String,
+  ) {
+    val newSource = source.copy(content)
+    val filePath = "src/main/kotlin/${newSource.path}/${newSource.name}.kt"
+    val projectPath = rootDir.resolve(this.name.removePrefix(":").replace(":", "/"))
+    projectPath.resolve(filePath).writeText(newSource.source)
   }
 
   protected fun modifyKotlinFile(

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
@@ -1228,12 +1228,22 @@ class ICTests : BaseIncrementalCompilationTest() {
                 withBuildScript {
                   sources = sources()
                   applyMetroDefault()
-                  dependencies(Dependency.implementation(":lib"))
+                  dependencies(
+                    Dependency.implementation(":common"),
+                    Dependency.implementation(":lib"),
+                  )
                 }
               }
-              .withSubproject("lib") {
-                sources.addAll(listOf(foo, bar))
+              .withSubproject("common") {
+                sources.add(bar)
                 withBuildScript { applyMetroDefault() }
+              }
+              .withSubproject("lib") {
+                sources.add(foo)
+                withBuildScript {
+                  applyMetroDefault()
+                  dependencies(Dependency.implementation(":common"))
+                }
               }
               .write()
 

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
@@ -1,5 +1,7 @@
 // Copyright (C) 2025 Zac Sweers
 // SPDX-License-Identifier: Apache-2.0
+@file:Suppress("UPPER_BOUND_VIOLATED_BASED_ON_JAVA_ANNOTATIONS")
+
 package dev.zacsweers.metro.gradle.incremental
 
 import com.autonomousapps.kit.GradleBuilder.build
@@ -1281,6 +1283,7 @@ class ICTests : BaseIncrementalCompilationTest() {
       }
 
     val project = fixture.gradleProject
+    val libProject = project.subprojects.first { it.name == "lib" }
 
     fun buildAndAssertOutput() {
       val buildResult = build(project.rootDir, "compileKotlin")
@@ -1294,7 +1297,8 @@ class ICTests : BaseIncrementalCompilationTest() {
     buildAndAssertOutput()
 
     // Adding a bar param to FooImpl, FooImpl.$$MetroFactory should be regenerated with member field
-    project.modify(
+    libProject.modify(
+      project.rootDir,
       fixture.foo,
       """
       interface Foo

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/MetroProject.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/MetroProject.kt
@@ -6,6 +6,7 @@ import com.autonomousapps.kit.AbstractGradleProject
 import com.autonomousapps.kit.GradleProject
 import com.autonomousapps.kit.GradleProject.DslKind
 import com.autonomousapps.kit.Source
+import com.autonomousapps.kit.gradle.BuildScript
 
 abstract class MetroProject(
   private val debug: Boolean = false,
@@ -15,38 +16,40 @@ abstract class MetroProject(
 
   open fun StringBuilder.onBuildScript() {}
 
-  val gradleProject: GradleProject
+  open val gradleProject: GradleProject
     get() =
       newGradleProjectBuilder(DslKind.KOTLIN)
         .withRootProject {
           sources = this@MetroProject.sources()
-          withBuildScript {
-            plugins(GradlePlugins.Kotlin.jvm, GradlePlugins.metro)
-
-            withKotlin(
-              buildString {
-                onBuildScript()
-
-                // Metro config
-                appendLine("metro {")
-                appendLine(
-                  """
-                  debug.set(true)
-                  reportsDestination.set(layout.buildDirectory.dir("metro"))
-                """
-                    .trimIndent()
-                )
-                val metroOptions =
-                  metroOptions.enableScopedInjectClassHints
-                    ?.let { "enableScopedInjectClassHints.set($it)" }
-                    .orEmpty()
-                if (metroOptions.isNotBlank()) {
-                  appendLine("  $metroOptions")
-                }
-                appendLine("}")
-              }
-            )
-          }
+          withBuildScript { applyMetroDefault() }
         }
         .write()
+
+  fun BuildScript.Builder.applyMetroDefault() = apply {
+    plugins(GradlePlugins.Kotlin.jvm, GradlePlugins.metro)
+
+    withKotlin(
+      buildString {
+        onBuildScript()
+
+        // Metro config
+        appendLine("metro {")
+        appendLine(
+          """
+            debug.set($debug)
+            reportsDestination.set(layout.buildDirectory.dir("metro"))
+          """
+            .trimIndent()
+        )
+        val metroOptions =
+          metroOptions.enableScopedInjectClassHints
+            ?.let { "enableScopedInjectClassHints.set($it)" }
+            .orEmpty()
+        if (metroOptions.isNotBlank()) {
+          appendLine("  $metroOptions")
+        }
+        appendLine("}")
+      }
+    )
+  }
 }


### PR DESCRIPTION
Several of my devs ran into an IC issue with metro 0.4.0. I managed to reproduce it in a test, I found a few important factors to create this issue:
1. The graph must be extendable
2. The mutator must be scoped
3. The mutator must live in a different module from the graph

Error:
```
Class test.FooImpl$$$MetroFactory does not have member field 'test.FooImpl$$$MetroFactory INSTANCE'
java.lang.NoSuchFieldError: Class test.FooImpl$$$MetroFactory does not have member field 'test.FooImpl$$$MetroFactory INSTANCE'
	at test.AppGraph$$$MetroGraph.<init>(AppGraph.kt)
	at test.AppGraph$Companion.invoke(AppGraph.kt:6)
	at test.MainKt.main(Main.kt)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at dev.zacsweers.metro.gradle.incremental.ICTests.icWorksWhenAddingAParamToExistingInjectedTypeWithScope$buildAndAssertOutput$27(ICTests.kt:1303)
	at dev.zacsweers.metro.gradle.incremental.ICTests.icWorksWhenAddingAParamToExistingInjectedTypeWithScope(ICTests.kt:1324)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```