### PR TITLE
Fix redundant class key in metrox-android/README.md ActivityKey example

### DIFF
--- a/metrox-android/README.md
+++ b/metrox-android/README.md
@@ -36,7 +36,7 @@ For example, use `@ActivityKey` for an injected `Activity`:
 
 ```kotlin
 @ContributesIntoMap(AppScope::class, binding<Activity>())
-@ActivityKey(MainActivity::class)
+@ActivityKey
 class MainActivity(private val fragmentFactory: FragmentFactory): AppCompatActivity()
 ```
 


### PR DESCRIPTION
<!--
  STOP AND READ!

  Couple small asks to help with review 🥺
  - Please write a description (however long or short as necessary.)
  - If you are showing me AI-generated output (code or otherwise), please be upfront about it, indicate what parts, and de-fluff _before_ opening the PR.
-->

The explicit class key in the README example is redundant and triggers a warning.

This removes the unnecessary argument and uses the implicit key instead.