### PR TITLE
Wrap type resolution in InjectedClassFirGenerator with try-catch

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/InjectedClassFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/InjectedClassFirGenerator.kt
@@ -271,7 +271,8 @@ internal class InjectedClassFirGenerator(session: FirSession, compatContext: Com
               try {
                 resolver.resolveType(it)
               } catch (_: Exception) {
-                // Generic type resolution may fail during IDE indexing
+                // Generic type resolution may fail during IDE indexing because
+                // this isn't a deep resolve
                 return@any false
               }
             }


### PR DESCRIPTION
Encountered an error (full stacktrace [here](https://gist.github.com/kevinguitar/4088a13d18973c1ff724f90a4b35160d)) in the IDE while editing the code.
```
org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments: Expected FirResolvedTypeRef with ConeKotlinType but was FirUserTypeRefImpl
	at org.jetbrains.kotlin.fir.types.FirTypeUtilsKt.getConeType(FirTypeUtils.kt:201)
	at org.jetbrains.kotlin.fir.types.FirTypeUtilsKt.toConeTypeProjection(FirTypeUtils.kt:161)
	at org.jetbrains.kotlin.fir.resolve.providers.impl.FirTypeResolverImpl.resolveUserType(FirTypeResolverImpl.kt:195)
	at org.jetbrains.kotlin.fir.resolve.providers.impl.FirTypeResolverImpl.resolveType(FirTypeResolverImpl.kt:394)
	at dev.zacsweers.metro.compiler.fir.MetroFirTypeResolver$LocalMetroFirTypeResolver.resolveType(TypeResolverFactory.kt:132)
	at dev.zacsweers.metro.compiler.fir.generators.InjectedClassFirGenerator$InjectedClass.parentClassHasMemberInjections(InjectedClassFirGenerator.kt:271)
	at dev.zacsweers.metro.compiler.fir.generators.InjectedClassFirGenerator.generateNestedClassLikeDeclaration(InjectedClassFirGenerator.kt:506)
	at dev.zacsweers.metro.compiler.fir.generators.CompositeMetroFirDeclarationGenerationExtension.generateNestedClassLikeDeclaration(CompositeMetroFirDeclarationGenerationExtension.kt:149)
	at dev.zacsweers.metro.compiler.fir.generators.KotlinOnlyFirGenerationExtension.generateNestedClassLikeDeclaration(KotlinOnlyFirGenerationExtension.kt:46)

```

I tried the fix locally, and I can confirm the error goes away for me.

Resolves #2104 