### PR TITLE
Fix compiler compat dependency

### DIFF
--- a/compiler-compat/k2320_dev_5437/build.gradle.kts
+++ b/compiler-compat/k2320_dev_5437/build.gradle.kts
@@ -18,5 +18,5 @@ dependencies {
   compileOnly(kotlinVersion.map { "org.jetbrains.kotlin:kotlin-compiler:$it" })
   compileOnly(libs.kotlin.stdlib)
   api(project(":compiler-compat"))
-  implementation(project(":compiler-compat:k230_beta1"))
+  implementation(project(":compiler-compat:k230_Beta1"))
 }


### PR DESCRIPTION
I find this a little bit weird, dependencies are always case sensitive on my end 🤔 

The error I got on the latest main:
```
kevin@Kevins-MacBook-Pro-CMG metro % ./metrow publish --version 0.8.2-log --local
Publishing version 0.8.2-log locally...
Calculating task graph as configuration cache cannot be reused because file 'compiler-compat/k2320_dev_5437/build.gradle.kts' has changed.

[Incubating] Problems report is available at: file:///Users/kevin/Documents/metro/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/kevin/Documents/metro/compiler-compat/k2320_dev_5437/build.gradle.kts' line: 21

* What went wrong:
Project with path ':compiler-compat:k230_beta1' could not be found.
```