### PR TITLE
Fix NoSuchFieldError when sharded graphs access @Includes dependency properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog
 - **[FIR]**: Providers can now return instances of classes nested in the same container class.
 - **[IR]**: Fix codegen error when a scoped binding in a child graph supersedes the same-typed scoped binding from a parent graph and is used in a grandchild graph's multibinding. Basically, if graph A provides `Logger` and graph `B` also provides `Logger` (overriding `A`'s), graph `C` would incorrectly try to get it from `A` instead of `B`.
 - **[IR]**: Fix duplicate binding error in multibindings when multiple contributed containers include the same shared multibinding-contributing container.
+- **[IR]**: Fix `NoSuchFieldError` at runtime when sharded graphs access `@Includes` dependency properties.
 - **[IR]**: Check parent classes for `@Origin` annotations when performing IR-based contribution merging.
 - **[metrox-viewmodel-compose]**: Pass `CreationExtras` to the `createViewModel` lamba for `assistedMetroViewModel` when using `ManualViewModelAssistedFactory`
 

--- a/compiler-tests/src/test/data/box/dependencygraph/sharding/ShardingWithIncludes.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/sharding/ShardingWithIncludes.kt
@@ -1,0 +1,58 @@
+// KEYS_PER_GRAPH_SHARD: 2
+// ENABLE_GRAPH_SHARDING: true
+
+/*
+ * This test verifies that @Includes graph dependency properties are correctly
+ * accessed from shard classes.
+ *
+ * When sharding is enabled, bindings are distributed across nested shard classes
+ * (Shard1, Shard2, etc.) inside the main Impl class. @Includes parameters are
+ * stored as properties on the main Impl class, not in any shard. When a shard
+ * binding needs to access an @Includes dependency, the generated code must go
+ * through `this.graph.property` (shard -> main class) rather than directly
+ * accessing `this.property` on the shard.
+ *
+ * This is a regression test for a bug where GraphDependency and BoundInstance
+ * bindings bypassed generatePropertyAccess() and used irGet(thisReceiver)
+ * directly, causing NoSuchFieldError at runtime when the shard tried to access
+ * a field that only existed on the main graph class.
+ */
+
+interface ParentDependencies {
+  val greeting: String
+}
+
+@SingleIn(AppScope::class) @Inject class Service1(val greeting: String)
+
+@SingleIn(AppScope::class) @Inject class Service2(val greeting: String)
+
+@SingleIn(AppScope::class) @Inject class Service3(val s1: Service1, val s2: Service2)
+
+@DependencyGraph(scope = AppScope::class)
+interface TestGraph {
+  val service1: Service1
+  val service2: Service2
+  val service3: Service3
+
+  @DependencyGraph.Factory
+  fun interface Factory {
+    fun create(@Includes parent: ParentDependencies): TestGraph
+  }
+}
+
+fun box(): String {
+  val parent = object : ParentDependencies {
+    override val greeting: String = "Hello"
+  }
+  val graph = createGraphFactory<TestGraph.Factory>().create(parent)
+
+  return when {
+    graph.service1.greeting != "Hello" -> "FAIL: service1 greeting wrong"
+    graph.service2.greeting != "Hello" -> "FAIL: service2 greeting wrong"
+    graph.service3.s1.greeting != "Hello" -> "FAIL: service3.s1 greeting wrong"
+    graph.service3.s2.greeting != "Hello" -> "FAIL: service3.s2 greeting wrong"
+    graph.service3.s1 !== graph.service1 -> "FAIL: service1 not same instance"
+    graph.service3.s2 !== graph.service2 -> "FAIL: service2 not same instance"
+    else -> "OK"
+  }
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -1384,6 +1384,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("ShardingWithIncludes.kt")
+      public void testShardingWithIncludes() {
+        runTest("compiler-tests/src/test/data/box/dependencygraph/sharding/ShardingWithIncludes.kt");
+      }
+
+      @Test
       @TestMetadata("ShardingWithMultibindings.kt")
       public void testShardingWithMultibindings() {
         runTest("compiler-tests/src/test/data/box/dependencygraph/sharding/ShardingWithMultibindings.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -1384,6 +1384,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("ShardingWithIncludes.kt")
+      public void testShardingWithIncludes() {
+        runTest("compiler-tests/src/test/data/box/dependencygraph/sharding/ShardingWithIncludes.kt");
+      }
+
+      @Test
       @TestMetadata("ShardingWithMultibindings.kt")
       public void testShardingWithMultibindings() {
         runTest("compiler-tests/src/test/data/box/dependencygraph/sharding/ShardingWithMultibindings.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/expressions/GraphExpressionGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/expressions/GraphExpressionGenerator.kt
@@ -441,7 +441,11 @@ private constructor(
               // to build the full property access chain through ancestors
               val localProperty = bindingPropertyContext.get(parentContextKey)
               if (localProperty != null) {
-                irGetProperty(irGet(thisReceiver), localProperty.property)
+                generatePropertyAccess(
+                  localProperty.property,
+                  localProperty.shardProperty,
+                  localProperty.shardIndex,
+                )
               } else {
                 // Use resolveToken to build the property access chain through ancestors
                 val propertyAccess = resolveToken(binding.token)
@@ -452,7 +456,11 @@ private constructor(
               // parameters that are stored as fields)
               val localProperty = bindingPropertyContext.get(binding.contextualTypeKey)
               if (localProperty != null) {
-                irGetProperty(irGet(thisReceiver), localProperty.property)
+                generatePropertyAccess(
+                  localProperty.property,
+                  localProperty.shardProperty,
+                  localProperty.shardIndex,
+                )
               } else {
                 // Self-binding - graph provides itself
                 irGet(thisReceiver)
@@ -554,17 +562,24 @@ private constructor(
                   AccessType.PROVIDER
                 }
             } else if (binding.getter != null) {
-              val graphInstanceProperty =
-                bindingPropertyContext.get(IrContextualTypeKey(ownerKey))?.property
+              val graphInstanceBindingProperty =
+                bindingPropertyContext.get(IrContextualTypeKey(ownerKey))
                   ?: reportCompilerBug(
                     "No matching included type instance found for type $ownerKey while processing ${node.typeKey}"
                   )
 
               val getterContextKey = IrContextualTypeKey.from(binding.getter)
 
+              val graphInstanceAccess =
+                generatePropertyAccess(
+                  graphInstanceBindingProperty.property,
+                  graphInstanceBindingProperty.shardProperty,
+                  graphInstanceBindingProperty.shardIndex,
+                )
+
               val invokeGetter =
                 irInvoke(
-                  dispatchReceiver = irGetProperty(irGet(thisReceiver), graphInstanceProperty),
+                  dispatchReceiver = graphInstanceAccess,
                   callee = binding.getter.symbol,
                   typeHint = binding.typeKey.type,
                 )


### PR DESCRIPTION


In `GraphExpressionGenerator`, the `BoundInstance` and `GraphDependency` (getter case) handlers accessed @Includes graph dependency properties using `irGetProperty(irGet(thisReceiver), property)` directly. When code was generated inside a shard class, `thisReceiver` pointed to the shard's `this`, but the property lived on the main graph class. This generated bytecode like:

    this@Shard1.abc  // WRONG

instead of the correct:

    this@Shard1.graph.abc

At runtime this manifested as:

    java.lang.NoSuchFieldError: No field abc of type Abc in class MyGraphGraph$Impl$Shard1

The Kotlin/JVM backend generated a synthetic `access$` method on Shard1 to bridge the private field access from a lambda in the shard's init, but the field only existed on the main Impl class.

The fix routes all three call sites through `generatePropertyAccess()`, which already handles shard context correctly: for non-sharded properties (shardIndex == null) it generates `this.graph.property` instead of `this.property`.

<!--
  STOP AND READ!

  Couple small asks to help with review 🥺
  - Please write a description (however long or short as necessary.)
  - If you are showing me AI-generated output (code or otherwise), please be upfront about it, indicate what parts, and de-fluff _before_ opening the PR.
-->
