### PR TITLE
Honor provider-holder origins in FIR replacement merging

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -464,16 +464,34 @@ internal class ContributedInterfaceSupertypeGenerator(
 
     // Process replacements from native contributions
     val unmatchedReplacements = mutableSetOf<ClassId>()
-    contributionClassLikes
-      .mapNotNull {
-        val symbol = it.toClassSymbol(session)
-        // TODO remove expectAs in 2.3.20
-        if (contributionMappingsByClassId[it.expectAs<ConeKotlinType>().classId] == true) {
-          // It's a binding container, use as-is
-          symbol
-        } else {
-          // It's a contribution, get its original parent
-          symbol?.getContainingClassSymbol()
+    sequence {
+        yieldAll(
+          contributionClassLikes.mapNotNull {
+            val symbol = it.toClassSymbol(session)
+            // TODO remove expectAs in 2.3.20
+            if (contributionMappingsByClassId[it.expectAs<ConeKotlinType>().classId] == true) {
+              // It's a binding container, use as-is
+              symbol
+            } else {
+              // It's a contribution, get its original parent
+              symbol?.getContainingClassSymbol()
+            }
+          }
+        )
+
+        // When generateContributionProviders is enabled, binding contributions are represented by
+        // provider-holder binding containers that only carry @Origin. Scan the origin class too so
+        // its original @ContributesBinding(replaces = ...) annotations still participate in FIR
+        // merging, matching the IR fallback logic.
+        for ((containerClassId, isBindingContainer) in contributionMappingsByClassId) {
+          if (!isBindingContainer) continue
+          val containerSymbol =
+            containerClassId.toSymbol(session)?.expectAsOrNull<FirRegularClassSymbol>() ?: continue
+          val localTypeResolver = typeResolverFor(containerSymbol) ?: continue
+          val originClassId = containerSymbol.originClassId(session, localTypeResolver) ?: continue
+          val originClass =
+            originClassId.toSymbol(session)?.expectAsOrNull<FirClassSymbol<*>>() ?: continue
+          yield(originClass)
         }
       }
       .flatMap { contributingType ->


### PR DESCRIPTION
With `generateContributionProviders` enabled, binding contributions are represented by generated provider-holder containers that only carry `@Origin`. FIR replacement scanning only inspected the generated container itself, so `@ContributesBinding(replaces = ...)` on the origin class was ignored.

Scan provider-holder origins while collecting native replacements in `ContributedInterfaceSupertypeGenerator` so replaced classes still remove extension-generated contributions during FIR merging. This restores the expected replacement behavior for the remaining metro-extensions regressions under contribution providers.
