### PR TITLE
only use nonDispatchParameters for comparison

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectConstructorTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectConstructorTransformer.kt
@@ -142,7 +142,7 @@ internal class InjectConstructorTransformer(
                 .owner
                 .parameters()
                 .allParameters
-            for ((i, mirrorP) in parameters.allParameters.withIndex()) {
+            for ((i, mirrorP) in parameters.nonDispatchParameters.withIndex()) {
               val createP = createFunctionParams[i]
               if (createP.typeKey != mirrorP.typeKey) {
                 reportCompat(


### PR DESCRIPTION
Fixes false positive reports for parameter mismatches.