### PR TITLE
nit: Disabled cleanup step from manual docs site deployment

### DIFF
--- a/.github/workflows/docs-site-manual.yml
+++ b/.github/workflows/docs-site-manual.yml
@@ -124,7 +124,9 @@ jobs:
           echo "Updated mike versions after deployment:"
           mike list
 
-      - name: Delete old doc versions
-        run: |
-          git fetch origin gh-pages --depth=1
-          ./scripts/delete_old_version_docs.sh
+      # ℹ️ NOTE: 
+      # The 'delete_old_version_docs.sh' step is intentionally skipped for the manual deployment,
+      # because in case manual deployment was used to generate old versioned site
+      # that is not latest, then the cleanup script would immidiately delete it.
+      #
+      # So, skipping it here, and let the normal docs workflow handle cleanup on next run.


### PR DESCRIPTION
## Summary
Cleanup step using [`delete_old_version_docs.sh`](https://github.com/ZacSweers/metro/blob/main/scripts/delete_old_version_docs.sh) is removed, just in case we ever want to generate non-latest old version site to check something temporarily.