### PR TITLE
added: doc site cleanup script with workflow step

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -119,16 +119,15 @@ jobs:
         if: ${{ success() && contains(steps.version.outputs.METRO_VERSION, 'SNAPSHOT') }}
         run: mike deploy --update-aliases --push ${{ steps.version.outputs.METRO_VERSION }} snapshot
 
-      # Delete previous snapshot docs when a respective release is getting published
-      - name: Delete snapshot docs for new release
-        if: ${{ success() && !contains(steps.version.outputs.METRO_VERSION, 'SNAPSHOT') }}
-        run: |
-          mike delete --push ${{ steps.version.outputs.METRO_VERSION }}-SNAPSHOT || true
-
       - name: Deploy Release Docs with mike
         if: ${{ success() && !contains(steps.version.outputs.METRO_VERSION, 'SNAPSHOT') }}
         run: |
           mike deploy --update-aliases --push ${{ steps.version.outputs.METRO_VERSION }} latest
+
+      - name: Delete old doc versions
+        run: |
+          git fetch origin gh-pages --depth=1
+          ./scripts/delete_old_version_docs.sh
 
   # Docs dry run job for PRs that change requirements.txt
   docs-dry-run:

--- a/scripts/delete_old_version_docs.sh
+++ b/scripts/delete_old_version_docs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# This script cleans up old versioned mkdocs site by keeping only the latest
+# patch version for each major.minor series. 
+#
+# Example cleanup given the following versioned sites from `mike list`:
+# - "0.7.0-SNAPSHOT [snapshot]" <-- keep ✅
+# - "0.6.2 [latest]" <-- keep ✅
+# - "0.6.1" <-- deleted ❌
+# - "0.6.0" <-- deleted ❌
+# - "0.6.0-SNAPSHOT" <-- deleted ❌
+# - "0.5.5" <-- keep ✅
+# - "0.5.4" <-- deleted ❌
+#
+# Note: This script is adapted from `https://github.com/chrisbanes/haze` repository.
+
+
+# Check if mike is installed
+if ! command -v mike &> /dev/null; then
+    echo "Error: mike is not installed."
+    echo "Please install mike using: pip install mike"
+    exit 0
+fi
+
+# Get list of existing versioned mkdocs sites
+versions=($(mike list | tr ' ' '\n'))
+
+declare -A major_latest
+
+# Find latest per X.Y
+for v in "${versions[@]}"; do
+  major="${v%.*}"
+  if [[ -z "${major_latest[$major]}" ]]; then
+    major_latest[$major]="$v"
+  else
+    latest="${major_latest[$major]}"
+    # Use version sort (-V) to compare
+    greater=$(printf "%s\n%s\n" "$latest" "$v" | sort -V | tail -n1)
+    major_latest[$major]="$greater"
+  fi
+done
+
+to_delete=()
+for v in "${versions[@]}"; do
+  major="${v%.*}"
+  if [[ "$v" != "${major_latest[$major]}" ]]; then
+    to_delete+=("$v")
+  fi
+done
+
+if [[ ${#to_delete[@]} -eq 0 ]]; then
+  echo "No cleanup required - all versions are already the latest for their respective series"
+else
+  for v in "${to_delete[@]}"; do
+    echo "Cleaning up old versioned site - deleting $v"
+    mike delete "$v" --push
+  done
+fi


### PR DESCRIPTION
## Summary
As [suggested](https://androidstudygroup.slack.com/archives/C08CVCEFMLL/p1755680521563599?thread_ts=1755664125.432829&cid=C08CVCEFMLL) by Chris, I have adapted Haze's [script](https://github.com/chrisbanes/haze/blob/main/scripts/delete_old_version_docs.sh) to cleanup the old versioned sites after each deployment.

Currently we have:

```
0.7.0-SNAPSHOT [snapshot]
0.6.2 [latest]
0.6.1
0.6.0
0.5.5
0.5.4
0.5.3
0.5.2
0.5.1
0.5.0
```

After first run, we should see following versions deleted
```
0.6.1
0.6.0
0.5.4
0.5.3
0.5.2
0.5.1
0.5.0
```

### Preview

| Before | After |
| ----- | ----- |
| <img width="628" height="261" alt="Screenshot 2025-08-23 at 5 22 44 AM" src="https://github.com/user-attachments/assets/10cea0a9-e924-467f-bbfb-2d7eae1056f4" /> | <img width="603" height="260" alt="Screenshot 2025-08-23 at 5 22 10 AM" src="https://github.com/user-attachments/assets/8d047e65-61e8-4b71-9833-1826d932bd9a" /> | 
