### PR TITLE
Fix implicit bound type cache collisions

### DIFF
--- a/compiler-tests/src/test/data/box/aggregation/interop/QualifiedContributesBindingAndIgnoreQualifierMultibinding.kt
+++ b/compiler-tests/src/test/data/box/aggregation/interop/QualifiedContributesBindingAndIgnoreQualifierMultibinding.kt
@@ -1,0 +1,36 @@
+// WITH_ANVIL
+
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+
+// Regression test for PR #2096. A qualified explicit binding and an explicit
+// multibinding with ignoreQualifier = true on the same class must not share the
+// same resolved qualified key.
+
+@Qualifier
+annotation class DatabaseQualifier
+
+interface DatabaseFile {
+  val path: String
+}
+
+@DatabaseQualifier
+@ContributesBinding(AppScope::class)
+@ContributesMultibinding(AppScope::class, ignoreQualifier = true)
+@Inject
+class DatabaseFileImpl : DatabaseFile {
+  override val path: String = "database.db"
+}
+
+@DependencyGraph(scope = AppScope::class)
+interface ExampleGraph {
+  @DatabaseQualifier val qualifiedDatabaseFile: DatabaseFile
+  val databaseFiles: Set<DatabaseFile>
+}
+
+fun box(): String {
+  val graph = createGraph<ExampleGraph>()
+  assertEquals("database.db", graph.qualifiedDatabaseFile.path)
+  assertEquals(listOf("database.db"), graph.databaseFiles.map { it.path })
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -428,6 +428,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("QualifiedContributesBindingAndIgnoreQualifierMultibinding.kt")
+      public void testQualifiedContributesBindingAndIgnoreQualifierMultibinding() {
+        runTest("compiler-tests/src/test/data/box/aggregation/interop/QualifiedContributesBindingAndIgnoreQualifierMultibinding.kt");
+      }
+
+      @Test
       @TestMetadata("RankBasedReplacementFromClassWithMultipleBindingsInGraphExtension.kt")
       public void testRankBasedReplacementFromClassWithMultipleBindingsInGraphExtension() {
         runTest("compiler-tests/src/test/data/box/aggregation/interop/RankBasedReplacementFromClassWithMultipleBindingsInGraphExtension.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -419,6 +419,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     }
 
     @Test
+    @TestMetadata("QualifiedContributesBindingAndIgnoreQualifierMultibinding.kt")
+    public void testQualifiedContributesBindingAndIgnoreQualifierMultibinding() {
+      runTest("compiler-tests/src/test/data/box/aggregation/interop/QualifiedContributesBindingAndIgnoreQualifierMultibinding.kt");
+    }
+
+    @Test
     @TestMetadata("RankBasedReplacementFromClassWithMultipleBindingsInGraphExtension.kt")
     public void testRankBasedReplacementFromClassWithMultipleBindingsInGraphExtension() {
       runTest("compiler-tests/src/test/data/box/aggregation/interop/RankBasedReplacementFromClassWithMultipleBindingsInGraphExtension.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -428,6 +428,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("QualifiedContributesBindingAndIgnoreQualifierMultibinding.kt")
+      public void testQualifiedContributesBindingAndIgnoreQualifierMultibinding() {
+        runTest("compiler-tests/src/test/data/box/aggregation/interop/QualifiedContributesBindingAndIgnoreQualifierMultibinding.kt");
+      }
+
+      @Test
       @TestMetadata("RankBasedReplacementFromClassWithMultipleBindingsInGraphExtension.kt")
       public void testRankBasedReplacementFromClassWithMultipleBindingsInGraphExtension() {
         runTest("compiler-tests/src/test/data/box/aggregation/interop/RankBasedReplacementFromClassWithMultipleBindingsInGraphExtension.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBoundTypeResolver.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBoundTypeResolver.kt
@@ -9,8 +9,7 @@ import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.classId
-import org.jetbrains.kotlin.ir.util.classIdOrFail
-import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.name.StandardClassIds
 
 /**
@@ -27,7 +26,7 @@ internal class IrBoundTypeResolver(
   private val defaultBindingLookup: (IrDeclarationWithName, IrClass) -> IrTypeKey?,
 ) {
 
-  private val implicitBoundTypeCache = mutableMapOf<ClassId, Optional<IrTypeKey>>()
+  private val implicitBoundTypeCache = mutableMapOf<IrTypeKey, Optional<IrTypeKey>>()
 
   /**
    * Resolves the bound type for [contributingClass] given its contributing [annotation].
@@ -67,8 +66,18 @@ internal class IrBoundTypeResolver(
   }
 
   private fun resolveImplicitBoundType(clazz: IrClass, ignoreQualifier: Boolean): IrTypeKey? {
+    val cacheKey =
+      IrTypeKey(
+        type = clazz.defaultType,
+        qualifier =
+          if (ignoreQualifier) {
+            null
+          } else {
+            with(metroContext) { clazz.qualifierAnnotation() }
+          },
+      )
     return implicitBoundTypeCache
-      .getOrPut(clazz.classIdOrFail) { // TODO iter once
+      .getOrPut(cacheKey) { // TODO iter once
         val supertypesExcludingAny =
           clazz.superTypes
             .mapNotNull {


### PR DESCRIPTION
Key IrBoundTypeResolver's implicit bound type cache by the qualifier-aware contributing IrTypeKey instead of ClassId. This keeps qualified bindings and ignoreQualifier=true multibindings from reusing the same cached bound type.

Add a compiler box regression test for the mixed @ContributesBinding/@ContributesMultibinding case so qualified and unqualified multibindings stay distinct.
