### PR TITLE
Fix default values getting overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 - **[FIR]** Fix another eager `allSessions` lookup to avoid lockups in the IDE.
 - **[FIR/IR]** Ensure qualifier annotations on explicit binding params are propagated to generated providers when `generateContributionProviders` is enabled.
 - **[FIR/IR/Circuit]** Fix support for `@CircuitInject` on non-`@Inject`-annotated classes.
+- **[IR]** Check for matching parameter's default value first when copying default value expressions. Previously, if multiple parameters with the same type had default values, only one would be used.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changelog
 
 Special thanks to the following contributors for contributing to this release!
 
+- [@asapha](https://github.com/asapha)
 - [@kevinguitar](https://github.com/kevinguitar)
 - [@LionZXY](https://github.com/LionZXY)
 - [@Sultan1993](https://github.com/Sultan1993)

--- a/compiler-tests/src/test/data/box/dependencygraph/optional/DefaultValuesAlignToParameters.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/optional/DefaultValuesAlignToParameters.kt
@@ -1,5 +1,3 @@
-// MODULE: main
-
 @Inject
 data class Example(
   val foo: String = "foo",

--- a/compiler-tests/src/test/data/box/dependencygraph/optional/UseDefaultValues.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/optional/UseDefaultValues.kt
@@ -1,0 +1,21 @@
+// MODULE: main
+
+@Inject
+data class Example(
+  val foo: String = "foo",
+  val one: Int = 1,
+  val bar: String = "bar",
+  val two: Int = 2,
+)
+
+@DependencyGraph(AppScope::class)
+interface AppGraph {
+  val exampleFactory: Provider<Example>
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+
+  assertEquals(Example(), graph.exampleFactory())
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -1610,6 +1610,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       public void testScopedDefaultInSeparateCompilation() {
         runTest("compiler-tests/src/test/data/box/dependencygraph/optional/ScopedDefaultInSeparateCompilation.kt");
       }
+
+      @Test
+      @TestMetadata("UseDefaultValues.kt")
+      public void testUseDefaultValues() {
+        runTest("compiler-tests/src/test/data/box/dependencygraph/optional/UseDefaultValues.kt");
+      }
     }
 
     @Nested

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -1588,6 +1588,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("DefaultValuesAlignToParameters.kt")
+      public void testDefaultValuesAlignToParameters() {
+        runTest("compiler-tests/src/test/data/box/dependencygraph/optional/DefaultValuesAlignToParameters.kt");
+      }
+
+      @Test
       @TestMetadata("DefaultWorksWithoutAnnotation.kt")
       public void testDefaultWorksWithoutAnnotation() {
         runTest("compiler-tests/src/test/data/box/dependencygraph/optional/DefaultWorksWithoutAnnotation.kt");
@@ -1609,12 +1615,6 @@ public class BoxTestGenerated extends AbstractBoxTest {
       @TestMetadata("ScopedDefaultInSeparateCompilation.kt")
       public void testScopedDefaultInSeparateCompilation() {
         runTest("compiler-tests/src/test/data/box/dependencygraph/optional/ScopedDefaultInSeparateCompilation.kt");
-      }
-
-      @Test
-      @TestMetadata("UseDefaultValues.kt")
-      public void testUseDefaultValues() {
-        runTest("compiler-tests/src/test/data/box/dependencygraph/optional/UseDefaultValues.kt");
       }
     }
 

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -1588,6 +1588,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("DefaultValuesAlignToParameters.kt")
+      public void testDefaultValuesAlignToParameters() {
+        runTest("compiler-tests/src/test/data/box/dependencygraph/optional/DefaultValuesAlignToParameters.kt");
+      }
+
+      @Test
       @TestMetadata("DefaultWorksWithoutAnnotation.kt")
       public void testDefaultWorksWithoutAnnotation() {
         runTest("compiler-tests/src/test/data/box/dependencygraph/optional/DefaultWorksWithoutAnnotation.kt");
@@ -1609,12 +1615,6 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       @TestMetadata("ScopedDefaultInSeparateCompilation.kt")
       public void testScopedDefaultInSeparateCompilation() {
         runTest("compiler-tests/src/test/data/box/dependencygraph/optional/ScopedDefaultInSeparateCompilation.kt");
-      }
-
-      @Test
-      @TestMetadata("UseDefaultValues.kt")
-      public void testUseDefaultValues() {
-        runTest("compiler-tests/src/test/data/box/dependencygraph/optional/UseDefaultValues.kt");
       }
     }
 

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -1610,6 +1610,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       public void testScopedDefaultInSeparateCompilation() {
         runTest("compiler-tests/src/test/data/box/dependencygraph/optional/ScopedDefaultInSeparateCompilation.kt");
       }
+
+      @Test
+      @TestMetadata("UseDefaultValues.kt")
+      public void testUseDefaultValues() {
+        runTest("compiler-tests/src/test/data/box/dependencygraph/optional/UseDefaultValues.kt");
+      }
     }
 
     @Nested

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -679,6 +679,7 @@ internal fun IrBuilderWithScope.parametersAsProviderArguments(
   parameters: Parameters,
   receiver: IrValueParameter,
   fields: Map<IrTypeKey, IrField>,
+  nameToField: Map<Name, IrField>? = null,
   calleeParameters: Parameters = parameters,
 ): List<IrExpression?> {
   return buildList {
@@ -688,7 +689,10 @@ internal fun IrBuilderWithScope.parametersAsProviderArguments(
         .map { parameter ->
           // When calling value getter on Provider<T>, make sure the dispatch
           // receiver is the Provider instance itself
-          val providerInstance = irGetField(irGet(receiver), fields.getValue(parameter.typeKey))
+          // Look up by name first (handles multiple params with same type key),
+          // fall back to type key (handles deduped params where name was removed)
+          val field = nameToField?.get(parameter.name) ?: fields.getValue(parameter.typeKey)
+          val providerInstance = irGetField(irGet(receiver), field)
           typeAsProviderArgument(
             parameter.contextualTypeKey,
             providerInstance,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindingContainerTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindingContainerTransformer.kt
@@ -348,6 +348,10 @@ internal class BindingContainerTransformer(context: IrMetroContext) :
         sourceParameters
       }
 
+    // Use parameter name as the primary field key to correctly handle multiple parameters
+    // with the same type key (e.g., two String params with different defaults).
+    // The typeKey map is kept as a fallback for dedup cases.
+    val nameToField = mutableMapOf<Name, IrField>()
     val typeKeyToField = mutableMapOf<IrTypeKey, IrField>()
     val ctor: IrConstructor
     if (factoryCls.isObject) {
@@ -378,7 +382,9 @@ internal class BindingContainerTransformer(context: IrMetroContext) :
           stubDefaults = false,
           typeRemapper = { type -> typeRemapper.remapType(type) },
         ) { typeKey, irParam ->
-          typeKeyToField[typeKey] = irParam.addBackingFieldTo(factoryCls)
+          val field = irParam.addBackingFieldTo(factoryCls)
+          nameToField[irParam.name] = field
+          typeKeyToField[typeKey] = field
         }
         body = generateDefaultConstructorBody()
       }
@@ -401,6 +407,7 @@ internal class BindingContainerTransformer(context: IrMetroContext) :
                 parameters = sourceParameters,
                 receiver = invokeFunction.dispatchReceiverParameter!!,
                 fields = typeKeyToField,
+                nameToField = nameToField,
               ),
           )
         )

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectedClassTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectedClassTransformer.kt
@@ -80,6 +80,7 @@ import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.Name
 
 internal class InjectedClassTransformer(
   context: IrMetroContext,
@@ -307,6 +308,11 @@ internal class InjectedClassTransformer(
         nonAssistedParameters
       }
 
+    // Use parameter name as the primary field key to correctly handle multiple parameters
+    // with the same type key (e.g., two String params with different defaults).
+    // The typeKey map is kept as a fallback for dedup cases where the original parameter
+    // name was deduped away but shares a type key with the surviving parameter.
+    val nameToField = mutableMapOf<Name, IrField>()
     val typeKeyToField = mutableMapOf<IrTypeKey, IrField>()
     val ctor: IrConstructor
     if (factoryCls.isObject) {
@@ -329,7 +335,9 @@ internal class InjectedClassTransformer(
               stubDefaults = false,
               typeRemapper = { type -> typeRemapper.remapType(type) },
             ) { typeKey, irParam ->
-              typeKeyToField[typeKey] = irParam.addBackingFieldTo(factoryCls)
+              val field = irParam.addBackingFieldTo(factoryCls)
+              nameToField[irParam.name] = field
+              typeKeyToField[typeKey] = field
             }
             body = generateDefaultConstructorBody()
           }
@@ -370,6 +378,7 @@ internal class InjectedClassTransformer(
       newInstanceFunction,
       constructorParameters,
       injectors,
+      nameToField,
       typeKeyToField,
     )
 
@@ -414,7 +423,8 @@ internal class InjectedClassTransformer(
     newInstanceFunction: IrSimpleFunction,
     constructorParameters: Parameters,
     injectors: List<MembersInjectorTransformer.MemberInjectClass>,
-    fields: Map<IrTypeKey, IrField>,
+    nameToField: Map<Name, IrField>,
+    typeKeyToField: Map<IrTypeKey, IrField>,
   ) {
     if (invokeFunction.isFakeOverride) {
       invokeFunction.finalizeFakeOverride(thisReceiver)
@@ -439,7 +449,10 @@ internal class InjectedClassTransformer(
                 val providerInstance =
                   irGetField(
                     irGet(invokeFunction.dispatchReceiverParameter!!),
-                    fields.getValue(constructorParam.typeKey),
+                    // Look up by name first (handles multiple params with same type key),
+                    // fall back to type key (handles deduped params where name was removed)
+                    nameToField[constructorParam.name]
+                      ?: typeKeyToField.getValue(constructorParam.typeKey),
                   )
                 val contextKey = targetParam.contextualTypeKey
                 typeAsProviderArgument(
@@ -494,7 +507,7 @@ internal class InjectedClassTransformer(
                       parametersAsProviderArguments(
                         parameters,
                         invokeFunction.dispatchReceiverParameter!!,
-                        fields,
+                        typeKeyToField,
                       )
                     )
                   },


### PR DESCRIPTION
Hey, I got a subtle one…
If you have multiple default values of the same type in a constructor, they all end up having the same value when injected.

The test results in

```
Expected <Example(foo=foo, one=1, bar=bar, two=2)>, actual <Example(foo=bar, one=2, bar=bar, two=2)>.
```

Dumped via `scratch.kt`

```kotlin
  class MetroFactory : Factory<Example> {
      […]
       override operator fun invoke(): Example {
      return Companion.newInstance(foo = <this>.#bar.invoke(), one = <this>.#two.invoke(), bar = <this>.#bar.invoke(), two = <this>.#two.invoke())
    }
  }
```

Can repro in 0.12