### PR TITLE
fix: prioritize tagged releases in docs workflow concurrency

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -23,10 +23,10 @@ permissions:
   pages: write
   id-token: write
 
-# Only allow one docs deployment at a time, and queue subsequent ones
+# Only allow one docs deployment at a time per type, prioritize tagged releases
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ startsWith(github.ref, 'refs/tags/') && 'pages-release' || 'pages-dev' }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   # Metro docs site build job


### PR DESCRIPTION
### Summary
- Use separate concurrency groups for tagged releases vs dev builds
- Tagged releases use 'pages-release' group and never get cancelled
- Dev builds use 'pages-dev' group and can be cancelled by newer builds
- Prevents tagged release docs from being cancelled by subsequent builds

Fixes issue where docs deployment was cancelled with: 'Canceling since a higher priority waiting request for pages exists'

**Related Issue:** 
* https://github.com/ZacSweers/metro/issues/1012