### PR TITLE
Throw IllegalStateException if object graph not found for class

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/DependencyGraphFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/DependencyGraphFirGenerator.kt
@@ -474,7 +474,7 @@ internal class DependencyGraphFirGenerator(session: FirSession) :
       // Graph factory $$Impl class, just generate the SAM function
       log("Generating factory impl into ${owner.classId}")
       val graphClass = owner.requireContainingClassSymbol().requireContainingClassSymbol()
-      val graphObject = graphObject(graphClass)!!
+      val graphObject = graphObject(graphClass) ?: error("No graph object found for $graphClass")
       val creator =
         graphObject.findCreator(session, "generateFunctions ${context.owner.classId}", ::log)!!
       val samFunction = creator.classSymbol.findSamFunction(session)


### PR DESCRIPTION
I'm trying to migrate an Anvil `@MergeSubcomponent` (unsupported by Metro AFAIK) and have been getting failures that look like this:

```kotlin
e: java.lang.NullPointerException
        at dev.zacsweers.metro.compiler.fir.generators.DependencyGraphFirGenerator.generateFunctions(DependencyGraphFirGenerator.kt:477)
        at dev.zacsweers.metro.compiler.fir.generators.KotlinOnlyFirGenerationExtension.generateFunctions(KotlinOnlyFirGenerationExtension.kt:38)
        at org.jetbrains.kotlin.fir.scopes.impl.FirGeneratedMemberDeclarationsStorage$CallableStorage.generateMemberFunctions(FirGeneratedScopes.kt:213)
...
```

This change makes failures a bit easier to debug:

```kotlin
e: java.lang.IllegalStateException: No graph object found for FirRegularClassSymbol com/squareup/cash/ui/SandboxedActivityComponent
        at dev.zacsweers.metro.compiler.fir.generators.DependencyGraphFirGenerator.generateFunctions(DependencyGraphFirGenerator.kt:477)
        at dev.zacsweers.metro.compiler.fir.generators.KotlinOnlyFirGenerationExtension.generateFunctions(KotlinOnlyFirGenerationExtension.kt:38)
        at org.jetbrains.kotlin.fir.scopes.impl.FirGeneratedMemberDeclarationsStorage$CallableStorage.generateMemberFunctions(FirGeneratedScopes.kt:213)
...
```