### PR TITLE
fix (phase 1): Added 404 support that broke after introducing `mike`

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Page Not Found - 🚇 Metro</title>
+  <noscript>
+    <meta http-equiv="refresh" content="1; url=/metro/latest/" />
+  </noscript>
+  <script>
+    // Currently `mike` does not support 404 page
+    // https://github.com/jimporter/mike/issues/72
+    // This is interim solution to take user to latest release site
+    window.location.replace("/metro/latest/");
+  </script>
+</head>
+<body>
+  <h1>🚇 Page Not Found</h1>
+  <p>The page you're looking for doesn't exist or might have been moved.</p>
+  <p>Redirecting to <a href="/metro/latest/">metro/latest/</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Mike does not come with default 404 handler (https://github.com/jimporter/mike/issues/72) This breaks Metro site's ability to serve mkdocs's default 404 that was also enhanced in https://github.com/ZacSweers/metro/pull/796

This is **Phase 1** with basic fix that redirects users to `latest` stable release, with following benefits
* When user visit old non-versioned site, they will be redirected to `latest` version
* When user visit page that might have been moved, they will also be redirect to `latest` site


| Fix Demo | 🎥 |
| ------ | ----- | 
| Before - No 404 handler | ![2025-08-19 09 49 29](https://github.com/user-attachments/assets/f3240c55-9db4-4880-a58b-22dd8cb43102) | 
| After - Redirect on any 404 | ![2025-08-19 10 03 08](https://github.com/user-attachments/assets/f4c75c60-4dee-4bd6-b73e-ae97be3e3a72) | 
| After - Redirect from non-versioned sites | ![2025-08-19 10 04 26](https://github.com/user-attachments/assets/dc9a7569-03c0-4c34-a8ad-a87d543ea0a4) |



> p.s. I basically wanted to leverage existing 404 pages that exist for each versioned site, however due to another known issue https://github.com/squidfunk/mkdocs-material/issues/7629 I wasn't able to do it in one go! So, opted for simple phase 1 solution for now.