### PR TITLE
Remove duplicate in differences.md

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -9,7 +9,7 @@
     * There is no Hilt support, though some features are similar in the same way that Anvil’s features are similar.
     * There is no `@Reusable`.
     * There is no `@BindsOptionalOf`. Instead, Metro supports default [optional bindings](bindings.md#optional-bindings).
-        * Metro does does support [interop](interop.md) with Dagger's `@BindsOptionalOf` annotation.
+        * Metro does support [interop](interop.md) with Dagger's `@BindsOptionalOf` annotation.
     * Metro can inject private properties, functions, and constructors.
     * There is no `@BindsInstance` annotation. Use `@Provides` on `@DependencyGraph.Factory` function parameters instead.
     * Included dependencies ("component dependencies" in Dagger) must be annotated with `@Includes` in graph creators.


### PR DESCRIPTION
Removes duplicate words. No functional changes only cleanup to improve readability.