### PR TITLE
Fix missing contribution hints for assisted factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 **Unreleased**
 --------------
 
+### Fixes
+
+- **[FIR]** Fix missing contribution hints for assisted factories
+
 ### Changes
 
 - Mark generated Circuit factories as `@Deprecated(HIDDEN)` + disable them in IDE as they're not necessary there.

--- a/compiler-tests/src/test/data/box/aggregation/contributionproviders/abstractedAssistedFactoryIsAccessibleExternally.kt
+++ b/compiler-tests/src/test/data/box/aggregation/contributionproviders/abstractedAssistedFactoryIsAccessibleExternally.kt
@@ -1,0 +1,40 @@
+// MODULE: lib
+interface Base {
+  val text: String
+
+  interface Factory {
+    fun create(text: String): Base
+  }
+}
+
+// MODULE: impl(lib)
+@AssistedInject
+class BaseImpl(
+  @Assisted override val text: String
+) : Base {
+
+  @ContributesBinding(AppScope::class)
+  @AssistedFactory
+  interface Factory : Base.Factory {
+    override fun create(text: String): BaseImpl
+  }
+}
+
+// MODULE: main(lib, impl)
+@Inject
+class Example(
+  factory: Base.Factory
+) {
+  val text = factory.create("example").text
+}
+
+@DependencyGraph(AppScope::class)
+interface AppGraph {
+  val example: Example
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertEquals("example", graph.example.text)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -257,6 +257,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     @TestDataPath("$PROJECT_ROOT")
     public class Contributionproviders {
       @Test
+      @TestMetadata("abstractedAssistedFactoryIsAccessibleExternally.kt")
+      public void testAbstractedAssistedFactoryIsAccessibleExternally() {
+        runTest("compiler-tests/src/test/data/box/aggregation/contributionproviders/abstractedAssistedFactoryIsAccessibleExternally.kt");
+      }
+
+      @Test
       public void testAllFilesPresentInContributionproviders() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler-tests/src/test/data/box/aggregation/contributionproviders"), Pattern.compile("^(.+)\\.kt$"), null, true);
       }

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -248,6 +248,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
   @TestDataPath("$PROJECT_ROOT")
   public class Contributionproviders {
     @Test
+    @TestMetadata("abstractedAssistedFactoryIsAccessibleExternally.kt")
+    public void testAbstractedAssistedFactoryIsAccessibleExternally() {
+      runTest("compiler-tests/src/test/data/box/aggregation/contributionproviders/abstractedAssistedFactoryIsAccessibleExternally.kt");
+    }
+
+    @Test
     public void testAllFilesPresentInContributionproviders() {
       KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler-tests/src/test/data/box/aggregation/contributionproviders"), Pattern.compile("^(.+)\\.kt$"), null, true);
     }

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -257,6 +257,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     @TestDataPath("$PROJECT_ROOT")
     public class Contributionproviders {
       @Test
+      @TestMetadata("abstractedAssistedFactoryIsAccessibleExternally.kt")
+      public void testAbstractedAssistedFactoryIsAccessibleExternally() {
+        runTest("compiler-tests/src/test/data/box/aggregation/contributionproviders/abstractedAssistedFactoryIsAccessibleExternally.kt");
+      }
+
+      @Test
       public void testAllFilesPresentInContributionproviders() {
         KtTestUtil.assertAllTestsPresentByMetadataWithExcluded(this.getClass(), new File("compiler-tests/src/test/data/box/aggregation/contributionproviders"), Pattern.compile("^(.+)\\.kt$"), null, true);
       }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionHintFirGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributionHintFirGenerator.kt
@@ -16,6 +16,7 @@ import dev.zacsweers.metro.compiler.fir.metroFirBuiltIns
 import dev.zacsweers.metro.compiler.fir.predicates
 import dev.zacsweers.metro.compiler.fir.resolvedArgumentTypeRef
 import dev.zacsweers.metro.compiler.fir.scopeArgument
+import dev.zacsweers.metro.compiler.fir.usesContributionProviderPath
 import dev.zacsweers.metro.compiler.getAndAdd
 import dev.zacsweers.metro.compiler.ir.transformers.HintGenerator
 import dev.zacsweers.metro.compiler.mapNotNullToSet
@@ -96,6 +97,7 @@ internal class ContributionHintFirGenerator(
         // so we must compute their ClassIds and resolve them here.
         val hasBindingContributions =
           generateContributionProviders &&
+            contributingClass.usesContributionProviderPath(session) &&
             contributions.any { annotation ->
               val classId = annotation.toAnnotationClassIdSafe(session) ?: return@any false
               classId !in session.classIds.contributesToAnnotations


### PR DESCRIPTION
Ran into a missing binding on an abstract assisted factory:
```
error: [Metro/MissingBinding] Cannot find an @Inject constructor or @Provides-annotated function/property for: Base.Factory

    Base.Factory is injected at
        [AppGraph] Example(…, factory)
    Example is requested at
        [AppGraph] AppGraph.example
```

_Disclosure: The bug was located with the help of AI_