### PR TITLE
fix: Mkdocs python requirement for build and deployment

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -18,3 +18,8 @@ repackage==0.7.3
 six==1.17.0
 termcolor==3.1.0
 tornado==6.5.1
+
+# Imaging dependencies for mkdocs-material social plugin
+# https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/
+cairosvg==2.7.1
+pillow==10.4.0


### PR DESCRIPTION
Potential fix for https://github.com/ZacSweers/metro/actions/runs/16613166178/job/47000355022

```
Run mkdocs build
ERROR   -  Required dependencies of "social" plugin not found:
- ModuleNotFoundError("No module named 'cairosvg'")
- ModuleNotFoundError("No module named 'PIL'")

--> Install with: pip install "mkdocs-material[imaging]"

Aborted with a BuildError!
Error: Process completed with exit code 1.
```



It looks like I cant just use `mkdocs-material[imaging]` in requirements

https://pypi.org/project/mkdocs-material/