### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -101,7 +101,7 @@ interface MapMultibinding {
 
   @Provides
   @IntoMap
-  @MapKey(2)
+  @IntKey(2)
   fun provideInt2() = 2
 }
 ```


### PR DESCRIPTION
Fix a typo in the docs that references the wrong annotation.