### PR TITLE
Fix evaluation of top-level constants used in annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@ Now, Metro runs in a single pass. Most of Metro's core transformations are run i
 
 - **[FIR]**: Improve optional binding member injections detection.
 - **[FIR]**: Add `@HiddenFromObjC` to generated top-level composable classes for native compilations.
+- **[FIR]**: Fix evaluation of top-level constants used in annotations like `@Assisted` or `@Named`.
 - **[FIR/IR]**: Support generic `@BindingContainer` classes included via `@Includes` with concrete type arguments (e.g., `@Includes TypedBindings<Int>`). Type parameters are now properly propagated to generated factory classes and substituted during binding resolution.
 - **[IR]**: Fix propagation of `Map` graph inputs down to graph extensions.
 - **[IR]**: Guard against identity mappings (T -> T) to prevent infinite recursion when remapping generic types.

--- a/compiler-tests/src/test/data/box/inject/assisted/AssistedInjectWithConstValQualifiers.kt
+++ b/compiler-tests/src/test/data/box/inject/assisted/AssistedInjectWithConstValQualifiers.kt
@@ -1,0 +1,35 @@
+// Two parameters of the same type with different @Named qualifiers using const val references
+// should not be deduped in the factory.
+// Regression test for a bug where FIR wouldn't resolve constants
+
+const val QUALIFIER_A = "qualifier_a"
+const val QUALIFIER_B = "qualifier_b"
+
+@AssistedInject
+class ExampleClass(
+  @Named(QUALIFIER_A) val a: String,
+  @Named(QUALIFIER_B) val b: String,
+  @Assisted val count: Int,
+) {
+  fun call(): String = "$a $b $count"
+}
+
+@AssistedFactory
+fun interface ExampleClassFactory {
+  fun create(count: Int): ExampleClass
+}
+
+@DependencyGraph
+interface AppGraph {
+  val factory: ExampleClassFactory
+
+  @Provides @Named(QUALIFIER_A) fun provideA(): String = "Hello"
+
+  @Provides @Named(QUALIFIER_B) fun provideB(): String = "World"
+}
+
+fun box(): String {
+  val result = createGraph<AppGraph>().factory.create(42)
+  assertEquals("Hello World 42", result.call())
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -1428,6 +1428,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("AssistedInjectWithConstValQualifiers.kt")
+      public void testAssistedInjectWithConstValQualifiers() {
+        runTest("compiler-tests/src/test/data/box/inject/assisted/AssistedInjectWithConstValQualifiers.kt");
+      }
+
+      @Test
       @TestMetadata("AssistedParamNamesDisabled.kt")
       public void testAssistedParamNamesDisabled() {
         runTest("compiler-tests/src/test/data/box/inject/assisted/AssistedParamNamesDisabled.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -1428,6 +1428,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("AssistedInjectWithConstValQualifiers.kt")
+      public void testAssistedInjectWithConstValQualifiers() {
+        runTest("compiler-tests/src/test/data/box/inject/assisted/AssistedInjectWithConstValQualifiers.kt");
+      }
+
+      @Test
       @TestMetadata("AssistedParamNamesDisabled.kt")
       public void testAssistedParamNamesDisabled() {
         runTest("compiler-tests/src/test/data/box/inject/assisted/AssistedParamNamesDisabled.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/MetroFirAnnotation.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/MetroFirAnnotation.kt
@@ -10,9 +10,11 @@ import org.jetbrains.kotlin.fir.expressions.FirAnnotationCall
 import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
 import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
+import org.jetbrains.kotlin.fir.expressions.FirPropertyAccessExpression
 import org.jetbrains.kotlin.fir.expressions.FirResolvedQualifier
 import org.jetbrains.kotlin.fir.expressions.arguments
 import org.jetbrains.kotlin.fir.extensions.FirSupertypeGenerationExtension.TypeResolveService
+import org.jetbrains.kotlin.fir.references.toResolvedPropertySymbol
 import org.jetbrains.kotlin.fir.types.renderReadable
 import org.jetbrains.kotlin.fir.types.renderReadableWithFqNames
 import org.jetbrains.kotlin.fir.types.resolvedType
@@ -79,6 +81,11 @@ private fun StringBuilder.renderAsAnnotationArgument(argument: FirExpression, si
         (argument.argument as? FirResolvedQualifier)?.symbol?.classId?.asSingleFqName() ?: "<Error>"
       append(id)
       append("::class")
+    }
+    is FirPropertyAccessExpression -> {
+      // Enum entry or const val reference
+      val symbol = argument.calleeReference.toResolvedPropertySymbol()
+      append(symbol?.callableId ?: "...")
     }
     // TODO
     //      is IrVararg -> {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/fir.kt
@@ -391,9 +391,9 @@ private fun renderAnnotationArgument(
           }
         }
     }
-    // Enum entry reference
+    // Enum entry reference or const val reference
     is FirPropertyAccessExpression -> {
-      arg.calleeReference.toResolvedPropertySymbol()?.resolvedReceiverTypeRef?.coneType?.classId
+      arg.calleeReference.toResolvedPropertySymbol()?.callableId
     }
 
     is FirFunctionCall -> {


### PR DESCRIPTION
Like `@Assisted` or `@Named`