### PR TITLE
Fix generateContributionProviders doc

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
@@ -855,7 +855,7 @@ internal enum class MetroOption(val raw: RawMetroOption<*>) {
       defaultValue = false,
       valueDescription = "<true | false>",
       description =
-        "When enabled, generates top-level contribution provider classes with @Provides functions instead of nested @Binds interfaces. This allows implementation classes to remain internal/private.",
+        "When enabled, generates top-level contribution provider classes with @Provides functions instead of nested @Binds interfaces. This allows implementation classes to remain internal.",
       required = false,
       allowMultipleOccurrences = false,
     )

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroPluginExtension.kt
@@ -427,9 +427,8 @@ constructor(
   /**
    * When enabled, generates top-level contribution provider classes with `@Provides` functions
    * instead of nested `@Binds` interfaces for `@ContributesBinding`, `@ContributesIntoSet`, and
-   * `@ContributesIntoMap`. This allows implementation classes to remain `internal` or `private`
-   * since the generated provider directly constructs them (which in turn allows for finer grained
-   * IC).
+   * `@ContributesIntoMap`. This allows implementation classes to remain `internal` since the
+   * generated provider directly constructs them (which in turn allows for finer grained IC).
    *
    * Disabled by default.
    */


### PR DESCRIPTION
Fixed a mistake in the `generateContributionProviders` doc - impl class can only be internal.