### PR TITLE
Fix Kotlin internal error overriding Metro error when there's a missing factory for a Java `@Inject` class

### DIFF
--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
@@ -8,6 +8,7 @@ import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.SourceFile.Companion.java
 import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
 import com.tschuchort.compiletesting.addPreviousResultToClasspath
 import java.nio.file.Path
@@ -281,6 +282,39 @@ abstract class MetroCompilerTest {
         // Imports
         for (import in (defaultImports + extraImports)) {
           appendLine("import $import")
+        }
+
+        appendLine()
+        appendLine()
+        appendLine(source)
+      },
+    )
+  }
+
+  /**
+   * Returns a [SourceFile] representation of this [source]. This includes common imports from
+   * Metro.
+   */
+  protected fun sourceJava(
+    @Language("java") source: String,
+    fileNameWithoutExtension: String? = null,
+    packageName: String = "test",
+    vararg extraImports: String,
+  ): SourceFile {
+    val fileName =
+      fileNameWithoutExtension
+        ?: CLASS_NAME_REGEX.find(source)?.groups?.get("name")?.value
+        ?: FUNCTION_NAME_REGEX.find(source)?.groups?.get("name")?.value?.capitalizeUS()
+        ?: "source"
+    return java(
+      "${fileName}.java",
+      buildString {
+        // Package statement
+        appendLine("package $packageName;")
+
+        // Imports
+        for (import in (defaultImports + extraImports)) {
+          appendLine("import $import;")
         }
 
         appendLine()

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/InjectConstructorTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/InjectConstructorTransformerTest.kt
@@ -4,10 +4,12 @@ package dev.zacsweers.metro.compiler.transformers
 
 import com.google.common.truth.Truth.assertThat
 import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import dev.zacsweers.metro.compiler.ExampleClass
 import dev.zacsweers.metro.compiler.ExampleGraph
 import dev.zacsweers.metro.compiler.MetroCompilerTest
 import dev.zacsweers.metro.compiler.assertCallableFactory
+import dev.zacsweers.metro.compiler.assertContainsAll
 import dev.zacsweers.metro.compiler.assertDiagnostics
 import dev.zacsweers.metro.compiler.assertNoArgCallableFactory
 import dev.zacsweers.metro.compiler.callProperty
@@ -358,5 +360,44 @@ class InjectConstructorTransformerTest : MetroCompilerTest() {
           .trimIndent()
       )
     }
+  }
+
+  // https://github.com/ZacSweers/metro/issues/935
+  // Covers a use-case where we would previously get a Kotlin internal error that read:
+  // e: kotlin.NotImplementedError: An operation is not implemented: Unknown file
+  @Test
+  fun `when no factory is found for a Java class, the exception should still specify it in the error message`() {
+    val previousResult =
+      compile(
+        sourceJava(
+          """
+            public class ExampleClass {
+              @Inject public ExampleClass() {
+            
+              }
+            }
+          """
+            .trimIndent()
+        )
+      )
+    val result =
+      compile(
+        source(
+          """
+            @DependencyGraph
+            interface ExampleGraph {
+              val exampleClass: ExampleClass
+            }
+          """
+            .trimIndent()
+        ),
+        expectedExitCode = ExitCode.COMPILATION_ERROR,
+        options = metroOptions.copy(enableDaggerRuntimeInterop = true),
+        previousCompilationResult = previousResult,
+      )
+
+    result.assertContainsAll(
+      "Could not find generated factory for 'test.ExampleClass' in upstream module where it's defined. Run the Metro compiler over that module too, or Dagger if you're using its interop for Java files."
+    )
   }
 }

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/InjectConstructorTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/InjectConstructorTransformerTest.kt
@@ -373,7 +373,7 @@ class InjectConstructorTransformerTest : MetroCompilerTest() {
           """
             public class ExampleClass {
               @Inject public ExampleClass() {
-            
+
               }
             }
           """


### PR DESCRIPTION
- Fixes #935