### PR TITLE
Don't suffix top-level-inject class names anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This release significantly improves the runtime performance of Metro-generated g
 
 - 🚀 Improves graph init runtime performance by **30–40%**
 - 🤏 Reduces generated graph code size by **60–70%** (even higher if you heavily use multibindings)
+- **Behavior change**: When using top-level function injection, the generated class now has the same name as the function. Previously it was suffixed with `Class`.
 - **New**: Experimental support for sharding large graphs. For extremely large dependency graphs on the JVM, their generated implementations could exceed the JVM class size limit. To avoid this, Metro now supports sharding within graphs (as needed) to distribute initialization code across multiple inner _shard_ classes. This is currently disabled by default but can be enabled via the `enableGraphSharding` Gradle DSL property.
 - **New**: Support `@Provides` properties with `@JvmField` annotations.
 - **Enhancement**: Avoid unnecessary intermediate `Provider` instance allocations during graph expression gen. This means that when a direct type is requested in code gen, Metro will skip instantiating the intermediate `MetroFactory` instance if possible, avoiding unnecessary allocations.

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/InjectedClassFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/InjectedClassFirGenerator.kt
@@ -3,7 +3,6 @@
 package dev.zacsweers.metro.compiler.fir.generators
 
 import dev.zacsweers.metro.compiler.NameAllocator
-import dev.zacsweers.metro.compiler.asName
 import dev.zacsweers.metro.compiler.capitalizeUS
 import dev.zacsweers.metro.compiler.compat.CompatContext
 import dev.zacsweers.metro.compiler.fir.Keys
@@ -103,10 +102,7 @@ internal class InjectedClassFirGenerator(session: FirSession, compatContext: Com
         .filterIsInstance<FirNamedFunctionSymbol>()
         .filter { it.callableId.classId == null }
         .associateBy {
-          ClassId(
-            it.callableId.packageName,
-            "${it.callableId.callableName.capitalizeUS()}Class".asName(),
-          )
+          ClassId(it.callableId.packageName, it.callableId.callableName.capitalizeUS())
         }
     }
 
@@ -123,9 +119,9 @@ internal class InjectedClassFirGenerator(session: FirSession, compatContext: Com
    * Will generate
    *
    * ```
-   * class AppClass @Inject constructor(private val message: String) {
+   * class AppClass @Inject constructor(private val message: Provider<String>) {
    *   operator fun invoke() {
-   *     App(message)
+   *     App(message())
    *   }
    * }
    * ```

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/TopLevelInjectTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/transformers/TopLevelInjectTest.kt
@@ -41,7 +41,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           interface ExampleGraph {
-            val app: AppClass
+            val app: App
           }
           """
             .trimIndent()
@@ -68,7 +68,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           interface ExampleGraph {
-            val app: AppClass
+            val app: App
           }
           """
             .trimIndent()
@@ -95,7 +95,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           interface ExampleGraph {
-            val app: AppClass
+            val app: App
 
             @DependencyGraph.Factory
             fun interface Factory {
@@ -127,7 +127,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           interface ExampleGraph {
-            val app: AppClass
+            val app: App
 
             @DependencyGraph.Factory
             fun interface Factory {
@@ -159,7 +159,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           abstract class ExampleGraph {
-            abstract val app: AppClass
+            abstract val app: App
 
             private var count: Int = 0
 
@@ -194,7 +194,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           abstract class ExampleGraph {
-            abstract val app: AppClass
+            abstract val app: App
 
             private var count: Int = 0
 
@@ -233,7 +233,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           abstract class ExampleGraph {
-            abstract val app: AppClass
+            abstract val app: App
 
             private var count: Int = 0
 
@@ -271,7 +271,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           interface ExampleGraph {
-            val app: AppClass
+            val app: App
 
             @Named("int") @Provides private fun provideInt(): Int {
               return 0
@@ -303,7 +303,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           interface ExampleGraph {
-            @Named("app") val app: AppClass
+            @Named("app") val app: App
 
             @Provides private fun provideInt(): Int {
               return 0
@@ -334,7 +334,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           interface ExampleGraph {
-            val app: AppClass
+            val app: App
 
             @Provides val provideInt: Int get() = 2
             @Provides val provideLong: Long get() = 3
@@ -370,7 +370,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
               @DependencyGraph
               interface ExampleGraph {
-                val app: AppClass
+                val app: App
               }
               """
                 .trimIndent()
@@ -418,7 +418,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
               @DependencyGraph
               interface ExampleGraph {
-                val app: AppClass
+                val app: App
 
                 @Provides fun provideClock(): Clock = object : Clock {}
                 @Provides fun provideUiComponent(): MyUiComponentClass = object : MyUiComponentClass {}
@@ -472,7 +472,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
               @DependencyGraph
               interface ExampleGraph {
-                val app: AppClass
+                val app: App
 
                 @Provides fun provideClock(): Clock = object : Clock {}
                 @Provides fun provideUiComponent(): MyUiComponentClass = object : MyUiComponentClass {}
@@ -528,7 +528,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
               @DependencyGraph
               interface ExampleGraph {
-                val app: AppClass
+                val app: App
 
                 @Provides fun provideClock(): Clock = object : Clock {}
                 @Provides fun provideUiComponent(): MyUiComponentClass = object : MyUiComponentClass {}
@@ -576,7 +576,7 @@ class TopLevelInjectTest : MetroCompilerTest() {
 
           @DependencyGraph
           interface ExampleGraph {
-            val app: AppClass
+            val app: App
 
             @Provides private fun provideDeferred(): Deferred<String> {
               return CompletableDeferred("Hello, world!")


### PR DESCRIPTION
Essentially resolves #1502 along the way