### PR TITLE
Add macosX64 target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ Changelog
 ### Changes
 
 - Mark generated Circuit factories as `@Deprecated(HIDDEN)` + disable them in IDE as they're not necessary there.
+- Add back deprecated `macosX64()`, `tvosX64()`, and `watchosX64()` targets for now due to [KT-78660 (comment)](https://youtrack.jetbrains.com/issue/KT-78660#focus=Comments-27-13603171.0-0).
 
 ### Contributors
 
 Special thanks to the following contributors for contributing to this release!
 
 - [@kevinguitar](https://github.com/kevinguitar)
+- [@LionZXY](https://github.com/LionZXY)
 - [@Sultan1993](https://github.com/Sultan1993)
 
 0.13.2

--- a/build-logic/src/main/kotlin/MetroProjectExtension.kt
+++ b/build-logic/src/main/kotlin/MetroProjectExtension.kt
@@ -101,6 +101,7 @@ constructor(private val project: Project, objects: ObjectFactory) {
           iosSimulatorArm64()
           iosArm64()
           iosX64()
+          macosX64()
         } else {
           // Tier 1
           macosArm64()
@@ -119,6 +120,9 @@ constructor(private val project: Project, objects: ObjectFactory) {
           // Tier 3
           mingwX64()
           iosX64()
+          macosX64()
+          tvosX64()
+          watchosX64()
           if (!requiresAndroidXDeps) {
             androidNativeArm32()
             androidNativeArm64()

--- a/metrox-viewmodel-compose/api/metrox-viewmodel-compose.klib.api
+++ b/metrox-viewmodel-compose/api/metrox-viewmodel-compose.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, macosX64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/metrox-viewmodel/api/metrox-viewmodel.klib.api
+++ b/metrox-viewmodel/api/metrox-viewmodel.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/runtime/api/runtime.klib.api
+++ b/runtime/api/runtime.klib.api
@@ -1,6 +1,6 @@
 // Klib ABI Dump
-// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
-// Alias: native => [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, mingwX64, tvosArm64, tvosSimulatorArm64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Targets: [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, wasmWasi, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
+// Alias: native => [androidNativeArm32, androidNativeArm64, androidNativeX64, androidNativeX86, iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true


### PR DESCRIPTION
Although the Kotlin team already considers these targets to be deprecated, **dropping them for Metro makes it impossible to use Metro for apps that have already been published on the App Store**. This is because the App Store requires a macosX64 target for apps that previously supported it.

> Apps for Macs with Apple silicon. If your Mac app requires the high performance of Apple silicon, you can make your app available on the Mac App Store only to Macs with an M1 chip or later. To only support Macs with Apple silicon, your app must require a minimum OS version of macOS Monterey 12 or later, **and have never supported Intel-based Macs**. In Xcode, update the Architectures build setting for your target and specify to build ARM64 only. Apps can add Intel support and lower the minimum OS version in an update but, once released, they cannot return to only supporting Apple silicon.

Source: https://developer.apple.com/app-store/submitting/

That’s why I think macosX64 is worth enabling

References:
- Kotlin Slack discussion [here](https://kotlinlang.slack.com/archives/C0KLZSCHF/p1775552300894569?thread_ts=1775051562.095799&cid=C0KLZSCHF)
- YouTrack issue [here](https://youtrack.jetbrains.com/issue/KT-78660#focus=Comments-27-13603171.0-0)
- Clean up PR [here](https://github.com/ZacSweers/metro/pull/2025)