### PR TITLE
fixed: re-enable metro docs site search

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ plugins:
   # Social plugin for delightful card previews on social media
   # https://squidfunk.github.io/mkdocs-material/plugins/social/
   - social
+  - search
 
 #extra_css:
 #  - 'css/app.css'


### PR DESCRIPTION
It was unintentionally disabled. See https://github.com/ZacSweers/metro/issues/897 for details.
- [x] Validated search working by running it locally.

Fixes #897
