### PR TITLE
CompilerCompat: Include compat modules only when they have version.txt

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -127,7 +127,7 @@ dependencies {
   add(embedded.name, libs.kotlinx.serialization.json)
   add(embedded.name, project(":compiler-compat"))
   rootProject.isolated.projectDirectory.dir("compiler-compat").asFile.listFiles()!!.forEach {
-    if (it.isDirectory && it.name.startsWith("k")) {
+    if (it.isDirectory && it.name.startsWith("k") && File(it, "version.txt").exists()) {
       add(embedded.name, project(":compiler-compat:${it.name}"))
     }
   }


### PR DESCRIPTION
This PR resolves an error when there are stale compiler targets with `build` dirs, currently they will be picked up because of [this](https://github.com/ZacSweers/metro/blob/f876cde9a5894a71fddb2743eaaf5a59afd3ccd4/compiler/build.gradle.kts#L129-L133) check. I've enhanced it a bit and check for `version.txt` existence.
```
Could not determine the dependencies of task ':compiler:shadowJar'.
> Could not resolve all dependencies for configuration ':compiler:embeddedClasspath'.
   > Could not resolve project :compiler-compat:k2320_beta2.
     Required by:
         project ':compiler'
      > Unable to find a matching variant of project :compiler-compat:k2320_beta2:
          - No variants exist.
   > Could not resolve project :compiler-compat:k2320_dev_5706.
     Required by:
         project ':compiler'
      > Unable to find a matching variant of project :compiler-compat:k2320_dev_5706:
          - No variants exist.
   > Could not resolve project :compiler-compat:k2320_beta1.
     Required by:
         project ':compiler'
      > Unable to find a matching variant of project :compiler-compat:k2320_beta1:
          - No variants exist.
```