### PR TITLE
[ADDED] Metro docs site custom 404 page support

### DIFF
--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -5,6 +5,9 @@
 # It requires Python to run.
 # Install the packages with the following command:
 # pip install mkdocs mkdocs-material mdx_truly_sane_lists
+#
+# To run the site locally with hot-reload support, use:
+# ./deploy_website.sh --local
 
 if [[ "$1" = "--local" ]]; then local=true; fi
 

--- a/docs/site-assets/overrides/404.html
+++ b/docs/site-assets/overrides/404.html
@@ -1,0 +1,18 @@
+{% extends "main.html" %}
+
+{% block content %}
+
+<!--
+Custom 404 - Not found page
+===========================
+Provides a friendly message when a user tries to access a page that doesn't exist or has moved.
+-->
+
+<h1 id="404-page-not-found">404 - Not found</h1>
+<p><strong>ℹ️ The document you're looking for doesn't exist or has been moved.</strong></p>
+
+<p style="line-height: 2;">Try using the 🔍 <a href="?q=" data-toggle="modal">search</a> feature to find the document.
+If the content can't be found, feel free to <a href="https://github.com/ZacSweers/metro/issues">report</a> the issue.</p>
+<p>Alternatively, you can return to the <a href="{{ base_url }}">🚇 Metro home</a>.</p>
+
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,9 @@ theme:
   features:
     - content.code.copy
     - content.code.select
+  # Custom dir for theme overrides (eg. custom 404 page)
+  # - https://squidfunk.github.io/mkdocs-material/customization/
+  custom_dir: 'docs/site-assets/overrides'
 
 #extra_css:
 #  - 'css/app.css'


### PR DESCRIPTION
Now contains some additional guidelines and quick link to search or home.

Related to https://github.com/ZacSweers/metro/issues/794


--- 

### Demo 📹 

https://github.com/user-attachments/assets/f3c660fd-3479-429d-84e9-19c902bfc948

---

Before this change


https://github.com/user-attachments/assets/32154f58-bf85-4b4e-b184-9dc098b1f1f8
