### PR TITLE
Remove references to @Multibinding

### DIFF
--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/ContributesGraphExtensionTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/ContributesGraphExtensionTest.kt
@@ -414,7 +414,7 @@ class ContributesGraphExtensionTest : MetroCompilerTest() {
 
             @ContributesTo(AppScope::class)
             interface MultibindingsModule2 {
-              // Important for @Multibinding to be used for this test's coverage, as opposed to @ElementsIntoSet
+              // Important for @Multibinds to be used for this test's coverage, as opposed to @ElementsIntoSet
               @Multibinds(allowEmpty = true)
               fun provideMulti(): Set<@JvmSuppressWildcards MultiboundType>
             }

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -111,7 +111,7 @@ Alternatively, they can be declared with an `@Multibinds`-annotated accessor pro
 ```kotlin
 @DependencyGraph
 interface MapMultibinding {
-  @Multibinding
+  @Multibinds
   val ints: Map<Int, Int>
 }
 ```
@@ -123,7 +123,7 @@ Map multibindings support injecting *map providers*, where the value type can be
 ```kotlin
 @DependencyGraph
 interface MapMultibinding {
-  @Multibinding
+  @Multibinds
   val ints: Map<Int, Provider<Int>>
 }
 ```


### PR DESCRIPTION
Just a mall fix to remove old references to `@Multibinding`.

I noticed this wasn't correct in the docs, and did a global search in the project for `@Multibinding`
to verify only correct usages were left, which caught one usage in a test as well.

No functional changes are in this PR.

