### PR TITLE
Add diagnostic for contributed binding containers with no (visible) noarg constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 **Unreleased**
 --------------
 
+* **Enhancement**: Add diagnostic for contributed binding containers with no (visible) no-arg constructor.
 * **Fix**: Don't allocate new fields for deferred bindings reserved by extension graphs.
 
 0.6.1

--- a/compiler-tests/src/test/data/diagnostic/bindingcontainer/ContributedContainersMustHaveNoArgConstructors.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/bindingcontainer/ContributedContainersMustHaveNoArgConstructors.fir.diag.txt
@@ -1,0 +1,3 @@
+/ContributedContainersMustHaveNoArgConstructors.kt:(132,139): error: Contributed binding container BadContainer1's no-arg constructor must be public or internal.
+
+/ContributedContainersMustHaveNoArgConstructors.kt:(211,224): error: Contributed binding containers must have a no-arg constructor.

--- a/compiler-tests/src/test/data/diagnostic/bindingcontainer/ContributedContainersMustHaveNoArgConstructors.kt
+++ b/compiler-tests/src/test/data/diagnostic/bindingcontainer/ContributedContainersMustHaveNoArgConstructors.kt
@@ -1,0 +1,10 @@
+// RENDER_DIAGNOSTICS_FULL_TEXT
+
+@ContributesTo(AppScope::class)
+@BindingContainer
+class BadContainer1 <!METRO_DECLARATION_VISIBILITY_ERROR!>private<!> constructor()
+
+@ContributesTo(AppScope::class)
+@BindingContainer
+class <!BINDING_CONTAINER_ERROR!>BadContainer2<!>(private val foo: String)
+

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/DiagnosticTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/DiagnosticTestGenerated.java
@@ -66,6 +66,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
     }
 
     @Test
+    @TestMetadata("ContributedContainersMustHaveNoArgConstructors.kt")
+    public void testContributedContainersMustHaveNoArgConstructors() {
+      runTest("compiler-tests/src/test/data/diagnostic/bindingcontainer/ContributedContainersMustHaveNoArgConstructors.kt");
+    }
+
+    @Test
     @TestMetadata("IllegalTypes.kt")
     public void testIllegalTypes() {
       runTest("compiler-tests/src/test/data/diagnostic/bindingcontainer/IllegalTypes.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirMetroErrors.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/FirMetroErrors.kt
@@ -74,6 +74,7 @@ internal object FirMetroErrors : BaseDiagnosticRendererFactory() {
   val FUNCTION_INJECT_ERROR by error1<String>(NAME_IDENTIFIER)
   val FUNCTION_INJECT_TYPE_PARAMETERS_ERROR by error1<String>(TYPE_PARAMETERS_LIST)
   val BINDING_CONTAINER_ERROR by error1<String>(NAME_IDENTIFIER)
+  val BINDING_CONTAINER_CONSTRUCTOR_VISIBILITY_ERROR by error1<String>(VISIBILITY_MODIFIER)
 
   override val MAP: KtDiagnosticFactoryToRendererMap =
     KtDiagnosticFactoryToRendererMap("FirMetroErrors").apply {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/BindingContainerClassChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/BindingContainerClassChecker.kt
@@ -9,6 +9,7 @@ import dev.zacsweers.metro.compiler.fir.isAnnotatedWithAny
 import dev.zacsweers.metro.compiler.fir.resolvedBindingContainersClassIds
 import dev.zacsweers.metro.compiler.fir.resolvedClassId
 import dev.zacsweers.metro.compiler.fir.resolvedIncludesClassIds
+import dev.zacsweers.metro.compiler.fir.validateVisibility
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
@@ -24,6 +25,7 @@ import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.constructors
 import org.jetbrains.kotlin.fir.declarations.processAllDeclarations
 import org.jetbrains.kotlin.fir.declarations.toAnnotationClass
+import org.jetbrains.kotlin.fir.declarations.utils.classId
 import org.jetbrains.kotlin.fir.declarations.utils.isAbstract
 import org.jetbrains.kotlin.fir.declarations.utils.isEnumClass
 import org.jetbrains.kotlin.fir.declarations.utils.isInterface
@@ -167,7 +169,34 @@ internal object BindingContainerClassChecker : FirClassChecker(MppCheckerKind.Co
       }
     }
 
-    val isAbstract = declaration.isAbstract || declaration.isInterface
+    val isInterface = declaration.isInterface
+
+    if (!isInterface) {
+      val isContributed = declaration.isAnnotatedWithAny(session, classIds.contributesToAnnotations)
+      if (isContributed) {
+        // Check for a single, no-arg constructor
+        val constructors = declaration.constructors(session)
+        if (constructors.isNotEmpty()) {
+          val noArgConstructor =
+            declaration.constructors(session).find { it.valueParameterSymbols.isEmpty() }
+          if (noArgConstructor == null) {
+            reporter.reportOn(
+              source,
+              BINDING_CONTAINER_ERROR,
+              "Contributed binding containers must have a no-arg constructor.",
+            )
+          } else {
+            noArgConstructor.validateVisibility(
+              "Contributed binding container ${declaration.classId.asFqNameString()}'s no-arg constructor"
+            ) {
+              return
+            }
+          }
+        }
+      }
+    }
+
+    val isAbstract = isInterface || declaration.isAbstract
 
     // Check for no conflicting names, requires class-level
     val providerNames = mutableMapOf<Name, FirCallableSymbol<*>>()


### PR DESCRIPTION
Resolves #966