### PR TITLE
Fix false positive SuspiciousUnusedMultibinding for reachable multibindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changelog
 
 ### Fixes
 
+- **[IR]**: Fix false positive `SuspiciousUnusedMultibinding` warning when a synthetic multibinding is consumed via `@ContributesBinding` constructor injection in the same scope.
+
 ### Changes
 
 ### Contributors

--- a/compiler-tests/src/test/data/diagnostic/multibindings/SuspiciousUnusedMultibindingSet.kt
+++ b/compiler-tests/src/test/data/diagnostic/multibindings/SuspiciousUnusedMultibindingSet.kt
@@ -31,3 +31,26 @@ class Impl4 : BaseViewModel
 @ContributesIntoSet(AppScope::class)
 @Inject
 class Impl5 : BaseViewModel
+
+interface Writer
+
+interface Tracker
+
+@ContributesIntoSet(AppScope::class, binding = binding<Writer>())
+@Inject
+class WriterA : Writer
+
+@ContributesIntoSet(AppScope::class, binding = binding<Writer>())
+@Inject
+class WriterB : Writer
+
+@ContributesBinding(AppScope::class, binding = binding<Tracker>())
+@Inject
+class DefaultTracker(
+  private val writers: Set<Writer>,
+) : Tracker
+
+@DependencyGraph(AppScope::class)
+interface TrackerGraph {
+  val tracker: Tracker
+}

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/IrBindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/IrBindingGraph.kt
@@ -321,6 +321,10 @@ internal class IrBindingGraph(
           }
           for ((key, binding) in bindingLookup.getAvailableMultibindings()) {
             if (binding.declaration != null) continue // Skip explicitly declared
+            // If the synthetic multibinding key itself is reachable, it's consumed by the graph
+            // (e.g., via constructor injection of a @ContributesBinding class) and should not be
+            // flagged as suspicious.
+            if (key in reachableKeys) continue
             val unusedSources = binding.sourceBindings.intersect(unusedMultibindingElements)
             if (unusedSources.isEmpty()) continue
 


### PR DESCRIPTION
## Problem

`SuspiciousUnusedMultibinding` fires on synthetic multibindings that are actually consumed — specifically when a `@ContributesBinding` class takes `Set<T>` as a constructor parameter in the same scope.

Example: `WriterA`/`WriterB` contribute to `Set<Writer>`, `DefaultTracker` consumes it via constructor injection and is `@ContributesBinding`, `TrackerGraph` requests `Tracker`. All in `AppScope`. The multibinding is consumed but the warning fires.

Note: #1932 reported a similar symptom but was a scope mismatch issue. This is a different case — same scope, consumption path through `@ContributesBinding` constructor injection.

## Root cause

The detection loop checks if source element keys are unused, but doesn't check whether the multibinding key itself is reachable. When it is (e.g. consumed via `@ContributesBinding` constructor injection), the warning is a false positive.

## Fix

Guard in the detection loop: if the synthetic multibinding key is in `reachableKeys`, skip the warning.

## Test

Extended `SuspiciousUnusedMultibindingSet.kt` with a `TrackerGraph` reproducer — `DefaultTracker(@ContributesBinding)` consuming `Set<Writer>` via constructor injection, same scope. No diagnostic expected. Existing `AppGraph` case still correctly warns for genuinely unused `Set<BaseViewModel>`.