### PR TITLE
fixed: metro docs site url not adhering to `use_directory_urls` config

### DIFF
--- a/.github/workflows/mkdocs-requirements.txt
+++ b/.github/workflows/mkdocs-requirements.txt
@@ -1,4 +1,4 @@
-click==8.2.2
+click==8.2.1
 future==1.0.0
 Jinja2==3.1.6
 livereload==2.7.1
@@ -9,7 +9,7 @@ mike==2.1.3
 mkdocs==1.6.1
 mkdocs-get-deps==0.2.0
 mkdocs-macros-plugin==1.3.9
-mkdocs-material==9.6.16
+mkdocs-material==9.6.20
 mkdocs-material-extensions==1.3.1
 mkdocs-callouts==1.16.0
 Pygments==2.19.2


### PR DESCRIPTION
## Summary
I have recently noticed that metro sites are using `.html` URL instead of plain URL as seen in following issue
* https://github.com/ZacSweers/metro/issues/1053

Unfortunately, there is no indication anywhere on web on why this might be broken. So, I created [mkdocs-playground](https://github.com/hossain-khan/mkdocs-playground) and incrementally added metro config until the issue was reproducible! yay! 😅

It turned out to be combination of latest `mkdocs-material` and compatible `click` version. I looked into `mkdocs-material` [release notes](https://github.com/squidfunk/mkdocs-material/releases), however it does not mention anything about `use_directory_urls` fix.

Closes #1053

---

### Before

<img width="1560" height="659" alt="Screenshot 2025-09-16 at 7 52 35 PM" src="https://github.com/user-attachments/assets/5a6dd77f-c12f-46e2-ab30-31f35ca946fd" />

### After

<img width="1561" height="660" alt="Screenshot 2025-09-16 at 7 53 28 PM" src="https://github.com/user-attachments/assets/7d398592-8c2f-4e59-b3a6-150ca21485b1" />
