### PR TITLE
Pass the extras when creating view models

### DIFF
--- a/metrox-viewmodel-compose/src/commonMain/kotlin/dev/zacsweers/metrox/viewmodel/MetroViewModel.kt
+++ b/metrox-viewmodel-compose/src/commonMain/kotlin/dev/zacsweers/metrox/viewmodel/MetroViewModel.kt
@@ -52,6 +52,7 @@ public inline fun <reified VM : ViewModel> assistedMetroViewModel(
     viewModelStoreOwner = viewModelStoreOwner,
     key = key,
     factory = LocalMetroViewModelFactory.current,
+    extras = extras,
   )
 
 /**
@@ -86,6 +87,7 @@ public inline fun <
           return modelClass.cast(provider().createViewModel())
         }
       },
+    extras = extras,
   )
 }
 


### PR DESCRIPTION
`assistedMetroViewModel` was not passing the extras to `viewModel` so they never get passed to the view model factory.
