### PR TITLE
Fix mkdocs edit button to use `main` branch instead of `master`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@
 site_name: Metro
 repo_name: Metro
 repo_url: https://github.com/ZacSweers/metro
+edit_uri: edit/main/docs/
 site_url: https://zacsweers.github.io/metro/
 site_description: "A multiplatform dependency injection framework for Kotlin"
 site_author: Zac Sweers


### PR DESCRIPTION
<!--
  STOP AND READ!

  Couple small asks to help with review 🥺
  - Please write a description (however long or short as necessary.)
  - If you are showing me AI-generated output (code or otherwise), please be upfront about it, indicate what parts, and de-fluff _before_ opening the PR.
-->

## Summary
Edit and viewing now works! 🎉 

Fixes https://github.com/ZacSweers/metro/pull/1482#issuecomment-3621328781

> _ps. Nothing to do with `mike` this time!_ 😅 

![2025-12-06 18 05 30](https://github.com/user-attachments/assets/048f0d14-24a1-4db4-8317-14621f5470d0)


