### PR TITLE
Fix IC issue with non-assisted param removed from constructor

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/BindingLookup.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/BindingLookup.kt
@@ -842,6 +842,9 @@ internal class BindingLookup(
               return@getOrPut emptySet()
             }
 
+        // Record a lookup of the target's factory function in case its constructor params change
+        trackFunctionCall(sourceGraph, targetClassFactory.function)
+
         val targetKey = IrTypeKey(targetType)
         val targetAnnotations = targetClass.metroAnnotations(context.metroSymbols.classIds)
         val targetRemapper = targetClass.deepRemapperFor(targetType)


### PR DESCRIPTION
Note: Both the test case and the solution are AI-generated with small manual tweaks and cleanup. I spent some time reading the code and I believe I understand what's causing the issue, that said, I don't fully comprehend the solution as I'm not familiar with IC mechanics - I'm really sorry if the solution doesn't make sense. I verified that the integration test fails without the fix and passes with the fix, plus I cherry-picked this fix on top of the 0.10.4 tag and tested it in our app to verify that it fixes our issue. More about the issue below.

---

Our app setup is roughly as follows:

```kotlin
// :presenters Gradle module
class Presenter @AssistedInject constructor(
  private val analytics: Analytics,
  private val featureFlagManager: FeatureFlagManager,
  ...
  @Assisted private val navigator: Navigator,
) : MoleculePresenter<ViewModel, ViewEvent> {
  ...
  @AssistedFactory
  interface Factory {
    fun create(navigator: Navigator): Presenter
  }
}  

// :applets Gradle module, has an "api projects.presenters" dependency
@BindingContainer
@ContributesTo(SandboxedActivityScope::class)
class AppletViewsModule {
  companion object {
    @Provides @IntoSet
    fun balanceApplet(presenterFactory: Presenter.Factory): Applet {
      return Applet(
        ...
        tileBuilder = { navigator, scope ->
          val presenter =
            presenterFactory.create(navigator).asPresenter().start(scope, lifecycleOwner)
          ...
        },
      )
    }
  }
}

// :app Gradle module that depends on "projects.applets" and creates a graph for SandboxedActivityScope
```

We discovered that removing or adding a non-assisted parameter to `Presenter`'s constructor, e.g. as follows:

```kotlin
class Presenter @AssistedInject constructor(
  private val analytics: Analytics,
  // private val featureFlagManager: FeatureFlagManager,
  ...
  @Assisted private val navigator: Navigator,
) : MoleculePresenter<ViewModel, ViewEvent> {
  ...
  @AssistedFactory
  interface Factory {
    fun create(navigator: Navigator): Presenter
  }
} 
```

Leads to a runtime crash that looks roughly like this:

```kotlin
java.lang.NoSuchMethodError: No virtual method create(Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;Ldev/zacsweers/metro/Provider;)Lcom/squareup/cash/.../presenters/Presenter$MetroFactory; in class Lcom/squareup/cash/.../presenters/Presenter$MetroFactory$Companion; or its super classes (declaration of 'com.squareup.cash.presenters.Presenter$MetroFactory$Companion' appears in /data/app/~~IbWdTUh4tVmh7PLzPcGeqg==/com.squareup.cash.beta.debug-8r5U_uv532p-ul6LsNlTHA==/base.apk!classes13.dex)
  at com.squareup.cash.VariantSandboxedComponent$Impl$SandboxedActivityComponentImpl.getSetOfAppletProvider(Unknown Source:190)
```

There seems to be a missing IC dependency between "sourceGraph" and the "create" function that Metro generates for the `@AssistedInject`-ed class, so when the function's signature changes the graph doesn't get recompiled. The fix addresses it by tracking that function as a graph dependency.