### PR TITLE
Ensure contributed binding containers' included containers are available in root dependency graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 --------------
 
 * **Enhancement**: Transform and collect contribution data in a single pass during IR.
+* **Fix**: Ensure contributed binding containers' included containers are available in root dependency graphs.
 
 0.6.3
 -----

--- a/compiler-tests/src/test/data/box/bindingcontainers/TransitiveContributedContainersInRootGraphs.kt
+++ b/compiler-tests/src/test/data/box/bindingcontainers/TransitiveContributedContainersInRootGraphs.kt
@@ -1,0 +1,27 @@
+@ContributesTo(AppScope::class)
+@BindingContainer(includes = [IncludedBindings::class])
+interface Bindings1 {
+  @Binds val Int.bindNumber: Number
+}
+
+@BindingContainer
+interface IncludedBindings {
+  @Binds val String.bindCharSequence: CharSequence
+}
+
+@DependencyGraph(Unit::class, additionalScopes = [AppScope::class])
+interface UnitGraph {
+  val number: Number
+  val charSequence: CharSequence
+
+  @Provides fun provideString(): String = "Hello, World!"
+
+  @Provides fun provideInt(): Int = 3
+}
+
+fun box(): String {
+  val graph = createGraph<UnitGraph>()
+  assertEquals("Hello, World!", graph.charSequence)
+  assertEquals(3, graph.number)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -218,6 +218,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     public void testTransitiveContributedContainersInContributedGraphs() {
       runTest("compiler-tests/src/test/data/box/bindingcontainers/TransitiveContributedContainersInContributedGraphs.kt");
     }
+
+    @Test
+    @TestMetadata("TransitiveContributedContainersInRootGraphs.kt")
+    public void testTransitiveContributedContainersInRootGraphs() {
+      runTest("compiler-tests/src/test/data/box/bindingcontainers/TransitiveContributedContainersInRootGraphs.kt");
+    }
   }
 
   @Nested

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/DependencyGraphNodeCache.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/DependencyGraphNodeCache.kt
@@ -15,6 +15,7 @@ import dev.zacsweers.metro.compiler.ir.parameters.wrapInMembersInjector
 import dev.zacsweers.metro.compiler.ir.transformers.BindingContainer
 import dev.zacsweers.metro.compiler.ir.transformers.BindingContainerTransformer
 import dev.zacsweers.metro.compiler.mapNotNullToSet
+import dev.zacsweers.metro.compiler.mapToSet
 import dev.zacsweers.metro.compiler.memoized
 import dev.zacsweers.metro.compiler.reportCompilerBug
 import dev.zacsweers.metro.compiler.tracing.Tracer
@@ -622,6 +623,11 @@ internal class DependencyGraphNodeCache(
             .orEmpty()
         }
       val mergedContainers = bindingContainers.filterNot { it.ir.classId in replaced }
+        .mapToSet { it.ir }
+        .let { rootContainers ->
+          // Now that we've filtered out the removed and excluded containers, we can pull in the transitively included ones
+          bindingContainerTransformer.resolveAllBindingContainersCached(rootContainers)
+        }
 
       for (container in mergedContainers) {
         providerFactories += container.providerFactories.values.map { it.typeKey to it }


### PR DESCRIPTION
- Fixes #1006