### PR TITLE
Add missing syntax highlighting

### DIFF
--- a/docs/dependency-graphs.md
+++ b/docs/dependency-graphs.md
@@ -289,7 +289,7 @@ interface LoggedInGraph {
 
 In the `:app` module:
 
-```
+```kotlin
 @DependencyGraph(AppScope::class)
 interface AppGraph
 ```


### PR DESCRIPTION
This adds the missing code highlighting in the documentation. 

(I’ve read through all the documents, and everything is very clear. Thank you for providing such high-quality documentation.)