### PR TITLE
Ensure graph extension classes implement contributed interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 - **Enhancement**: Simplify assisted factory impl class generation by moving it entirely to IR.
 - **Fix**: Register `MetroDiagnostics` in FIR.
 - **Fix**: When transforming FIR override statuses, check all supertypes and not just immediate supertype.
+  **Fix:** Ensure graph extension classes implement contributed interfaces. Previously, only instances of an extension would implement the contributed interfaces.
 
 0.6.6
 -----

--- a/compiler-tests/src/test/data/box/contributesgraphextension/WithContributedAccessorInterface.kt
+++ b/compiler-tests/src/test/data/box/contributesgraphextension/WithContributedAccessorInterface.kt
@@ -1,0 +1,49 @@
+// https://github.com/ZacSweers/metro/issues/1074
+// Use-case: ensure that the graph extension class has its supertypes updated with contributed
+// accessor interfaces, not just the implementation used under the hood.
+// MODULE: lib
+package test
+
+abstract class ChildScope
+
+@GraphExtension(ChildScope::class)
+interface ChildGraph {
+
+  @GraphExtension.Factory
+  @ContributesTo(AppScope::class)
+  interface Factory {
+    fun createChild(): ChildGraph
+  }
+}
+
+@ContributesTo(ChildScope::class)
+interface FooProvider {
+  val foo: Foo
+}
+
+interface Foo
+
+// MODULE: main(lib)
+package test
+
+@DependencyGraph(AppScope::class)
+interface AppGraph
+
+@Inject
+@ContributesBinding(ChildScope::class)
+class RealFoo : Foo
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+
+  assertTrue(ChildGraph::class.java.interfaces.isNotEmpty())
+  // We should be able to find the factory method by any contributed interface
+  val factoryMethod = graph.javaClass.methods.find {
+    FooProvider::class.java.isAssignableFrom(it.returnType)
+  }
+  assertNotNull(factoryMethod)
+  assertEquals(ChildGraph::class.java, factoryMethod.returnType)
+  val childGraph = factoryMethod.invoke(graph) as FooProvider
+  assertTrue(childGraph.foo is RealFoo)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -326,6 +326,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("WithContributedAccessorInterface.kt")
+    public void testWithContributedAccessorInterface() {
+      runTest("compiler-tests/src/test/data/box/contributesgraphextension/WithContributedAccessorInterface.kt");
+    }
+
+    @Test
     @TestMetadata("WithContributesBinding.kt")
     public void testWithContributesBinding() {
       runTest("compiler-tests/src/test/data/box/contributesgraphextension/WithContributesBinding.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/ExtensionPredicates.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/ExtensionPredicates.kt
@@ -26,9 +26,12 @@ internal class ExtensionPredicates(private val classIds: ClassIds) {
 
   internal val bindingContainerPredicate =
     annotated(classIds.bindingContainerAnnotations.asFqNames())
-  internal val originPredicate =
-    annotated(classIds.originAnnotations.asFqNames())
+  internal val originPredicate = annotated(classIds.originAnnotations.asFqNames())
   internal val dependencyGraphPredicate = annotated(classIds.dependencyGraphAnnotations.asFqNames())
+  internal val dependencyGraphAndExtensionPredicate =
+    annotated(
+      (classIds.dependencyGraphAnnotations + classIds.graphExtensionAnnotations).asFqNames()
+    )
   internal val graphExtensionFactoryPredicate =
     annotated(classIds.graphExtensionFactoryAnnotations.asFqNames())
 


### PR DESCRIPTION
- Previously, only instances of an extension would implement the contributed interfaces.
- This is mostly important for use-cases where reflection is used to compare graph methods's return types against contributed types.
- As a more concrete example: imagine you have multiple apps that each define their own graph and graph extensions for the same scopes, like graph A and extension B. Then you have various feature modules that contribute interfaces to B's scope. The feature modules do not know about B directly, but can look up factory methods where the contributed interface is assignable from the method return type (B) in order to call and create the extension.
- Fixes #1074