### PR TITLE
Fail tests eagerly when compiler plugins report errors

### DIFF
--- a/compiler-tests/src/test/data/box/provides/SimpleFunctionProvider.kt
+++ b/compiler-tests/src/test/data/box/provides/SimpleFunctionProvider.kt
@@ -2,8 +2,8 @@
 interface ExampleGraph {
   val provider: Provider<String>
 
-//  @Provides
-//  fun provideValue(): String = "Hello, world!"
+  @Provides
+  fun provideValue(): String = "Hello, world!"
 }
 
 fun box(): String {

--- a/compiler-tests/src/test/data/box/provides/SimpleFunctionProvider.kt
+++ b/compiler-tests/src/test/data/box/provides/SimpleFunctionProvider.kt
@@ -2,8 +2,8 @@
 interface ExampleGraph {
   val provider: Provider<String>
 
-  @Provides
-  fun provideValue(): String = "Hello, world!"
+//  @Provides
+//  fun provideValue(): String = "Hello, world!"
 }
 
 fun box(): String {

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/AbstractBoxTest.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/AbstractBoxTest.kt
@@ -3,7 +3,9 @@
 package dev.zacsweers.metro.compiler
 
 import org.jetbrains.kotlin.config.JvmTarget
+import org.jetbrains.kotlin.test.backend.handlers.NoFir2IrCompilationErrorsHandler
 import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.builders.configureIrHandlersStep
 import org.jetbrains.kotlin.test.directives.CodegenTestDirectives.IGNORE_DEXING
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives.WITH_STDLIB
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives.FULL_JDK
@@ -30,6 +32,13 @@ open class AbstractBoxTest : AbstractFirLightTreeBlackBoxCodegenTest() {
         +WITH_STDLIB
 
         +IGNORE_DEXING // Avoids loading R8 from the classpath.
+      }
+
+      configureIrHandlersStep {
+        useHandlers(
+          // Errors in compiler plugin backend should fail test without running box function.
+          ::NoFir2IrCompilationErrorsHandler
+        )
       }
     }
   }


### PR DESCRIPTION
This avoids attempting to run box tests which are likely to fail at runtime if a compiler plugin reports errors in the backend. Tests should avoid the test runtime exception when possible and should only report the diagnostic difference.