### PR TITLE
chore: remove reference to non-existent samples/multi-module-test

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -14,12 +14,6 @@ A multiplatform sample that demonstrates using Metro with [Circuit](https://gith
 
 Various demonstrating interop between Metro and other dependency injection frameworks.
 
-## [multi-module-test](https://github.com/ZacSweers/metro/tree/main/samples/multi-module-test)
-
-A sample + integration test demonstrating Metro in a multi-module project structure with.
-
-This sample shows how Metro handles dependencies across module boundaries and component hierarchies.
-
 ## [weather-app](https://github.com/ZacSweers/metro/tree/main/samples/weather-app)
 
 A simple command-line weather app that demonstrates basic Metro usage.


### PR DESCRIPTION
## Summary
Despite original PR https://github.com/ZacSweers/metro/pull/311 adding this reference, it never existed it seems! 🤷🏽‍♂️ 
Removed it as it is giving 404


https://zacsweers.github.io/metro/latest/samples/

<img width="1050" height="322" alt="Screenshot 2025-10-23 at 11 38 37 PM" src="https://github.com/user-attachments/assets/c6bbd51c-4bbd-4948-9cb9-976676ffa44a" />

<!--
  STOP AND READ!

  Couple small asks to help with review 🥺
  - Please write a description (however long or short as necessary.)
  - If you are showing me AI-generated output (code or otherwise), please be upfront about it, indicate what parts, and de-fluff _before_ opening the PR.
-->
