### PR TITLE
Fix `Map<Class<*>, V>` interop in constructor injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 
 - **[FIR]**: Don't use a memoizing sequence for all FirSession instance as it seems that the IDE will mutate the underlying source lists in some cases.
 - **[FIR]**: Providers can now return instances of classes nested in the same container class.
+- **[IR]**: Fix `Map<Class<*>, V>` map key interop in constructor injection paths when `enableKClassToClassMapKeyInterop` is enabled.
 - **[IR]**: Fix codegen error when a scoped binding in a child graph supersedes the same-typed scoped binding from a parent graph and is used in a grandchild graph's multibinding. Basically, if graph A provides `Logger` and graph `B` also provides `Logger` (overriding `A`'s), graph `C` would incorrectly try to get it from `A` instead of `B`.
 - **[IR]**: Fix duplicate binding error in multibindings when multiple contributed containers include the same shared multibinding-contributing container.
 - **[IR]**: Fix `NoSuchFieldError` at runtime when sharded graphs access `@Includes` dependency properties.

--- a/compiler-tests/src/test/data/box/interop/kclass/ClassMapKeyInjectConstructorInterop.kt
+++ b/compiler-tests/src/test/data/box/interop/kclass/ClassMapKeyInjectConstructorInterop.kt
@@ -1,0 +1,39 @@
+// ENABLE_KCLASS_TO_CLASS_INTEROP
+
+// Regression test: when Map<Class<*>, V> is injected through an @Inject constructor,
+// the factory stores the binding as a Provider<Map<KClass<*>, V>> internally.
+// The KClass-to-Class map key conversion must happen after the provider is invoked,
+// not before, otherwise it crashes trying to access type arguments on the Provider type.
+
+interface Greeting
+
+class HelloGreeting : Greeting
+
+class GoodbyeGreeting : Greeting
+
+@Inject
+class GreetingHolder(val greetings: Map<Class<*>, Greeting>)
+
+@DependencyGraph
+interface ExampleGraph {
+  @Provides @IntoMap @ClassKey(HelloGreeting::class) fun provideHello(): Greeting = HelloGreeting()
+
+  @Provides
+  @IntoMap
+  @ClassKey(GoodbyeGreeting::class)
+  fun provideGoodbye(): Greeting = GoodbyeGreeting()
+
+  val holder: GreetingHolder
+}
+
+fun box(): String {
+  val graph = createGraph<ExampleGraph>()
+  val map = graph.holder.greetings
+  assertEquals(2, map.size)
+  for (key in map.keys) {
+    assertTrue(key is Class<*>)
+  }
+  assertIs<HelloGreeting>(map[HelloGreeting::class.java])
+  assertIs<GoodbyeGreeting>(map[GoodbyeGreeting::class.java])
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -2094,6 +2094,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("ClassMapKeyInjectConstructorInterop.kt")
+      public void testClassMapKeyInjectConstructorInterop() {
+        runTest("compiler-tests/src/test/data/box/interop/kclass/ClassMapKeyInjectConstructorInterop.kt");
+      }
+
+      @Test
       @TestMetadata("ClassMapKeyProviderInterop.kt")
       public void testClassMapKeyProviderInterop() {
         runTest("compiler-tests/src/test/data/box/interop/kclass/ClassMapKeyProviderInterop.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -2094,6 +2094,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("ClassMapKeyInjectConstructorInterop.kt")
+      public void testClassMapKeyInjectConstructorInterop() {
+        runTest("compiler-tests/src/test/data/box/interop/kclass/ClassMapKeyInjectConstructorInterop.kt");
+      }
+
+      @Test
       @TestMetadata("ClassMapKeyProviderInterop.kt")
       public void testClassMapKeyProviderInterop() {
         runTest("compiler-tests/src/test/data/box/interop/kclass/ClassMapKeyProviderInterop.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/expressions/GraphExpressionGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/expressions/GraphExpressionGenerator.kt
@@ -709,8 +709,15 @@ private constructor(
             val (property, storedKey, shardProperty, shardIndex) = bindingProperty
             // Only return early if we got an actual instance property, not a provider fallback
             if (!storedKey.isWrappedInProvider) {
-              return@mapIndexed generatePropertyAccess(property, shardProperty, shardIndex)
-                .toTargetType(actual = AccessType.INSTANCE, contextualTypeKey = contextualTypeKey)
+              val instanceExpression =
+                generatePropertyAccess(property, shardProperty, shardIndex)
+                  .toTargetType(actual = AccessType.INSTANCE, contextualTypeKey = contextualTypeKey)
+              return@mapIndexed typeAsProviderArgument(
+                param.contextualTypeKey,
+                instanceExpression,
+                isAssisted = param.isAssisted,
+                isGraphInstance = param.isGraphInstance,
+              )
             }
           }
         }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -659,15 +659,13 @@ internal fun IrBuilderWithScope.typeAsProviderArgument(
 ): IrExpression {
   val symbols = context.metroSymbols
 
-  // If KClass/Class interop is enabled and the consumer declared Map<Class<*>, V>,
-  // convert the canonical Map<KClass<*>, V> to Map<Class<*>, V> via `mapKeys { it.key.java }`
-  val convertedBindingCode = maybeConvertMapKeysToJavaClass(bindingCode, contextKey)
-
-  val irType = convertedBindingCode.type
+  val irType = bindingCode.type
 
   if (!irType.implementsLazyType() && !irType.implementsProviderType()) {
     // Not a provider, nothing else to do here!
-    return convertedBindingCode
+    // If KClass/Class interop is enabled and the consumer declared Map<Class<*>, V>,
+    // convert the canonical Map<KClass<*>, V> to Map<Class<*>, V> via `mapKeys { it.key.java }`
+    return maybeConvertMapKeysToJavaClass(bindingCode, contextKey)
   }
 
   val providerTypeConverter = symbols.providerTypeConverter
@@ -696,9 +694,7 @@ internal fun IrBuilderWithScope.typeAsProviderArgument(
             valueParameters = emptyList(),
             returnType = lazyType,
           ) {
-            +irReturn(
-              with(providerTypeConverter) { convertedBindingCode.convertTo(lazyContextKey) }
-            )
+            +irReturn(with(providerTypeConverter) { bindingCode.convertTo(lazyContextKey) })
           }
         } else {
           // ProviderOfLazy.create(provider) returns Provider<Lazy<T>>
@@ -707,14 +703,14 @@ internal fun IrBuilderWithScope.typeAsProviderArgument(
             dispatchReceiver = irGetObject(symbols.providerOfLazyCompanionObject),
             callee = symbols.providerOfLazyCreate,
             typeArgs = listOf(contextKey.typeKey.type),
-            args = listOf(convertedBindingCode),
+            args = listOf(bindingCode),
             typeHint =
               contextKey.typeKey.type.wrapInLazy(symbols).wrapInProvider(symbols.metroProvider),
           )
         }
       }
 
-      else -> with(providerTypeConverter) { convertedBindingCode.convertTo(contextKey) }
+      else -> with(providerTypeConverter) { bindingCode.convertTo(contextKey) }
     }
 
   // Determine whether we need to invoke the provider to get the value.
@@ -733,11 +729,16 @@ internal fun IrBuilderWithScope.typeAsProviderArgument(
 
   return if (shouldInvoke) {
     // provider.invoke()
-    irInvoke(
-      dispatchReceiver = metroProviderExpression,
-      callee = symbols.providerInvoke,
-      typeHint = contextKey.typeKey.type,
-    )
+    val invoked =
+      irInvoke(
+        dispatchReceiver = metroProviderExpression,
+        callee = symbols.providerInvoke,
+        typeHint = contextKey.typeKey.type,
+      )
+    // If KClass/Class interop is enabled and the consumer declared Map<Class<*>, V>,
+    // convert the canonical Map<KClass<*>, V> to Map<Class<*>, V> via `mapKeys { it.key.java }`.
+    // This must happen after invoking the provider, since the binding code is Provider<Map<...>>.
+    maybeConvertMapKeysToJavaClass(invoked, contextKey)
   } else {
     metroProviderExpression
   }
@@ -771,12 +772,30 @@ private fun maybeConvertMapKeysToJavaClass(
   val rawKeyClassId = keyType.rawType().classId
   if (rawKeyClassId != Symbols.ClassIds.JavaLangClass) return bindingCode
 
+  val rawKeyTypeProjection = rawType.arguments[0] as? IrTypeProjection ?: return bindingCode
+  val kclassKeyType =
+    makeTypeProjection(
+      rawKeyTypeProjection.type.normalizeToKClassIfJavaClass(),
+      rawKeyTypeProjection.variance,
+    )
+  val valueType = rawType.arguments[1]
+
   // The consumer declared Map<Class<*>, V>, convert map keys from KClass to Class
-  return convertClassMapToKClassMap(keyType, bindingCode)
+  return convertClassMapToKClassMap(
+    keyType = keyType,
+    kclassKeyType = kclassKeyType,
+    valueType = valueType,
+    bindingCode = bindingCode,
+  )
 }
 
 context(context: IrMetroContext, scope: IrBuilderWithScope)
-private fun convertClassMapToKClassMap(keyType: IrType, bindingCode: IrExpression): IrExpression {
+private fun convertClassMapToKClassMap(
+  keyType: IrType,
+  kclassKeyType: IrTypeArgument,
+  valueType: IrTypeArgument,
+  bindingCode: IrExpression,
+): IrExpression {
   val mapKeysFunction = context.metroSymbols.mapKeysFunction
   val mapEntryKeyGetter = context.metroSymbols.mapEntryKeyGetter
   val kClassJavaGetter =
@@ -784,11 +803,6 @@ private fun convertClassMapToKClassMap(keyType: IrType, bindingCode: IrExpressio
       ?: reportCompilerBug(
         "KClass.java property getter not found but enableKClassClassInterop is enabled"
       )
-
-  // Extract types from the binding's canonical map type: Map<KClass<*>, V>
-  val mapType = bindingCode.type.requireSimpleType()
-  val kclassKeyType = mapType.arguments[0]
-  val valueType = mapType.arguments[1]
 
   // Build Map.Entry<KClass<*>, V> type for the lambda parameter
   val entryType =


### PR DESCRIPTION
Handle KClass->Class map key conversion safely when binding expressions carry provider wrappers, and ensure direct-constructor graph generation paths also run through `typeAsProviderArgument` conversion logic.

The full stack trace was this:
```
> Task :common:reports-applet:impl:compileDebugKotlin FAILED
e: org.jetbrains.kotlin.fir.pipeline.IrGenerationExtensionException: Index: 1, Size: 1
        at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.applyIrGenerationExtensions(convertToIr.kt:577)
        at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.runActualizationPipeline(convertToIr.kt:279)
        at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.convertToIrAndActualize(convertToIr.kt:150)
        at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize(convertToIr.kt:115)
        at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize$default(convertToIr.kt:88)
        at org.jetbrains.kotlin.cli.jvm.compiler.legacy.pipeline.JvmCompilerPipelineKt.convertToIrAndActualizeForJvm(jvmCompilerPipeline.kt:100)
        at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:30)
        at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:25)
        at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:19)
        at org.jetbrains.kotlin.cli.pipeline.PipelinePhase.phaseBody(PipelinePhase.kt:68)
        at org.jetbrains.kotlin.cli.pipeline.PipelinePhase.phaseBody(PipelinePhase.kt:58)
        at org.jetbrains.kotlin.config.phaser.NamedCompilerPhase.invoke(CompilerPhase.kt:102)
        at org.jetbrains.kotlin.backend.common.phaser.CompositePhase.invoke(PhaseBuilders.kt:22)
        at org.jetbrains.kotlin.config.phaser.CompilerPhaseKt.invokeToplevel(CompilerPhase.kt:53)
        at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.runPhasedPipeline(AbstractCliPipeline.kt:109)
        at org.jetbrains.kotlin.cli.pipeline.AbstractCliPipeline.execute(AbstractCliPipeline.kt:68)
        at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecutePhased(K2JVMCompiler.kt:51)
        at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecutePhased(K2JVMCompiler.kt:42)
        at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:89)
        at org.jetbrains.kotlin.cli.common.CLICompiler.exec(CLICompiler.kt:359)
        at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunnerBase.runCompiler(IncrementalJvmCompilerRunnerBase.kt:178)
        at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunnerBase.runCompiler(IncrementalJvmCompilerRunnerBase.kt:40)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:504)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:418)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileNonIncrementally(IncrementalCompilerRunner.kt:301)
        at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:128)
        at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:684)
        at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:94)
        at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1810)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:360)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:714)
        at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:598)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:844)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:721)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:720)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
        at java.base/java.util.Collections$SingletonList.get(Collections.java:5180)
        at dev.zacsweers.metro.compiler.ir.IrKt.convertClassMapToKClassMap(ir.kt:791)
        at dev.zacsweers.metro.compiler.ir.IrKt.maybeConvertMapKeysToJavaClass(ir.kt:775)
        at dev.zacsweers.metro.compiler.ir.IrKt.typeAsProviderArgument(ir.kt:664)
        at dev.zacsweers.metro.compiler.ir.transformers.InjectedClassTransformer.implementFactoryInvokeOrGetBody(InjectedClassTransformer.kt:436)
        at dev.zacsweers.metro.compiler.ir.transformers.InjectedClassTransformer.getOrGenerateFactory(InjectedClassTransformer.kt:358)
        at dev.zacsweers.metro.compiler.ir.transformers.InjectedClassTransformer.visitClass(InjectedClassTransformer.kt:95)
        at dev.zacsweers.metro.compiler.ir.transformers.CoreTransformers.visitClassInner(CoreTransformers.kt:126)
        at dev.zacsweers.metro.compiler.ir.transformers.CoreTransformers.visitClassNew(CoreTransformers.kt:99)
        at org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext.visitClass(IrElementTransformerVoidWithContext.kt:62)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:57)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitClass(IrElementTransformerVoid.kt:19)
        at org.jetbrains.kotlin.ir.declarations.IrClass.accept(IrClass.kt:72)
        at org.jetbrains.kotlin.ir.IrElementBase.transform(IrElementBase.kt:33)
        at org.jetbrains.kotlin.ir.util.TransformKt.transformInPlace(transform.kt:35)
        at org.jetbrains.kotlin.ir.declarations.IrPackageFragment.transformChildren(IrPackageFragment.kt:31)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitPackageFragment(IrElementTransformerVoid.kt:146)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:160)
        at org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext.visitFileNew(IrElementTransformerVoidWithContext.kt:122)
        at org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext.visitFile(IrElementTransformerVoidWithContext.kt:55)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:163)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitFile(IrElementTransformerVoid.kt:19)
        at org.jetbrains.kotlin.ir.declarations.IrFile.accept(IrFile.kt:27)
        at org.jetbrains.kotlin.ir.declarations.IrFile.transform(IrFile.kt:30)
        at org.jetbrains.kotlin.ir.declarations.IrFile.transform(IrFile.kt:19)
        at org.jetbrains.kotlin.ir.util.TransformKt.transformInPlace(transform.kt:35)
        at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.transformChildren(IrModuleFragment.kt:46)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitModuleFragment(IrElementTransformerVoid.kt:102)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitModuleFragment(IrElementTransformerVoid.kt:107)
        at org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid.visitModuleFragment(IrElementTransformerVoid.kt:19)
        at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.accept(IrModuleFragment.kt:36)
        at org.jetbrains.kotlin.ir.declarations.IrModuleFragment.transform(IrModuleFragment.kt:39)
        at dev.zacsweers.metro.compiler.ir.MetroIrGenerationExtension.generateInner(MetroIrGenerationExtension.kt:129)
        at dev.zacsweers.metro.compiler.ir.MetroIrGenerationExtension.generate(MetroIrGenerationExtension.kt:70)
        at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.applyIrGenerationExtensions(convertToIr.kt:571)
        ... 43 more

```