### PR TITLE
Fix rank-based binding replacements getting dropped for multi-contribution classes in root graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changelog
 
 ### Fixes
 
+- [FIR, Anvil Interop] Fix rank-based binding replacements getting dropped for multi-contribution classes in root graphs.
+
 0.9.2
 -----
 

--- a/compiler-tests/src/test/data/box/aggregation/interop/RankBasedReplacementFromClassWithMultipleBindingsInRootGraph.kt
+++ b/compiler-tests/src/test/data/box/aggregation/interop/RankBasedReplacementFromClassWithMultipleBindingsInRootGraph.kt
@@ -1,0 +1,34 @@
+// Similar to https://github.com/ZacSweers/metro/issues/1549 but for 'rank' processing in root
+// graphs
+// The important conditions in this test case:
+// - There is a class LowRankImpl with one or more bindings
+// - There is another class HighRankImpl with the same binding as LowRankImpl, at least one other
+// binding, and one of the bindings replaces LowRankImpl
+// - The bindings are contributed to the root graph
+
+// WITH_ANVIL
+// MODULE: lib
+import com.squareup.anvil.annotations.ContributesBinding
+
+interface ContributedInterface
+
+interface OtherInterface
+
+@ContributesBinding(AppScope::class, boundType = ContributedInterface::class)
+object LowRankImpl : ContributedInterface, OtherInterface
+
+@ContributesBinding(AppScope::class, boundType = OtherInterface::class)
+@ContributesBinding(AppScope::class, boundType = ContributedInterface::class, rank = 100)
+object HighRankImpl : ContributedInterface, OtherInterface
+
+// MODULE: main(lib)
+@DependencyGraph(AppScope::class)
+interface AppGraph {
+  val contributedInterface: ContributedInterface
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertTrue(graph.contributedInterface == HighRankImpl)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -233,6 +233,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("RankBasedReplacementFromClassWithMultipleBindingsInRootGraph.kt")
+      public void testRankBasedReplacementFromClassWithMultipleBindingsInRootGraph() {
+        runTest("compiler-tests/src/test/data/box/aggregation/interop/RankBasedReplacementFromClassWithMultipleBindingsInRootGraph.kt");
+      }
+
+      @Test
       @TestMetadata("RepeatedContributesBindingAnvilInteropWorksForBoundTypeAndIgnoreQualifier.kt")
       public void testRepeatedContributesBindingAnvilInteropWorksForBoundTypeAndIgnoreQualifier() {
         runTest("compiler-tests/src/test/data/box/aggregation/interop/RepeatedContributesBindingAnvilInteropWorksForBoundTypeAndIgnoreQualifier.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ClassIds.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ClassIds.kt
@@ -176,10 +176,17 @@ public class ClassIds(
    * sure and is just a general catch-all.
    */
   internal val allRepeatableContributesAnnotationsContainers =
-    allContributesAnnotations.mapToSet { it.createNestedClassId(Symbols.Names.Container) }
+    allContributesAnnotations.toContainerAnnotations()
 
   internal val allContributesAnnotationsWithContainers =
     allContributesAnnotations + allRepeatableContributesAnnotationsContainers
+
+  internal val contributesBindingAnnotationsWithContainers =
+    contributesBindingAnnotations + contributesBindingAnnotations.toContainerAnnotations()
+
+  private fun Set<ClassId>.toContainerAnnotations() = mapToSet {
+    it.createNestedClassId(Symbols.Names.Container)
+  }
 
   internal val graphLikeAnnotations = dependencyGraphAnnotations + graphExtensionAnnotations
   internal val graphFactoryLikeAnnotations =

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -514,7 +514,7 @@ internal class ContributedInterfaceSupertypeGenerator(
         .mapNotNull { it.toClassSymbol(session)?.getContainingClassSymbol() }
         .flatMap { contributingType ->
           contributingType
-            .annotationsIn(session, session.classIds.contributesBindingAnnotations)
+            .annotationsIn(session, session.classIds.contributesBindingAnnotationsWithContainers)
             .mapNotNull { annotation ->
               val scope = annotation.resolvedScopeClassId(typeResolver) ?: return@mapNotNull null
               if (scope !in allScopes) return@mapNotNull null


### PR DESCRIPTION
- This issue happened due to missing the synthetic Container annotations for repeated annotations in rank processing.
