### PR TITLE
IC test: Multiple binding replacements are respected when adding new binding contribution

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -31,7 +31,6 @@ import org.jetbrains.kotlin.fir.analysis.checkers.getContainingClassSymbol
 import org.jetbrains.kotlin.fir.caches.FirCache
 import org.jetbrains.kotlin.fir.caches.firCachesFactory
 import org.jetbrains.kotlin.fir.declarations.FirClassLikeDeclaration
-import org.jetbrains.kotlin.fir.declarations.FirDeclarationOrigin
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.ResolveStateAccess
 import org.jetbrains.kotlin.fir.declarations.utils.classId
@@ -329,14 +328,8 @@ internal class ContributedInterfaceSupertypeGenerator(session: FirSession) :
         val localTypeResolver =
           typeResolverFactory.create(contributingType) ?: return@flatMap emptySequence()
 
-        val annotationsToCheck =
-          if (contributingType.origin == FirDeclarationOrigin.Library) {
-            session.classIds.allContributesAnnotationsWithContainers
-          } else {
-            session.classIds.allContributesAnnotations
-          }
         contributingType
-          .annotationsIn(session, annotationsToCheck)
+          .annotationsIn(session, session.classIds.allContributesAnnotationsWithContainers)
           .filter { it.scopeArgument()?.resolveClassId(localTypeResolver) in scopes }
           .flatMap { annotation -> annotation.resolvedReplacedClassIds(localTypeResolver) }
       }

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
@@ -1434,4 +1434,128 @@ class ICTests : BaseIncrementalCompilationTest() {
 
     buildAndAssertOutput()
   }
+
+  @Test
+  fun multipleBindingReplacementsAreRespectedWhenAddingNewContribution() {
+    val fixture =
+      object : MetroProject() {
+        override fun sources() = listOf(appGraph, fakeImpl, main)
+
+        override val gradleProject: GradleProject
+          get() =
+            newGradleProjectBuilder(DslKind.KOTLIN)
+              .withRootProject {
+                withBuildScript {
+                  sources = sources()
+                  applyMetroDefault()
+                  dependencies(
+                    Dependency.implementation(":common"),
+                    Dependency.implementation(":lib"),
+                  )
+                }
+              }
+              .withSubproject("common") {
+                sources.add(fooBar)
+                withBuildScript { applyMetroDefault() }
+              }
+              .withSubproject("lib") {
+                sources.add(realImpl)
+                withBuildScript {
+                  applyMetroDefault()
+                  dependencies(Dependency.implementation(":common"))
+                }
+              }
+              .write()
+
+        private val appGraph =
+          source(
+            """
+          @DependencyGraph(AppScope::class)
+          interface AppGraph {
+            val bar: Bar
+          }
+            """
+              .trimIndent()
+          )
+
+        private val fooBar =
+          source(
+            """
+          interface Foo
+          interface Bar : Foo {
+            val str: String
+          }
+            """.trimIndent()
+          )
+
+        val realImpl =
+          source(
+            """
+          @Inject
+          @ContributesBinding(AppScope::class, binding = binding<Foo>())
+          @ContributesBinding(AppScope::class, binding = binding<Bar>())
+          class RealImpl : Bar {
+            override val str: String = "real"
+          }
+          """
+              .trimIndent()
+          )
+
+        private val fakeImpl =
+          source(
+            """
+          @Inject
+          @ContributesBinding(AppScope::class, binding = binding<Foo>(), replaces = [RealImpl::class])
+          @ContributesBinding(AppScope::class, binding = binding<Bar>(), replaces = [RealImpl::class])
+          class FakeImpl : Bar {
+            override val str: String = "fake"
+          }
+          """
+              .trimIndent()
+          )
+
+        val placeholder =
+          source("")
+
+        val main =
+          source(
+            """
+            fun main(): String {
+              val graph = createGraph<AppGraph>()
+              return graph.bar.str
+            }
+            """
+              .trimIndent()
+          )
+      }
+    val project = fixture.gradleProject
+    val libProject = project.subprojects.first { it.name == "lib" }
+
+    fun buildAndAssertOutput() {
+      val buildResult = build(project.rootDir, "compileKotlin")
+      assertThat(buildResult.task(":compileKotlin")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+      val mainClass = project.classLoader().loadClass("test.MainKt")
+      val string = mainClass.declaredMethods.first { it.name == "main" }.invoke(null) as String
+      assertThat(string).isEqualTo("fake")
+    }
+
+    buildAndAssertOutput()
+
+    // Adding a new binding contribution should be alright
+    libProject.modify(
+      project.rootDir,
+      fixture.placeholder,
+      """
+      interface Baz
+
+      @Inject
+      @ContributesBinding(AppScope::class)
+      class BazImpl : Baz
+      """
+        .trimIndent(),
+    )
+
+    buildAndAssertOutput()
+  }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/incremental/ICTests.kt
@@ -1438,7 +1438,7 @@ class ICTests : BaseIncrementalCompilationTest() {
   @Test
   fun multipleBindingReplacementsAreRespectedWhenAddingNewContribution() {
     val fixture =
-      object : MetroProject() {
+      object : MetroProject(debug = true) {
         override fun sources() = listOf(appGraph, fakeImpl, main)
 
         override val gradleProject: GradleProject


### PR DESCRIPTION
Few folks from my team including myself, started to face an IC issue related to multiple replacements from a single class. It's a bit different than https://github.com/ZacSweers/metro/pull/867, in this scenario, the replacers live in the same module as the graph.

The mutator could be something else, but adding a new binding contribution seems the most reliable way to reproduce it.

The test fails with:
```
e: file:///Users/kevin/Documents/metro/gradle-plugin/build/functionalTest/-1f10b796-46/src/main/kotlin/test/AppGraph.kt:7:11 [Metro/DuplicateBinding] Duplicate binding for test.Bar
├─ Binding 1: Contributed by 'test.FakeImpl' at an unknown source location (likely a separate compilation).
├─ Binding 2: Contributed by 'test.RealImpl' at an unknown source location (likely a separate compilation).
```