### PR TITLE
[DISABLE] Automatic docs site generation workflow

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -26,7 +26,7 @@ jobs:
   # Metro docs site build job
   docs-site:
     runs-on: ubuntu-latest
-    if: github.repository == 'zacsweers/metro'
+    if: false  # Workflow disabled for now. Original: ```if: github.repository == 'zacsweers/metro'```
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5


### PR DESCRIPTION
> ℹ️ **This PR is required to be merged before https://github.com/ZacSweers/metro/pull/938**

This is in preparation for versioned Metro doc site
* https://github.com/ZacSweers/metro/issues/917

Alternatively we could disable workflow in [settings](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/disable-and-enable-workflows), however, when re-enabled this may accidentally trigger if new commit is merged and that will overwrite the manually generated versioned site.