### PR TITLE
Fix typo in docs of `OptionalDependencyBehavior`

### DIFF
--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/OptionalDependencyBehavior.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/OptionalDependencyBehavior.kt
@@ -19,7 +19,7 @@ public enum class OptionalDependencyBehavior {
   DEFAULT,
 
   /**
-   * In this mode, all optional dependencies must by annotated with `@OptionalDependency` (in both
+   * In this mode, all optional dependencies must be annotated with `@OptionalDependency` (in both
    * graph accessors as well as injected parameters). This can be desirable for consistency with
    * accessors and/or to otherwise make the behavior more explicit.
    */


### PR DESCRIPTION
This PR fixes a small typo in the Kdoc of `OptionalDependencyBehavior.REQUIRE_OPTIONAL_DEPENDENCY`.