### PR TITLE
(temp) Revert "Enable enableGraphSharding by default" until 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Changelog
 
 ### Changes
 
-- `enableGraphSharding` is now enabled by default. Note this only kicks in (by default) for graphs with 2000+ bindings by default.
 - Deprecate the `generateThrowsAnnotations` option and make it no-op. This was only in place when debugging a past kotlin/native issue.
 
 ### Contributors

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
@@ -222,7 +222,7 @@ internal enum class MetroOption(val raw: RawMetroOption<*>) {
   ENABLE_GRAPH_SHARDING(
     RawMetroOption.boolean(
       name = "enable-graph-sharding",
-      defaultValue = true,
+      defaultValue = false,
       valueDescription = "<true | false>",
       description = "Enable/disable graph sharding of binding graphs.",
       required = false,

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
@@ -185,14 +185,16 @@ constructor(
   public val statementsPerInitFun: Property<Int> =
     objects.intProperty("metro.statementsPerInitFun", 25)
 
-  /** Enable/disable graph sharding of binding graphs. Enabled by default. */
+  /** Enable/disable graph sharding of binding graphs. Disabled by default. */
+  @DelicateMetroGradleApi("Sharding is an experimental feature")
   public val enableGraphSharding: Property<Boolean> =
-    objects.booleanProperty("metro.enableGraphSharding", true)
+    objects.booleanProperty("metro.enableGraphSharding", false)
 
   /**
    * Maximum number of binding keys per graph shard when sharding is enabled. Default is 2000, must
    * be > 0.
    */
+  @DelicateMetroGradleApi("Sharding is an experimental feature")
   public val keysPerGraphShard: Property<Int> = objects.intProperty("metro.keysPerGraphShard", 2000)
 
   /**
@@ -206,6 +208,7 @@ constructor(
    *
    * Disabled by default.
    */
+  @DelicateMetroGradleApi("Switching providers are an experimental feature")
   public val enableSwitchingProviders: Property<Boolean> =
     objects.booleanProperty("metro.enableSwitchingProviders", false)
 


### PR DESCRIPTION
Reverts ZacSweers/metro#1799

It's ready for default, just holding off on this as I might do one more patch release of 0.10.x