### PR TITLE
Fix excluded replaces effect in cross-module scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 **Unreleased**
 --------------
 
+- **Fix**: Don't apply `replaces` effect from excluded contributions in cross-module scenarios.
+
 0.9.1
 -----
 

--- a/compiler-tests/src/test/data/box/aggregation/ExcludedBindingContainerReplacesEffectIgnoredMultiModule.kt
+++ b/compiler-tests/src/test/data/box/aggregation/ExcludedBindingContainerReplacesEffectIgnoredMultiModule.kt
@@ -1,0 +1,33 @@
+// When a binding container from another module is excluded, its replaces annotation should have no effect.
+
+// MODULE: original
+// Contains the original binding container that provides Int = 1
+@ContributesTo(AppScope::class)
+@BindingContainer
+object OriginalIntBinding {
+  @Provides fun provideInt(): Int = 1
+}
+
+// MODULE: replacement(original)
+// Contains a replacement binding container that would provide Int = 2
+// This module depends on 'original' so it can reference OriginalIntBinding in replaces
+@ContributesTo(AppScope::class, replaces = [OriginalIntBinding::class])
+@BindingContainer
+object ReplacementIntBinding {
+  @Provides fun provideInt(): Int = 2
+}
+
+// MODULE: main(original, replacement)
+// The graph excludes ReplacementIntBinding, so OriginalIntBinding should still be used
+@DependencyGraph(AppScope::class, excludes = [ReplacementIntBinding::class])
+interface AppGraph {
+  val int: Int
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  // ReplacementIntBinding is excluded, so its replaces=[OriginalIntBinding] should have no effect
+  // OriginalIntBinding should still contribute, providing Int = 1
+  assertEquals(1, graph.int)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -104,6 +104,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("ExcludedBindingContainerReplacesEffectIgnoredMultiModule.kt")
+    public void testExcludedBindingContainerReplacesEffectIgnoredMultiModule() {
+      runTest("compiler-tests/src/test/data/box/aggregation/ExcludedBindingContainerReplacesEffectIgnoredMultiModule.kt");
+    }
+
+    @Test
     @TestMetadata("ExcludesWithOrigin.kt")
     public void testExcludesWithOrigin() {
       runTest("compiler-tests/src/test/data/box/aggregation/ExcludesWithOrigin.kt");


### PR DESCRIPTION
Follow-up to #1539. 

The previous fix only addressed same-module scenarios. Cross-module scenarios had a separate issue: IrContributionData.getScopedContributions() was processing replacements when gathering external contributions, before exclusions could be applied in IrContributionMerger.

Fix: Removed replacement processing from getScopedContributions(). All replacement logic now happens in IrContributionMerger.computeContributions() after exclusions are applied.

Added a multi-module test that fails without this fix and passes with it.