### PR TITLE
Fix assisted invoke parameter type wrapping in IR factory

### DIFF
--- a/compiler-tests/src/test/data/box/interop/dagger/AssistedDaggerLazyParameterInteropRegression.kt
+++ b/compiler-tests/src/test/data/box/interop/dagger/AssistedDaggerLazyParameterInteropRegression.kt
@@ -1,0 +1,34 @@
+// ENABLE_DAGGER_INTEROP
+package test
+
+import dagger.Lazy
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+
+// Regression repro for commit 85543469: assisted dagger.Lazy<T> params can be remapped to T,
+// causing a ClassCastException when the factory receives a DaggerInteropDoubleCheck instance.
+class AssistedLazyConsumer
+@AssistedInject
+constructor(@Assisted private val lazyString: Lazy<String>) {
+
+  fun value(): String = lazyString.get()
+
+  @AssistedFactory
+  interface Factory {
+    fun create(lazyString: Lazy<String>): AssistedLazyConsumer
+  }
+}
+
+@DependencyGraph
+interface ExampleGraph {
+  val assistedLazyConsumerFactory: AssistedLazyConsumer.Factory
+}
+
+fun box(): String {
+  val graph = createGraph<ExampleGraph>()
+  val consumer = graph.assistedLazyConsumerFactory.create(Lazy { "test" })
+
+  assertEquals("test", consumer.value())
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -1740,6 +1740,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("AssistedDaggerLazyParameterInteropRegression.kt")
+      public void testAssistedDaggerLazyParameterInteropRegression() {
+        runTest("compiler-tests/src/test/data/box/interop/dagger/AssistedDaggerLazyParameterInteropRegression.kt");
+      }
+
+      @Test
       @TestMetadata("BindsOptionalInAMultibindingCycle.kt")
       public void testBindsOptionalInAMultibindingCycle() {
         runTest("compiler-tests/src/test/data/box/interop/dagger/BindsOptionalInAMultibindingCycle.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -1740,6 +1740,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("AssistedDaggerLazyParameterInteropRegression.kt")
+      public void testAssistedDaggerLazyParameterInteropRegression() {
+        runTest("compiler-tests/src/test/data/box/interop/dagger/AssistedDaggerLazyParameterInteropRegression.kt");
+      }
+
+      @Test
       @TestMetadata("BindsOptionalInAMultibindingCycle.kt")
       public void testBindsOptionalInAMultibindingCycle() {
         runTest("compiler-tests/src/test/data/box/interop/dagger/BindsOptionalInAMultibindingCycle.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectedClassTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectedClassTransformer.kt
@@ -268,9 +268,13 @@ internal class InjectedClassTransformer(
           if (!isAssistedInject) {
             overriddenSymbols = listOf(metroSymbols.providerInvoke)
           } else {
+            val assistedInvokeParamTypeRemapper =
+              declaration.deepRemapperFor(factoryCls.defaultType)
             // Add assisted params
             for (param in constructorParameters.allParameters.filter { it.isAssisted }) {
-              addValueParameter(param.name, param.type)
+              val assistedParamType =
+                assistedInvokeParamTypeRemapper.remapType(param.contextualTypeKey.toIrType())
+              addValueParameter(param.name, assistedParamType)
             }
           }
         }


### PR DESCRIPTION
This is a regression from 85543469edb769d13099c2b49608b38d8baf2c90

