### PR TITLE
Failing test for a StackOverflowError in a soft cycle

### DIFF
--- a/compiler-tests/src/test/data/box/cycles/SoftCycleWithReplace.kt
+++ b/compiler-tests/src/test/data/box/cycles/SoftCycleWithReplace.kt
@@ -1,0 +1,57 @@
+// MembershipRepo
+interface MembershipRepo
+
+@ContributesBinding(AppScope::class)
+@Inject
+class RealMembershipRepo(
+  remoteConfig: Lazy<RemoteConfig>,
+) : MembershipRepo {
+  val hash = remoteConfig.value.hashCode()
+}
+
+@ContributesBinding(AppScope::class, replaces = [RealMembershipRepo::class])
+@Inject
+class FakeMembershipRepo(
+  real: RealMembershipRepo,
+  remoteConfig: Lazy<RemoteConfig>,
+) : MembershipRepo {
+  val hash = real.hashCode() + remoteConfig.value.hashCode()
+}
+
+// Remote Config
+interface RemoteConfig
+
+@ContributesBinding(AppScope::class, binding = binding<@Named("source_remote_config") RemoteConfig>())
+@Inject
+class CombinedRemoteConfig(
+  private val amplitudeRemoteConfig: Lazy<AmplitudeRemoteConfig>,
+) : RemoteConfig {
+  val hash = amplitudeRemoteConfig.value.hashCode()
+}
+
+@ContributesBinding(AppScope::class)
+@Inject
+class OverridableRemoteConfig(
+  @Named("source_remote_config") private val remoteConfig: RemoteConfig,
+) : RemoteConfig {
+  val hash = remoteConfig.hashCode()
+}
+
+@Inject
+class AmplitudeRemoteConfig(
+  private val remoteConfig: RemoteConfig,
+  private val membershipRepo: MembershipRepo,
+) : RemoteConfig {
+  val hash = remoteConfig.hashCode() + membershipRepo.hashCode()
+}
+
+@DependencyGraph(AppScope::class)
+interface CycleGraph {
+  val membershipRepo: MembershipRepo
+}
+
+fun box(): String {
+  val cycleGraph = createGraph<CycleGraph>()
+  assertNotNull(cycleGraph.membershipRepo)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -400,6 +400,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     public void testSmokeTest() {
       runTest("compiler-tests/src/test/data/box/cycles/SmokeTest.kt");
     }
+
+    @Test
+    @TestMetadata("SoftCycleWithReplace.kt")
+    public void testSoftCycleWithReplace() {
+      runTest("compiler-tests/src/test/data/box/cycles/SoftCycleWithReplace.kt");
+    }
   }
 
   @Nested


### PR DESCRIPTION
The test failed with this error
```
java.lang.StackOverflowError
	at CombinedRemoteConfig$$$MetroFactory.invoke(SoftCycleWithReplace.kt:26)
	at CombinedRemoteConfig$$$MetroFactory.invoke(SoftCycleWithReplace.kt:26)
	at dev.zacsweers.metro.internal.DelegateFactory.invoke(DelegateFactory.kt:25)
	at OverridableRemoteConfig$$$MetroFactory.invoke(SoftCycleWithReplace.kt:34)
	at OverridableRemoteConfig$$$MetroFactory.invoke(SoftCycleWithReplace.kt:34)
	at AmplitudeRemoteConfig$$$MetroFactory.invoke(SoftCycleWithReplace.kt:42)
	at AmplitudeRemoteConfig$$$MetroFactory.invoke(SoftCycleWithReplace.kt:42)
	at dev.zacsweers.metro.internal.BaseDoubleCheck.getValue(BaseDoubleCheck.kt:53)
	at CombinedRemoteConfig.<init>(SoftCycleWithReplace.kt:31)
	at CombinedRemoteConfig$$$MetroFactory$Companion.newInstance(SoftCycleWithReplace.kt:26)
```