### PR TITLE
Don't apply replaces effect from excluded contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This release significantly improves the runtime performance of Metro-generated g
 - **Fix**: Allow `Any` to be a `binding<...>()` type if no explicit supertypes are declared.
 - **Fix**: Mark `MembersInjected` bindings as deferrable in graph metadata reporting.
 - **Fix**: Use eager graphs for dominator tree analysis.
+- **Fix**: Don't apply `replaces` effect from excluded contributions (regular and binding containers).
 
 0.8.2
 -----

--- a/compiler-tests/src/test/data/box/aggregation/ExcludedBindingContainerReplacesEffectIgnored.kt
+++ b/compiler-tests/src/test/data/box/aggregation/ExcludedBindingContainerReplacesEffectIgnored.kt
@@ -1,0 +1,24 @@
+// When a binding container is excluded, its replaces annotation should have no effect.
+@DependencyGraph(AppScope::class, excludes = [IntBinding2::class])
+interface AppGraph {
+  val int: Int
+}
+
+@ContributesTo(AppScope::class)
+@BindingContainer
+object IntBinding1 {
+  @Provides fun provideInt(): Int = 1
+}
+
+@ContributesTo(AppScope::class, replaces = [IntBinding1::class])
+@BindingContainer
+object IntBinding2 {
+  @Provides fun provideInt(): Int = 2
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  // IntBinding2 is excluded, so its replaces=[IntBinding1] should have no effect
+  assertEquals(1, graph.int)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -98,6 +98,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("ExcludedBindingContainerReplacesEffectIgnored.kt")
+    public void testExcludedBindingContainerReplacesEffectIgnored() {
+      runTest("compiler-tests/src/test/data/box/aggregation/ExcludedBindingContainerReplacesEffectIgnored.kt");
+    }
+
+    @Test
     @TestMetadata("ExcludesWithOrigin.kt")
     public void testExcludesWithOrigin() {
       runTest("compiler-tests/src/test/data/box/aggregation/ExcludesWithOrigin.kt");


### PR DESCRIPTION
I've hit an issue (or at least I think) when I migrated our codebase to metro: When I exclude a `BindingContainer` that has a replaces annotation, I expect the replaces not having effect, but that is not the case.

With the help of AI I tried to solve this problem, the changes for me looks reasonable. I also did a bit of refactor by replacing sequence and collection operations with standard for loops to avoid allocation as much as possible.

Also added a test case that showcases the issue and which is solved by this change. If I missed something, or I interpret the expected behavior incorrectly, please close the PR!
