### PR TITLE
Patch the BindingContainer doc for replacing Contributed Bindings

### DIFF
--- a/docs/aggregation.md
+++ b/docs/aggregation.md
@@ -243,6 +243,24 @@ object FakeNetworkBindings {
 }
 ```
 
+### Replacing Contributed Bindings
+
+Binding containers can replace other contributed bindings, too:
+
+```kotlin
+// In production
+@ContributesBinding(AppScope::class)
+@Inject
+class HttpClientImpl : HttpClient
+
+// In tests
+@ContributesTo(AppScope::class, replaces = [HttpClientImpl::class])
+@BindingContainer
+object FakeNetworkBindings {
+  @Provides fun provideFakeHttpClient(): HttpClient = FakeHttpClient()
+}
+```
+
 ### Excluding Contributed Binding Containers
 
 Graphs can exclude specific contributed binding containers:
@@ -259,9 +277,6 @@ interface TestAppGraph {
   // NetworkBindings will not be included
 }
 ```
-
-!!! info
-    Currently, contributed binding containers cannot replace non-contributed-container types (i.e. `@ContributesBinding` classes) yet.
 
 ## `@ContributesGraphExtension`
 


### PR DESCRIPTION
Found out that it's possible after https://github.com/ZacSweers/metro/pull/826