### PR TITLE
[UPDATE] Mkdocs workflow to use mike for versioned site

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -10,9 +10,9 @@ on:
   # Allows manual deployements (if needed)
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Sets permissions of the GITHUB_TOKEN to allow pushing to `gh-pages` branch
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -26,7 +26,7 @@ jobs:
   # Metro docs site build job
   docs-site:
     runs-on: ubuntu-latest
-    if: false  # Workflow disabled for now. Original: ```if: github.repository == 'zacsweers/metro'```
+    if: github.repository == 'zacsweers/metro'
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
@@ -67,25 +67,61 @@ jobs:
       - name: Copy documentation files
         run: ./scripts/copy_docs_files.sh
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
+      - name: Extract Metro version from gradle.properties
+        id: version
+        run: |
+          METRO_VERSION=$(grep "VERSION_NAME=" gradle.properties | cut -d'=' -f2)
+          echo "METRO_VERSION=$METRO_VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $METRO_VERSION"
 
-      - name: Build MkDocs site
-        run: mkdocs build
+      - name: Validate version format
+        run: |
+          VERSION="${{ steps.version.outputs.METRO_VERSION }}"
+          
+          # Check if version is empty
+          if [[ -z "$VERSION" ]]; then
+            echo "ERROR: VERSION_NAME is empty in gradle.properties"
+            exit 1
+          fi
+          
+          # Check if version matches x.y.z or x.y.z-SNAPSHOT pattern
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-SNAPSHOT)?$ ]]; then
+            echo "ERROR: VERSION_NAME '$VERSION' does not match expected format:"
+            echo "   Expected: x.y.z or x.y.z-SNAPSHOT (e.g., 1.2.3 or 1.2.3-SNAPSHOT)"
+            echo "   Actual: $VERSION"
+            exit 1
+          fi
+          
+          echo "Version format is valid: $VERSION"
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './site'
+      - name: Configure Git for Mike
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: docs-site
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Fetch gh-pages branch
+        run: |
+          # Fetch the gh-pages branch to ensure we have the latest state
+          git fetch origin gh-pages:gh-pages || echo "gh-pages branch doesn't exist yet (first deployment)"
+
+      - name: Deploy SNAPSHOT Docs with mike
+        if: ${{ success() && contains(steps.version.outputs.METRO_VERSION, 'SNAPSHOT') }}
+        run: mike deploy --update-aliases --push ${{ steps.version.outputs.METRO_VERSION }} snapshot
+
+      - name: Deploy Release Docs with mike
+        if: ${{ success() && !contains(steps.version.outputs.METRO_VERSION, 'SNAPSHOT') }}
+        run: |
+          mike deploy --update-aliases --push ${{ steps.version.outputs.METRO_VERSION }} latest
+          mike set-default --push latest
+
+      # This is important step for first time repo setup with no prior non-snapshot release
+      - name: Set snapshot as default if no release versions exist
+        if: ${{ success() && contains(steps.version.outputs.METRO_VERSION, 'SNAPSHOT') }}
+        run: |
+          # Check if there are any non-snapshot versions
+          if ! mike list | grep -v SNAPSHOT | grep -q "[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+            echo "No release versions found, setting snapshot as default"
+            mike set-default --push snapshot
+          else
+            echo "Release versions exist, keeping current `latest` as default"
+          fi


### PR DESCRIPTION
## Summary
- Updated workflow to use `mike` which works with directly comitting to `gh-pages` branch.
- Removed `actions/upload-pages-artifact` and `actions/deploy-page` - no longer directly deploying to pages
- Also added `snapshot` and `latest` alias based on version in `gradle.properties` (similar to sqldelight)
- Added version format validation (fail early - just in case)

🏃🏽 Success run: https://github.com/hossain-khan/metro-docs/actions/runs/17008833135/job/48222094564
📺 Demo after workflow run: https://hossain-khan.github.io/metro-docs/ (has `0.7.0-SNAPSHOT` built 🙌🏽)

Takes care of following from https://github.com/ZacSweers/metro/pull/938
- [x] After merge, update [docs-site.yml](https://github.com/ZacSweers/metro/blob/main/.github/workflows/docs-site.yml) to use the `mike` tool instead. 
- [x] Figure out how to build the snapshot site that is not default
- [x] Figure out the release step task where we have to run `mike set-default 0.x.y` 


Fixes https://github.com/ZacSweers/metro/issues/917


## 🗒️ Todo for Zac

Update repo settings to use `gh-pages` content for Pages Site

<img width="1265" height="542" alt="Screenshot 2025-08-16 at 9 09 35 AM" src="https://github.com/user-attachments/assets/2e502d89-0fc9-42c5-8445-95d218384ecb" />

---

Also take a look why this failed earlier, may be some permission update needed? Or may be not after above change.
https://github.com/ZacSweers/metro/actions/runs/17004225450/job/48211508521

<img width="1238" height="271" alt="Screenshot 2025-08-16 at 9 37 18 AM" src="https://github.com/user-attachments/assets/73fa3607-6381-451e-b850-75a00e0e9c6c" />


