### PR TITLE
Disable doc deployments on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
 
   publish:
     runs-on: macos-latest
-    if: github.ref == 'refs/heads/main' && github.repository == 'zacsweers/metro'
+    if: github.ref == 'refs/heads/main' && github.event.repository.fork == false
     needs:
       - final-status
 

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -26,6 +26,7 @@ jobs:
   # Metro docs site build job
   docs-site:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -83,6 +84,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     needs: docs-site
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Avoids failures like https://github.com/Goooler/metro/actions/runs/16688020232/job/47241088869.