### PR TITLE
Skip assisted parameters when validating mirror matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog
 
 - **[IR]** Don't try class binding lookups for nullable types. These must always be explicitly provided.
 - **[IR]** Disambiguate return-type overloads of generated `@Binds` functions for `@Contributes` annotations that contribute multiple interfaces of the same simple name but different package name.
+- **[IR]** Skip assisted parameters when validating parameter type matching on native compilations.
 
 ### Changes
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectConstructorTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectConstructorTransformer.kt
@@ -143,7 +143,8 @@ internal class InjectConstructorTransformer(
                 .owner
                 .parameters()
                 .allParameters
-            for ((i, mirrorP) in parameters.nonDispatchParameters.withIndex()) {
+            for ((i, mirrorP) in
+              parameters.nonDispatchParameters.filterNot { it.isAssisted }.withIndex()) {
               val createP = createFunctionParams[i]
               if (createP.typeKey != mirrorP.typeKey) {
                 reportCompat(


### PR DESCRIPTION
Resolves #1736