### PR TITLE
fixed (potentially): `gh-pages` re-synched to workaround concurrent commit

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -136,6 +136,12 @@ jobs:
           rm -rf /tmp/docs-site-validation
           echo "Docs validation completed successfully"
 
+      - name: Re-sync gh-pages branch before deployment
+        run: |
+          # Safely update local gh-pages to match remote state to avoid push conflicts
+          git fetch origin gh-pages
+          git update-ref refs/heads/gh-pages origin/gh-pages
+
       - name: Deploy SNAPSHOT Docs with mike
         if: ${{ success() && contains(steps.version.outputs.METRO_VERSION, 'SNAPSHOT') }}
         run: mike deploy --update-aliases --push ${{ steps.version.outputs.METRO_VERSION }} snapshot


### PR DESCRIPTION
It seems like on rare-occassion, the right after release the `main` branch commit can make commit on `gh-pages` before the release tag workflow finishes.

For example the `0.6.8` release task:
* https://github.com/ZacSweers/metro/actions/runs/18047435530/job/51361485231

This should ideally fix the issue with outdated branch before `mike` deployment