### PR TITLE
Align return types for Metro graph factories with Dagger

### DIFF
--- a/compiler-tests/src/test/data/box/contributesgraphextension/ChildGraphIsUsedAsReturnType.kt
+++ b/compiler-tests/src/test/data/box/contributesgraphextension/ChildGraphIsUsedAsReturnType.kt
@@ -1,0 +1,44 @@
+// MODULE: lib
+@GraphExtension(String::class)
+interface ChildGraph {
+  @GraphExtension.Factory @ContributesTo(AppScope::class)
+  fun interface Factory {
+    fun create(): ChildGraph
+  }
+}
+
+// MODULE: main(lib)
+// WITH_REFLECT
+// ENABLE_GRAPH_IMPL_CLASS_AS_RETURN_TYPE
+
+import kotlin.reflect.full.functions
+import kotlin.reflect.jvm.javaType
+
+@DependencyGraph(AppScope::class)
+interface AppGraph
+
+fun box(): String {
+  val parentGraph = createGraph<AppGraph>()
+  val generatedMetroGraphClass = parentGraph.javaClass.classes.single { it.simpleName == "ChildGraphImpl" }
+
+  // In IR we change the return type of the implemented create() function from ChildGraph to
+  // ParentGraph$$$MetroGraph.ChildGraphImpl. The Kotlin compiler creates two functions in
+  // the generated class file, but in IR only one is visible:
+  //
+  // public final fun create(..): ParentGraph$$$MetroGraph.ChildGraphImpl
+  // public fun create(..): ChildGraph
+  //
+  // Because one of the two functions only exist in Java bytecode, we can only see it through
+  // Java reflection and not Kotlin reflection.
+  val javaFunctions = parentGraph.javaClass.methods.filter { it.name == "create" }
+  assertEquals(2, javaFunctions.size)
+
+  assertTrue(generatedMetroGraphClass.isInstance(javaFunctions.single { it.returnType == Class.forName("ChildGraph") }.invoke(parentGraph)))
+  assertTrue(generatedMetroGraphClass.isInstance(javaFunctions.single { it.returnType == generatedMetroGraphClass }.invoke(parentGraph)))
+
+  val kotlinFunction = parentGraph::class.functions.single { it.name == "create" }
+  assertTrue(generatedMetroGraphClass.isInstance(kotlinFunction.call(parentGraph)))
+  assertEquals(Class.forName("ChildGraph"), kotlinFunction.returnType.javaType)
+
+  return "OK"
+}

--- a/compiler-tests/src/test/data/dump/ir/dependencygraph/GraphImplClassAsReturnType.fir.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/dependencygraph/GraphImplClassAsReturnType.fir.kt.txt
@@ -1,0 +1,69 @@
+// FILE: GraphImplClassAsReturnType.kt
+
+@DependencyGraph(scope = AppScope::class)
+interface AppGraph : $$MetroContributionToAppScope {
+  companion object Companion {
+    private constructor() /* primary */ {
+      super/*Any*/()
+      /* <init>() */
+
+    }
+
+    @GraphFactoryInvokeFunctionMarker
+    operator fun invoke(): AppGraph {
+      return $$MetroGraph()
+    }
+
+  }
+
+  @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+  class $$MetroGraph : AppGraph {
+    private /* final field */ val thisGraphInstance: AppGraph = <this>
+    private /* final field */ val appGraphProvider: Provider<AppGraph> = Companion.invoke<AppGraph>(value = <this>.#thisGraphInstance)
+    @DependencyGraph(scope = String::class)
+    inner class ChildGraphImpl : ChildGraph {
+      constructor() /* primary */ {
+        super/*Any*/()
+        /* <init>() */
+
+      }
+
+    }
+
+    private constructor() /* primary */ {
+      super/*Any*/()
+      /* <init>() */
+
+    }
+
+    override fun create(): ChildGraphImpl {
+      return <this>.ChildGraphImpl()
+    }
+
+  }
+
+}
+
+@GraphExtension(scope = String::class)
+interface ChildGraph {
+  @Factory
+  @ContributesTo(scope = AppScope::class)
+  fun interface Factory {
+    @Deprecated(message = "This synthesized declaration should not be used directly", level = DeprecationLevel.HIDDEN)
+    @MetroContribution(scope = AppScope::class)
+    interface $$MetroContributionToAppScope : Factory {
+    }
+
+    abstract fun create(): ChildGraph
+
+  }
+
+}
+
+// FILE: childGraphFactoryAppScope.kt
+package metro.hints
+
+fun AppScope(contributed: Factory) {
+  return error(message = "Never called")
+}
+

--- a/compiler-tests/src/test/data/dump/ir/dependencygraph/GraphImplClassAsReturnType.kt
+++ b/compiler-tests/src/test/data/dump/ir/dependencygraph/GraphImplClassAsReturnType.kt
@@ -1,0 +1,11 @@
+// ENABLE_GRAPH_IMPL_CLASS_AS_RETURN_TYPE
+@GraphExtension(String::class)
+interface ChildGraph {
+  @GraphExtension.Factory @ContributesTo(AppScope::class)
+  fun interface Factory {
+    fun create(): ChildGraph
+  }
+}
+
+@DependencyGraph(AppScope::class)
+interface AppGraph

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -278,6 +278,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("ChildGraphIsUsedAsReturnType.kt")
+    public void testChildGraphIsUsedAsReturnType() {
+      runTest("compiler-tests/src/test/data/box/contributesgraphextension/ChildGraphIsUsedAsReturnType.kt");
+    }
+
+    @Test
     @TestMetadata("ContributedFactoryIsAvailableAsBinding.kt")
     public void testContributedFactoryIsAvailableAsBinding() {
       runTest("compiler-tests/src/test/data/box/contributesgraphextension/ContributedFactoryIsAvailableAsBinding.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrDumpTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrDumpTestGenerated.java
@@ -118,6 +118,12 @@ public class IrDumpTestGenerated extends AbstractIrDumpTest {
     }
 
     @Test
+    @TestMetadata("GraphImplClassAsReturnType.kt")
+    public void testGraphImplClassAsReturnType() {
+      runTest("compiler-tests/src/test/data/dump/ir/dependencygraph/GraphImplClassAsReturnType.kt");
+    }
+
+    @Test
     @TestMetadata("InitsAreChunked.kt")
     public void testInitsAreChunked() {
       runTest("compiler-tests/src/test/data/dump/ir/dependencygraph/InitsAreChunked.kt");

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroDirectives.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroDirectives.kt
@@ -30,6 +30,10 @@ object MetroDirectives : SimpleDirectivesContainer() {
     directive(
       "Enable/disable full binding graph validation of binds and provides declarations even if they are unused."
     )
+  val ENABLE_GRAPH_IMPL_CLASS_AS_RETURN_TYPE by
+    directive(
+      "If true changes the return type of generated Graph Factories from the declared interface type to the generated Metro graph type. This is helpful for Dagger/Anvil interop."
+    )
 
   // Dependency directives.
   val WITH_ANVIL by directive("Add Anvil as dependency and configure custom annotations.")

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroExtensionRegistrarConfigurator.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroExtensionRegistrarConfigurator.kt
@@ -69,6 +69,8 @@ class MetroExtensionRegistrarConfigurator(testServices: TestServices) :
             ?: optionDefaults.chunkFieldInits,
         enableFullBindingGraphValidation =
           MetroDirectives.ENABLE_FULL_BINDING_GRAPH_VALIDATION in module.directives,
+        enableGraphImplClassAsReturnType =
+          MetroDirectives.ENABLE_GRAPH_IMPL_CLASS_AS_RETURN_TYPE in module.directives,
         generateJvmContributionHintsInFir =
           MetroDirectives.GENERATE_JVM_CONTRIBUTION_HINTS_IN_FIR in module.directives,
         publicProviderSeverity =

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
@@ -490,6 +490,17 @@ internal enum class MetroOption(val raw: RawMetroOption<*>) {
       allowMultipleOccurrences = false,
     )
   ),
+  ENABLE_GRAPH_IMPL_CLASS_AS_RETURN_TYPE(
+    RawMetroOption.boolean(
+      name = "enable-graph-impl-class-as-return-type",
+      defaultValue = false,
+      valueDescription = "<true | false>",
+      description =
+        "If true changes the return type of generated Graph Factories from the declared interface type to the generated Metro graph type. This is helpful for Dagger/Anvil interop.",
+      required = false,
+      allowMultipleOccurrences = false,
+    )
+  ),
   CUSTOM_ORIGIN(
     RawMetroOption(
       name = "custom-origin",
@@ -598,6 +609,8 @@ public data class MetroOptions(
     MetroOption.ENABLE_DAGGER_ANVIL_INTEROP.raw.defaultValue.expectAs(),
   val enableFullBindingGraphValidation: Boolean =
     MetroOption.ENABLE_FULL_BINDING_GRAPH_VALIDATION.raw.defaultValue.expectAs(),
+  val enableGraphImplClassAsReturnType: Boolean =
+    MetroOption.ENABLE_GRAPH_IMPL_CLASS_AS_RETURN_TYPE.raw.defaultValue.expectAs(),
   val customOriginAnnotations: Set<ClassId> =
     MetroOption.CUSTOM_ORIGIN.raw.defaultValue.expectAs(),
 ) {
@@ -750,6 +763,9 @@ public data class MetroOptions(
           }
           MetroOption.ENABLE_FULL_BINDING_GRAPH_VALIDATION -> {
             options = options.copy(enableFullBindingGraphValidation = configuration.getAsBoolean(entry))
+          }
+          MetroOption.ENABLE_GRAPH_IMPL_CLASS_AS_RETURN_TYPE -> {
+            options = options.copy(enableGraphImplClassAsReturnType = configuration.getAsBoolean(entry))
           }
           MetroOption.CUSTOM_ORIGIN ->
             customOriginAnnotations.addAll(configuration.getAsSet(entry))

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrGraphExpressionGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrGraphExpressionGenerator.kt
@@ -279,6 +279,12 @@ private constructor(
               parentTracer,
             )
 
+          if (options.enableGraphImplClassAsReturnType) {
+            // This is probably not the right spot to change the return type, but the IrClass
+            // implementation is not exposed otherwise.
+            binding.accessor.returnType = extensionImpl.defaultType
+          }
+
           val ctor = extensionImpl.primaryConstructor!!
           val instanceExpression =
             irCallConstructor(ctor.symbol, node.sourceGraph.typeParameters.map { it.defaultType })

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/MetroCompilerTest.kt
@@ -256,6 +256,9 @@ abstract class MetroCompilerTest {
               MetroOption.ENABLE_FULL_BINDING_GRAPH_VALIDATION -> {
                 processor.option(entry.raw.cliOption, enableFullBindingGraphValidation)
               }
+              MetroOption.ENABLE_GRAPH_IMPL_CLASS_AS_RETURN_TYPE -> {
+                processor.option(entry.raw.cliOption, enableGraphImplClassAsReturnType)
+              }
             }
           yield(option)
         }

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -27,6 +27,7 @@ public abstract class dev/zacsweers/metro/gradle/MetroPluginExtension {
 	public final fun getChunkFieldInits ()Lorg/gradle/api/provider/Property;
 	public final fun getDebug ()Lorg/gradle/api/provider/Property;
 	public final fun getEnableFullBindingGraphValidation ()Lorg/gradle/api/provider/Property;
+	public final fun getEnableGraphImplClassAsReturnType ()Lorg/gradle/api/provider/Property;
 	public final fun getEnableKotlinVersionCompatibilityChecks ()Lorg/gradle/api/provider/Property;
 	public final fun getEnableScopedInjectClassHints ()Lorg/gradle/api/provider/Property;
 	public final fun getEnableStrictValidation ()Lorg/gradle/api/provider/Property;

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
@@ -138,6 +138,12 @@ public class MetroGradleSubplugin : KotlinCompilerPluginSupportPlugin {
             extension.enableFullBindingGraphValidation.orElse(extension.enableStrictValidation),
           )
         )
+        add(
+          lazyOption(
+            "enable-graph-impl-class-as-return-type",
+            extension.enableGraphImplClassAsReturnType.orElse(false),
+          )
+        )
         add(lazyOption("transform-providers-to-private", extension.transformProvidersToPrivate))
         add(lazyOption("shrink-unused-bindings", extension.shrinkUnusedBindings))
         add(lazyOption("chunk-field-inits", extension.chunkFieldInits))

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
@@ -81,6 +81,13 @@ constructor(layout: ProjectLayout, objects: ObjectFactory, providers: ProviderFa
   public val enableFullBindingGraphValidation: Property<Boolean> =
     objects.property(Boolean::class.javaObjectType).convention(false)
 
+  /**
+   * If true changes the return type of generated Graph Factories from the declared interface
+   * type to the generated Metro graph type. This is helpful for Dagger/Anvil interop.
+   */
+  public val enableGraphImplClassAsReturnType: Property<Boolean> =
+    objects.property(Boolean::class.javaObjectType).convention(false)
+
   @Deprecated(
     "Use enableFullBindingGraphValidation",
     ReplaceWith("enableFullBindingGraphValidation"),


### PR DESCRIPTION
Change the return type of generated factory functions for graphs and graph extensions from the interface type to the concrete generated class types. This behavior is aligned with Dagger.

See #1079