### PR TITLE
Update `@Multibinds` documentation

### DIFF
--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -111,7 +111,7 @@ Alternatively, they can be declared with an `@Multibinds`-annotated accessor pro
 ```kotlin
 @DependencyGraph
 interface MapMultibinding {
-  @Multibinds
+  @Multibinds(allowEmpty = true)
   val ints: Map<Int, Int>
 }
 ```
@@ -123,7 +123,7 @@ Map multibindings support injecting *map providers*, where the value type can be
 ```kotlin
 @DependencyGraph
 interface MapMultibinding {
-  @Multibinds
+  @Multibinds(allowEmpty = true)
   val ints: Map<Int, Provider<Int>>
 }
 ```

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/Multibinds.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/Multibinds.kt
@@ -27,10 +27,10 @@ package dev.zacsweers.metro
  *
  * ```
  * @DependencyGraph interface MyGraph {
- *   @Multibinds aSet(): Set<Foo>
- *   @Multibinds @MyQualifier aQualifiedSet(): Set<Foo>
- *   @Multibinds aMap(): Map<String, Foo>
- *   @Multibinds @MyQualifier aQualifiedMap(): Map<String, Foo>
+ *   @Multibinds(allowEmpty = true) fun aSet(): Set<Foo>
+ *   @Multibinds(allowEmpty = true) @MyQualifier val aQualifiedSet: Set<Foo>
+ *   @Multibinds(allowEmpty = true) fun aMap(): Map<String, Foo>
+ *   @Multibinds(allowEmpty = true) @MyQualifier val aQualifiedMap: Map<String, Foo>
  *
  *   @Provides
  *   fun usesMultibindings(set: Set<Foo>, @MyQualifier map: Map<String, Foo>): Any {


### PR DESCRIPTION
Update the documentation for `@Multibinds` to highlight the `allowEmpty` property. `@Multibinds` is optional, if there are more than zero bindings. So the more common use case for `@Multibinds` is providing a default empty binding.