### PR TITLE
Add a fallback to testCompilerVersionProvider

### DIFF
--- a/compiler-tests/build.gradle.kts
+++ b/compiler-tests/build.gradle.kts
@@ -13,10 +13,9 @@ sourceSets {
   register("generator230")
 }
 
-val testCompilerVersionProvider =
-  providers.gradleProperty("metro.testCompilerVersion").orElse(libs.versions.kotlin)
+val testCompilerVersionProvider = providers.gradleProperty("metro.testCompilerVersion")
 
-val testCompilerVersion = testCompilerVersionProvider.get()
+val testCompilerVersion = testCompilerVersionProvider.orElse(libs.versions.kotlin).get()
 
 val kotlinVersion =
   testCompilerVersion.substringBefore('-').split('.').let { (major, minor, patch) ->
@@ -113,7 +112,7 @@ val generateTests =
       .withPropertyName("testData")
       .withPathSensitivity(PathSensitivity.RELATIVE)
 
-    inputs.property("testCompilerVersion", testCompilerVersionProvider)
+    inputs.property("testCompilerVersion", testCompilerVersionProvider.orNull)
 
     outputs.dir(layout.projectDirectory.dir("src/test/java")).withPropertyName("generatedTests")
 


### PR DESCRIPTION
Gradle task `generateTests` stopped working after https://github.com/ZacSweers/metro/commit/8815ef410bae22bc223a431c3462d3325f638b7b