### PR TITLE
A couple of failing tests for AssistedFactory usages

### DIFF
--- a/compiler-tests/src/test/data/box/inject/assisted/AssistedFactoryDependenciesAreValidated.kt
+++ b/compiler-tests/src/test/data/box/inject/assisted/AssistedFactoryDependenciesAreValidated.kt
@@ -1,0 +1,35 @@
+@DependencyGraph(AppScope::class)
+interface AppGraph
+
+@DependencyGraph(Unit::class)
+interface UnitGraph {
+  val foo: Foo
+
+  @Provides
+  fun provideFoo(factory: Foo.Factory): Foo {
+    return factory.create("UnitGraph")
+  }
+}
+
+@Inject
+class Foo(
+  @Assisted str: String,
+  bar: Bar // <-- this should fail because it doesn't exist in UnitGraph
+) {
+  @AssistedFactory
+  interface Factory {
+    fun create(str: String): Foo
+  }
+}
+
+interface Bar
+
+@Inject
+@ContributesBinding(AppScope::class)
+class BarImpl : Bar
+
+fun box(): String {
+  val unitGraph = createGraph<UnitGraph>()
+  assertNotNull(unitGraph.foo)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/inject/assisted/SimpleAssistedFactory.kt
+++ b/compiler-tests/src/test/data/box/inject/assisted/SimpleAssistedFactory.kt
@@ -1,0 +1,25 @@
+@DependencyGraph(Unit::class)
+interface UnitGraph {
+  val foo: Foo
+
+  @Provides
+  fun provideFoo(factory: Foo.Factory): Foo {
+    return factory.create("UnitGraph")
+  }
+}
+
+@Inject
+class Foo(
+  @Assisted str: String,
+) {
+  @AssistedFactory
+  interface Factory {
+    fun create(str: String): Foo
+  }
+}
+
+fun box(): String {
+  val unitGraph = createGraph<UnitGraph>()
+  assertNotNull(unitGraph.foo)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -725,6 +725,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("AssistedFactoryDependenciesAreValidated.kt")
+      public void testAssistedFactoryDependenciesAreValidated() {
+        runTest("compiler-tests/src/test/data/box/inject/assisted/AssistedFactoryDependenciesAreValidated.kt");
+      }
+
+      @Test
       @TestMetadata("AssistedTypesCanBeExplicitlyProvided.kt")
       public void testAssistedTypesCanBeExplicitlyProvided() {
         runTest("compiler-tests/src/test/data/box/inject/assisted/AssistedTypesCanBeExplicitlyProvided.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -741,6 +741,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       public void testPreserveNullabilityInRemapping() {
         runTest("compiler-tests/src/test/data/box/inject/assisted/PreserveNullabilityInRemapping.kt");
       }
+
+      @Test
+      @TestMetadata("SimpleAssistedFactory.kt")
+      public void testSimpleAssistedFactory() {
+        runTest("compiler-tests/src/test/data/box/inject/assisted/SimpleAssistedFactory.kt");
+      }
     }
 
     @Nested


### PR DESCRIPTION
A few folks from my team started to see some weird runtime crashes, such as 

```
Caused by: java.lang.ClassCastException: dev.zacsweers.metro.internal.DoubleCheck cannot be cast to com.bandlab.share.dialog.template.api.ClipMakerAssetRepository$$$MetroFactory
  at com.bandlab.bandlab.AppGraph$$$MetroGraph$TrendingFeedPageGraphExtensionImpl.init2(Unknown Source:1349)
  at com.bandlab.bandlab.AppGraph$$$MetroGraph$TrendingFeedPageGraphExtensionImpl.<init>(Unknown Source:52)
  at com.bandlab.bandlab.AppGraph$$$MetroGraph.create(AppGraph.kt:11)
```

I found out the problem with this crash is because of missing dependencies in the graph that uses the assisted factory, so I went ahead to create a test case.

But there is a bizarre thing, if you look at the `SimpleAssistedFactory.kt` test case, it's a super simple case, but it still results in a runtime crash 😰  

For the problem my devs are facing, it's reproducible in `AssistedFactoryDependenciesAreValidated.kt`.