### PR TITLE
Fix outdated README.md in metrox-viewmodel

### DIFF
--- a/metrox-viewmodel/README.md
+++ b/metrox-viewmodel/README.md
@@ -81,7 +81,7 @@ class DetailsViewModel(@Assisted val id: String) : ViewModel() {
   // ...
 
   @AssistedFactory
-  @ViewModelAssistedFactoryKey(Factory::class)
+  @ViewModelAssistedFactoryKey(DetailsViewModel::class)
   @ContributesIntoMap(AppScope::class)
   fun interface Factory : ViewModelAssistedFactory {
     override fun create(extras: CreationExtras): DetailsViewModel {


### PR DESCRIPTION
Since commit 2f28957, `@ViewModelAssistedFactoryKey`  accepts `KClass<out ViewModel>` as a key instead of `KClass<out ViewModelAssistedFactory>`.
