### PR TITLE
chrore: docs site color config cleanup

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,9 +44,7 @@ theme:
 plugins:
   # Social plugin for delightful card previews on social media
   # https://squidfunk.github.io/mkdocs-material/plugins/social/
-  - social:
-     cards_layout_options:
-       background_color: "#FFFFFF"
+  - social
 
 #extra_css:
 #  - 'css/app.css'


### PR DESCRIPTION
Removed color definition, by default it's white! 🙂


---

Example:

<img width="1200" height="630" alt="adoption" src="https://github.com/user-attachments/assets/af60e27b-9dea-4c5f-b82d-c2a47fa2480e" />

