### PR TITLE
chore: Update links to doc site to use the `latest` alias

### DIFF
--- a/compiler-tests/src/test/data/diagnostic/provides/BindsNonThisReturningBodiesShouldError_AbstractClass.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/provides/BindsNonThisReturningBodiesShouldError_AbstractClass.fir.diag.txt
@@ -1,3 +1,3 @@
-/BindsNonThisReturningBodiesShouldError_AbstractClass.kt:(112,131): error: `@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/BindsNonThisReturningBodiesShouldError_AbstractClass.kt:(112,131): error: `@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.
 
-/BindsNonThisReturningBodiesShouldError_AbstractClass.kt:(188,201): error: `@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/BindsNonThisReturningBodiesShouldError_AbstractClass.kt:(188,201): error: `@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.

--- a/compiler-tests/src/test/data/diagnostic/provides/BindsNonThisReturningBodiesShouldError_Interface.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/provides/BindsNonThisReturningBodiesShouldError_Interface.fir.diag.txt
@@ -1,3 +1,3 @@
-/BindsNonThisReturningBodiesShouldError_Interface.kt:(107,126): error: `@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/BindsNonThisReturningBodiesShouldError_Interface.kt:(107,126): error: `@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.
 
-/BindsNonThisReturningBodiesShouldError_Interface.kt:(183,196): error: `@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/BindsNonThisReturningBodiesShouldError_Interface.kt:(183,196): error: `@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.

--- a/compiler-tests/src/test/data/diagnostic/provides/DaggerReusable_IsUnsupported.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/provides/DaggerReusable_IsUnsupported.fir.diag.txt
@@ -1,3 +1,3 @@
-/DaggerReusable_IsUnsupported.kt:(128,137): error: Dagger's `@Reusable` is not supported in Metro. See https://zacsweers.github.io/metro/faq#why-doesnt-metro-support-reusable for more information.
+/DaggerReusable_IsUnsupported.kt:(128,137): error: Dagger's `@Reusable` is not supported in Metro. See https://zacsweers.github.io/metro/latest/faq#why-doesnt-metro-support-reusable for more information.
 
-/DaggerReusable_IsUnsupported.kt:(196,205): error: Dagger's `@Reusable` is not supported in Metro. See https://zacsweers.github.io/metro/faq#why-doesnt-metro-support-reusable for more information.
+/DaggerReusable_IsUnsupported.kt:(196,205): error: Dagger's `@Reusable` is not supported in Metro. See https://zacsweers.github.io/metro/latest/faq#why-doesnt-metro-support-reusable for more information.

--- a/compiler-tests/src/test/data/diagnostic/provides/ProvidesCannotHaveReceivers_AbstractClass.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/provides/ProvidesCannotHaveReceivers_AbstractClass.fir.diag.txt
@@ -1,3 +1,3 @@
-/ProvidesCannotHaveReceivers_AbstractClass.kt:(113,123): error: `@Provides` properties may not be extension properties. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/ProvidesCannotHaveReceivers_AbstractClass.kt:(113,123): error: `@Provides` properties may not be extension properties. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.
 
-/ProvidesCannotHaveReceivers_AbstractClass.kt:(187,200): error: `@Provides` functions may not be extension functions. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/ProvidesCannotHaveReceivers_AbstractClass.kt:(187,200): error: `@Provides` functions may not be extension functions. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.

--- a/compiler-tests/src/test/data/diagnostic/provides/ProvidesCannotHaveReceivers_Interface.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/provides/ProvidesCannotHaveReceivers_Interface.fir.diag.txt
@@ -1,3 +1,3 @@
-/ProvidesCannotHaveReceivers_Interface.kt:(108,118): error: `@Provides` properties may not be extension properties. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/ProvidesCannotHaveReceivers_Interface.kt:(108,118): error: `@Provides` properties may not be extension properties. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.
 
-/ProvidesCannotHaveReceivers_Interface.kt:(182,195): error: `@Provides` functions may not be extension functions. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/ProvidesCannotHaveReceivers_Interface.kt:(182,195): error: `@Provides` functions may not be extension functions. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.

--- a/compiler-tests/src/test/data/diagnostic/provides/ProvidesWithExtensionsAndNonThisReturningBodiesShouldError.fir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/provides/ProvidesWithExtensionsAndNonThisReturningBodiesShouldError.fir.diag.txt
@@ -1,3 +1,3 @@
-/ProvidesWithExtensionsAndNonThisReturningBodiesShouldError.kt:(115,134): error: `@Provides` properties may not be extension properties. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/ProvidesWithExtensionsAndNonThisReturningBodiesShouldError.kt:(115,134): error: `@Provides` properties may not be extension properties. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.
 
-/ProvidesWithExtensionsAndNonThisReturningBodiesShouldError.kt:(185,198): error: `@Provides` functions may not be extension functions. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+/ProvidesWithExtensionsAndNonThisReturningBodiesShouldError.kt:(185,198): error: `@Provides` functions may not be extension functions. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/MetroDiagnostics.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/MetroDiagnostics.kt
@@ -208,7 +208,7 @@ private object FirMetroErrorMessages : BaseDiagnosticRendererFactory() {
         )
         put(
           DAGGER_REUSABLE_ERROR,
-          "Dagger's `@Reusable` is not supported in Metro. See https://zacsweers.github.io/metro/faq#why-doesnt-metro-support-reusable for more information.",
+          "Dagger's `@Reusable` is not supported in Metro. See https://zacsweers.github.io/metro/latest/faq#why-doesnt-metro-support-reusable for more information.",
         )
 
         // IR errors

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/BindingContainerCallableChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/BindingContainerCallableChecker.kt
@@ -272,14 +272,14 @@ internal object BindingContainerCallableChecker :
           reporter.reportOn(
             source,
             MetroDiagnostics.PROVIDES_COULD_BE_BINDS,
-            "`@Provides` extension $name just returning `this` should be annotated with `@Binds` instead for these. See https://zacsweers.github.io/metro/bindings/#binds for more information.",
+            "`@Provides` extension $name just returning `this` should be annotated with `@Binds` instead for these. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.",
           )
           return
         } else if (!returnsThis && annotations.isBinds) {
           reporter.reportOn(
             source,
             MetroDiagnostics.BINDS_ERROR,
-            "`@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/bindings/#binds for more information.",
+            "`@Binds` declarations with bodies should just return `this`. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.",
           )
           return
         }
@@ -288,7 +288,7 @@ internal object BindingContainerCallableChecker :
           reporter.reportOn(
             source,
             MetroDiagnostics.PROVIDES_ERROR,
-            "`@Provides` $name may not be extension $name. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/bindings/#binds for more information.",
+            "`@Provides` $name may not be extension $name. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.",
           )
           return
         }

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/BindingContainerTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/BindingContainerTransformerTest.kt
@@ -330,7 +330,7 @@ class BindingContainerTransformerTest : MetroCompilerTest() {
 
     result.assertDiagnostics(
       """
-        e: ExampleGraph.kt:9:22 `@Provides` functions may not be extension functions. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/bindings/#binds for more information.
+        e: ExampleGraph.kt:9:22 `@Provides` functions may not be extension functions. Use `@Binds` instead for these. See https://zacsweers.github.io/metro/latest/bindings/#binds for more information.
       """
         .trimIndent()
     )

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/InjectConstructorTransformerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/InjectConstructorTransformerTest.kt
@@ -354,7 +354,7 @@ class InjectConstructorTransformerTest : MetroCompilerTest() {
     ) {
       assertDiagnostics(
         """
-          e: MyClass.kt:8:1 Dagger's `@Reusable` is not supported in Metro. See https://zacsweers.github.io/metro/faq#why-doesnt-metro-support-reusable for more information.
+          e: MyClass.kt:8:1 Dagger's `@Reusable` is not supported in Metro. See https://zacsweers.github.io/metro/latest/faq#why-doesnt-metro-support-reusable for more information.
         """
           .trimIndent()
       )

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/AssistedFactory.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/AssistedFactory.kt
@@ -62,8 +62,8 @@ package dev.zacsweers.metro
  *
  * @see Assisted
  * @see Inject
- * @see <a href="https://zacsweers.github.io/metro/installation/#ide-support">Docs for how to enable
- *   IDE support</a>
+ * @see <a href="https://zacsweers.github.io/metro/latest/installation/#ide-support">Docs for how to
+ *   enable IDE support</a>
  */
 @MustBeDocumented
 @Retention(AnnotationRetention.RUNTIME)

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/DependencyGraph.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/DependencyGraph.kt
@@ -183,7 +183,7 @@ public annotation class DependencyGraph(
    * ## Using generated declarations directly
    *
    * If you
-   * [enable third party FIR plugins in the IDE](https://zacsweers.github.io/metro/installation/#ide-support),
+   * [enable third party FIR plugins in the IDE](https://zacsweers.github.io/metro/latest/installation/#ide-support),
    * these will be visible and directly linkable. However, your mileage may vary and it's
    * recommended to stick with the graph creator intrinsics for now until the IDE support is
    * improved.

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/Inject.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/Inject.kt
@@ -267,8 +267,8 @@ package dev.zacsweers.metro
  * }
  * ```
  *
- * @see <a href="https://zacsweers.github.io/metro/installation/#ide-support">Docs for how to enable
- *   IDE support</a>
+ * @see <a href="https://zacsweers.github.io/metro/latest/installation/#ide-support">Docs for how to
+ *   enable IDE support</a>
  */
 @Target(
   AnnotationTarget.CLASS,

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/asContribution.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/asContribution.kt
@@ -15,8 +15,8 @@ package dev.zacsweers.metro
  * function as their generated class is definitionally contextual and the compiler cannot infer that
  * from callsites of this function alone.
  *
- * @see <a href="https://zacsweers.github.io/metro/installation/#ide-support">Docs for how to enable
- *   IDE support</a>
+ * @see <a href="https://zacsweers.github.io/metro/latest/installation/#ide-support">Docs for how to
+ *   enable IDE support</a>
  */
 @Suppress("UnusedReceiverParameter")
 public inline fun <reified T : Any> Any.asContribution(): T {

--- a/samples/circuit-app/README.md
+++ b/samples/circuit-app/README.md
@@ -7,7 +7,7 @@ This is a sample that demonstrates using Metro with [Circuit](https://github.com
 - Compose
 - Multiplatform
 - Uses Circuit (KSP) code gen + demonstrates multiplatform integration with it
-- Top-level composable function injection (requires enabling [IDE support](https://zacsweers.github.io/metro/installation/#ide-support))
+- Top-level composable function injection (requires enabling [IDE support](https://zacsweers.github.io/metro/latest/installation/#ide-support))
 
 Note that KSP's support for generating common code is slightly broken, so this uses the workaround described [here](https://github.com/google/ksp/issues/567#issuecomment-2609469736).
 


### PR DESCRIPTION
## Summary
Uses versioned site's `latest` alias to point user to the page intended to. Otherwise, page will redirect to metro home page.

This is similar fix to https://github.com/ZacSweers/metro/pull/1033 

🛑 However, https://github.com/ZacSweers/metro/pull/1062 must be **merged first** to fix the URL format.

> ℹ️ Also note, until `0.6.7` is released, the URL format for `latest` won't be fixed. Snapshot will work. 
> I can manually fix `0.6.6` if this is really desired ^_^