### PR TITLE
[DOCS] Added additional note on static content saved in `gh-pages` for `404`

### DIFF
--- a/404-assets/README.md
+++ b/404-assets/README.md
@@ -1,0 +1,6 @@
+This `404-assets` directory contains snapshot of actual site content to provide consistent look & feel during the `404` error handling from GitHub pages. These files **do not** participate in docs site generation using `mkdocs` or `mike`.
+
+These assets are mainly used in [`404.html`](https://github.com/ZacSweers/metro/blob/gh-pages/404.html)
+
+
+If [Zensical](https://github.com/ZacSweers/metro/blob/main/docs/zensical-migration.md) natively supports GitHub's `404` handling, these files could potentially be removed along with the `404.html` page.


### PR DESCRIPTION
## Summary
Added some notes on duplicate static files needed for `404` page rendering.

### Related PRs
* https://github.com/ZacSweers/metro/pull/1983
* https://github.com/ZacSweers/metro/pull/1067

## Preview
Here is quick preview of how 404 renders now.

<img width="1449" height="1012" alt="Screenshot 2026-03-14 at 12 38 00 PM" src="https://github.com/user-attachments/assets/32aec96c-bac6-44ea-b5e1-cf3eb9ed7e2e" />


<details>

Full flow ^_^


![2026-03-14 12 36 22](https://github.com/user-attachments/assets/8295d352-074e-4204-a587-b7d2da56c0f2)

</details>

<!--
  STOP AND READ!

  Couple small asks to help with review 🥺
  - Please write a description (however long or short as necessary.)
  - If you are showing me AI-generated output (code or otherwise), please be upfront about it, indicate what parts, and de-fluff _before_ opening the PR.
-->
