### PR TITLE
fix: CI failure on `main` - Kotlin/Wasm package lock files

### DIFF
--- a/samples/kotlin-js-store/wasm/package-lock.json
+++ b/samples/kotlin-js-store/wasm/package-lock.json
@@ -4903,6 +4903,7 @@
       "devDependencies": {}
     },
     "packages_imported/metro-runtime/0.7.0-SNAPSHOT": {
+      "name": "metro-runtime",
       "version": "0.7.0-SNAPSHOT",
       "devDependencies": {}
     },


### PR DESCRIPTION
Some tasks from job https://github.com/ZacSweers/metro/actions/runs/17000311510/job/48201509162 was failing.

```
Run ./gradlew -p samples test allTests --continue --quiet
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':kotlinWasmStorePackageLock'.
> Lock file was changed. Run the `kotlinWasmUpgradePackageLock` task to actualize lock file
```

- Ran `kotlinWasmUpgradePackageLock` to update out-of-sync lock files