### PR TITLE
Remove implicitClassKey from ViewModelAssistedFactoryKey

### DIFF
--- a/metrox-viewmodel/api/metrox-viewmodel.klib.api
+++ b/metrox-viewmodel/api/metrox-viewmodel.klib.api
@@ -14,7 +14,7 @@ open annotation class dev.zacsweers.metrox.viewmodel/ManualViewModelAssistedFact
 }
 
 open annotation class dev.zacsweers.metrox.viewmodel/ViewModelAssistedFactoryKey : kotlin/Annotation { // dev.zacsweers.metrox.viewmodel/ViewModelAssistedFactoryKey|null[0]
-    constructor <init>(kotlin.reflect/KClass<out androidx.lifecycle/ViewModel> = ...) // dev.zacsweers.metrox.viewmodel/ViewModelAssistedFactoryKey.<init>|<init>(kotlin.reflect.KClass<out|androidx.lifecycle.ViewModel>){}[0]
+    constructor <init>(kotlin.reflect/KClass<out androidx.lifecycle/ViewModel>) // dev.zacsweers.metrox.viewmodel/ViewModelAssistedFactoryKey.<init>|<init>(kotlin.reflect.KClass<out|androidx.lifecycle.ViewModel>){}[0]
 
     final val value // dev.zacsweers.metrox.viewmodel/ViewModelAssistedFactoryKey.value|{}value[0]
         final fun <get-value>(): kotlin.reflect/KClass<out androidx.lifecycle/ViewModel> // dev.zacsweers.metrox.viewmodel/ViewModelAssistedFactoryKey.value.<get-value>|<get-value>(){}[0]

--- a/metrox-viewmodel/src/commonMain/kotlin/dev/zacsweers/metrox/viewmodel/ViewModelKeys.kt
+++ b/metrox-viewmodel/src/commonMain/kotlin/dev/zacsweers/metrox/viewmodel/ViewModelKeys.kt
@@ -24,7 +24,7 @@ public annotation class ViewModelKey(val value: KClass<out ViewModel> = Nothing:
  * A [MapKey] annotation for binding [assisted ViewModel factories][ViewModelAssistedFactory] in a
  * multibinding map.
  */
-@MapKey(implicitClassKey = true)
+@MapKey
 @Target(
   AnnotationTarget.FUNCTION,
   AnnotationTarget.FIELD,
@@ -34,9 +34,7 @@ public annotation class ViewModelKey(val value: KClass<out ViewModel> = Nothing:
   AnnotationTarget.TYPE,
 )
 @Retention(AnnotationRetention.RUNTIME)
-public annotation class ViewModelAssistedFactoryKey(
-  val value: KClass<out ViewModel> = Nothing::class
-)
+public annotation class ViewModelAssistedFactoryKey(val value: KClass<out ViewModel>)
 
 /**
  * A [MapKey] annotation for binding


### PR DESCRIPTION
I'm trying to integrate metrox-viewmodel in my project, and noticed `@ViewModelAssistedFactoryKey` has an implicit class key. From my understanding, we will always need to specify the class in this annotation because Factory is a separate instance from the ViewModel:

```kotlin
@AssistedInject
class SettingsViewModel(@Assisted val userId: String) : ViewModel() {

  @AssistedFactory
  @ViewModelAssistedFactoryKey(SettingsViewModel::class) // <--- we always need to specify VM class
  @ContributesIntoMap(AppScope::class)
  fun interface Factory : ViewModelAssistedFactory
}
```

Not sure if this was deliberate or not, please close the PR if it's not relevant 🙇 