### PR TITLE
Drop FIR-in-IR work-around for repeated annotations

### DIFF
--- a/compiler-compat/k2320_beta2/src/main/kotlin/dev/zacsweers/metro/compiler/compat/k2320_beta2/CompatContextImpl.kt
+++ b/compiler-compat/k2320_beta2/src/main/kotlin/dev/zacsweers/metro/compiler/compat/k2320_beta2/CompatContextImpl.kt
@@ -12,8 +12,6 @@ import org.jetbrains.kotlin.diagnostics.KtDiagnosticWithoutSource
 import org.jetbrains.kotlin.diagnostics.KtSourcelessDiagnosticFactory
 
 public class CompatContextImpl : CompatContext by DelegateType() {
-  override val supportsExternalRepeatableAnnotations: Boolean = true
-
   override fun KtSourcelessDiagnosticFactory.createCompat(
     message: String,
     location: CompilerMessageSourceLocation?,

--- a/compiler-compat/src/main/kotlin/dev/zacsweers/metro/compiler/compat/CompatContext.kt
+++ b/compiler-compat/src/main/kotlin/dev/zacsweers/metro/compiler/compat/CompatContext.kt
@@ -416,16 +416,6 @@ public interface CompatContext {
   public fun IrProperty.addBackingFieldCompat(builder: IrFieldBuilder.() -> Unit = {}): IrField
 
   @CompatApi(
-    since = "2.3.20-Beta2",
-    reason = CompatApi.Reason.COMPAT,
-    message =
-      "External repeatable annotations are not readable in IR until 2.3.20-Beta2. https://youtrack.jetbrains.com/issue/KT-83185",
-  )
-  // TODO enable in 2.3.20-dev-7429 dev build
-  public val supportsExternalRepeatableAnnotations: Boolean
-    get() = false
-
-  @CompatApi(
     since = "2.3.20",
     reason = CompatApi.Reason.COMPAT,
     message =

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContributionMerger.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContributionMerger.kt
@@ -4,17 +4,12 @@ package dev.zacsweers.metro.compiler.ir
 
 import androidx.collection.MutableScatterMap
 import dev.zacsweers.metro.compiler.Origins
-import dev.zacsweers.metro.compiler.expectAsOrNull
-import dev.zacsweers.metro.compiler.fir.coneTypeIfResolved
-import dev.zacsweers.metro.compiler.fir.replacesArgument
 import dev.zacsweers.metro.compiler.getAndAdd
 import dev.zacsweers.metro.compiler.safePathString
 import dev.zacsweers.metro.compiler.tracing.TraceScope
 import dev.zacsweers.metro.compiler.tracing.trace
 import java.util.SortedMap
 import java.util.SortedSet
-import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
-import org.jetbrains.kotlin.fir.types.classId
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
@@ -262,21 +257,10 @@ internal class IrContributionMerger(
       trace("Process replacements") {
         for (irClass in allClassesToScan) {
           val replacedClasses =
-            irClass.repeatableAnnotationsIn(
-              metroSymbols.classIds.allContributesAnnotationsWithContainers,
-              irBody = { annotations ->
-                annotations
-                  .flatMap { annotation -> annotation.replacedClasses() }
-                  .mapNotNull { replacedClass -> replacedClass.classType.rawType().classId }
-              },
-              firBody = { _, annotations ->
-                annotations
-                  .flatMap { it.replacesArgument()?.argumentList?.arguments.orEmpty() }
-                  .mapNotNull {
-                    it.expectAsOrNull<FirGetClassCall>()?.coneTypeIfResolved()?.classId
-                  }
-              },
-            )
+            irClass
+              .annotationsIn(metroSymbols.classIds.allContributesAnnotationsWithContainers)
+              .flatMap { annotation -> annotation.replacedClasses() }
+              .mapNotNull { replacedClass -> replacedClass.classType.rawType().classId }
           classesToReplace.addAll(replacedClasses)
         }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrRankedBindingProcessing.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrRankedBindingProcessing.kt
@@ -3,16 +3,6 @@
 package dev.zacsweers.metro.compiler.ir
 
 import dev.zacsweers.metro.compiler.computeOutrankedBindings
-import dev.zacsweers.metro.compiler.fir.MetroFirTypeResolver
-import dev.zacsweers.metro.compiler.fir.rankValue
-import dev.zacsweers.metro.compiler.fir.resolveClassId
-import dev.zacsweers.metro.compiler.fir.resolvedBindingArgument
-import dev.zacsweers.metro.compiler.fir.scopeArgument
-import org.jetbrains.kotlin.fir.FirSession
-import org.jetbrains.kotlin.fir.backend.Fir2IrComponents
-import org.jetbrains.kotlin.fir.backend.toIrType
-import org.jetbrains.kotlin.fir.expressions.FirAnnotation
-import org.jetbrains.kotlin.fir.types.coneTypeOrNull
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.types.IrType
@@ -20,14 +10,10 @@ import org.jetbrains.kotlin.ir.util.classIdOrFail
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.name.ClassId
 
-/** @see [repeatableAnnotationsIn] for docs on why this necessary. */
 internal object IrRankedBindingProcessing {
 
   /**
    * Provides `ContributesBinding.rank` interop for Dagger-Anvil.
-   *
-   * This uses [repeatableAnnotationsIn] to handle the KT-83185 workaround transparently. Both the
-   * FIR and IR paths produce bindings with [IrTypeKey] for consistent comparison.
    *
    * @return The bindings which have been outranked and should not be included in the merged graph.
    */
@@ -47,23 +33,9 @@ internal object IrRankedBindingProcessing {
 
     val rankedBindings =
       irContributions.flatMap { contributingType ->
-        contributingType.repeatableAnnotationsIn(
-          context.metroSymbols.classIds.contributesBindingAnnotationsWithContainers,
-          irBody = { irAnnotations ->
-            irAnnotations.mapNotNull { annotation ->
-              processIrAnnotation(annotation, contributingType, allScopes)
-            }
-          },
-          firBody = firBody@{ session, firAnnotations ->
-              // Fir2IrLazyClass and friends implement Fir2IrComponents, which we need to resolve
-              // binding types to IrTypes
-              val components =
-                contributingType as? Fir2IrComponents ?: return@firBody emptySequence()
-              firAnnotations.mapNotNull { annotation ->
-                processFirAnnotation(session, components, annotation, contributingType, allScopes)
-              }
-            },
-        )
+        contributingType
+          .annotationsIn(context.metroSymbols.classIds.contributesBindingAnnotationsWithContainers)
+          .mapNotNull { annotation -> processIrAnnotation(annotation, contributingType, allScopes) }
       }
 
     return computeOutrankedBindings(
@@ -92,37 +64,6 @@ internal object IrRankedBindingProcessing {
       contributingType = contributingType,
       typeKey =
         IrTypeKey(boundType, if (ignoreQualifier) null else contributingType.qualifierAnnotation()),
-      rank = annotation.rankValue(),
-    )
-  }
-
-  context(context: IrMetroContext)
-  private fun processFirAnnotation(
-    session: FirSession,
-    fir2IrComponents: Fir2IrComponents,
-    annotation: FirAnnotation,
-    contributingType: IrClass,
-    allScopes: Set<ClassId>,
-  ): ContributedBinding<IrClass, IrTypeKey>? {
-    // Use the FIR-specific scope resolution approach that handles external annotations correctly
-    val scope =
-      annotation.scopeArgument()?.resolveClassId(MetroFirTypeResolver.forIrUse()) ?: return null
-    if (scope !in allScopes) return null
-
-    val bindingConeType = annotation.resolvedBindingArgument(session)?.coneTypeOrNull
-
-    val boundType =
-      if (bindingConeType != null) {
-        // Look up the IR type from the ClassId
-        with(fir2IrComponents) { bindingConeType.toIrType() }
-      } else {
-        // Fall back to implicit bound type
-        contributingType.implicitBoundTypeOrNull()
-      } ?: return null
-
-    return ContributedBinding(
-      contributingType = contributingType,
-      typeKey = IrTypeKey(boundType, contributingType.qualifierAnnotation()),
       rank = annotation.rankValue(),
     )
   }


### PR DESCRIPTION
- Original issue: https://youtrack.jetbrains.com/issue/KT-83185
- Might be a little early since the main build is on 2.3.0 still, just drafting for now
