### PR TITLE
[DOCS] Python version requirement and venv setup guide

### DIFF
--- a/scripts/run_local_docs_site.sh
+++ b/scripts/run_local_docs_site.sh
@@ -2,12 +2,17 @@
 
 # The website is built using Zensical (successor to MkDocs Material).
 # https://zensical.org/
-# It requires Python to run.
+# It requires Python >=3.10 to run.
+#
+# To set up the environment, create a virtual environment and activate it (first time only):
+#   python3 -m venv .venv
+#   source .venv/bin/activate
+#
 # Install the packages with the following command:
-# pip install -r .github/workflows/mkdocs-requirements.txt
+#   pip install -r .github/workflows/mkdocs-requirements.txt
 #
 # To run the site locally with hot-reload support, use:
-# ./scripts/run_local_docs_site.sh
+#   ./scripts/run_local_docs_site.sh
 
 # Check if zensical is installed
 if ! command -v zensical &> /dev/null; then


### PR DESCRIPTION
## Summary
Added some note on local docsite run setup - had some issues when trying it out on my new macbook.

---

Zensical (https://pypi.org/project/zensical/) requires python 3.10+

For some reason latest macos comes with 3.9, so added minor note.

Also, added the best practice for using `.venv` for setting this up.

<!--
  STOP AND READ!

  Couple small asks to help with review 🥺
  - Please write a description (however long or short as necessary.)
  - If you are showing me AI-generated output (code or otherwise), please be upfront about it, indicate what parts, and de-fluff _before_ opening the PR.
-->
