### PR TITLE
Fix secondary constructor with contributionproviders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Changelog
 - **[docs]** Fix source links in Dokka API docs.
 - **[docs]** Don't publish `**.internal.**` APIs in Dokka API docs.
 
+### Contributors
+
+Special thanks to the following contributors for contributing to this release!
+
+- [@jonamireh](https://github.com/jonamireh)
+
 1.0.0-RC2
 ---------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 
 ### Fixes
 
+- **[IR]** Fix secondary inject constructors support when `generateContributionProviders` is enabled.
 - **[docs]** Fix source links in Dokka API docs.
 - **[docs]** Don't publish `**.internal.**` APIs in Dokka API docs.
 

--- a/compiler-tests/src/test/data/box/aggregation/contributionproviders/secondaryConstructor.kt
+++ b/compiler-tests/src/test/data/box/aggregation/contributionproviders/secondaryConstructor.kt
@@ -1,19 +1,17 @@
-// GENERATE_CONTRIBUTION_PROVIDERS
-
 @DependencyGraph(AppScope::class)
 interface AppGraph {
-    val accountManager: AccountManager
+  val accountManager: AccountManager
 }
 
 interface AccountManager
 
 @ContributesBinding(AppScope::class)
 class RealAccountManager : AccountManager {
-    @Inject
-    constructor()
+  @Inject constructor()
 }
 
 fun box(): String {
-    val graph = createGraph<AppGraph>()
-    return "OK"
+  val graph = createGraph<AppGraph>()
+  assertNotNull(graph.accountManager)
+  return "OK"
 }

--- a/compiler-tests/src/test/data/box/aggregation/contributionproviders/secondaryConstructor.kt
+++ b/compiler-tests/src/test/data/box/aggregation/contributionproviders/secondaryConstructor.kt
@@ -1,0 +1,19 @@
+// GENERATE_CONTRIBUTION_PROVIDERS
+
+@DependencyGraph(AppScope::class)
+interface AppGraph {
+    val accountManager: AccountManager
+}
+
+interface AccountManager
+
+@ContributesBinding(AppScope::class)
+class RealAccountManager : AccountManager {
+    @Inject
+    constructor()
+}
+
+fun box(): String {
+    val graph = createGraph<AppGraph>()
+    return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -356,6 +356,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       public void testScoped() {
         runTest("compiler-tests/src/test/data/box/aggregation/contributionproviders/scoped.kt");
       }
+
+      @Test
+      @TestMetadata("secondaryConstructor.kt")
+      public void testSecondaryConstructor() {
+        runTest("compiler-tests/src/test/data/box/aggregation/contributionproviders/secondaryConstructor.kt");
+      }
     }
 
     @Nested

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -347,6 +347,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     public void testScoped() {
       runTest("compiler-tests/src/test/data/box/aggregation/contributionproviders/scoped.kt");
     }
+
+    @Test
+    @TestMetadata("secondaryConstructor.kt")
+    public void testSecondaryConstructor() {
+      runTest("compiler-tests/src/test/data/box/aggregation/contributionproviders/secondaryConstructor.kt");
+    }
   }
 
   @Nested

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -356,6 +356,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       public void testScoped() {
         runTest("compiler-tests/src/test/data/box/aggregation/contributionproviders/scoped.kt");
       }
+
+      @Test
+      @TestMetadata("secondaryConstructor.kt")
+      public void testSecondaryConstructor() {
+        runTest("compiler-tests/src/test/data/box/aggregation/contributionproviders/secondaryConstructor.kt");
+      }
     }
 
     @Nested

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/MetroIrGenerationExtension.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/MetroIrGenerationExtension.kt
@@ -10,7 +10,7 @@ import dev.zacsweers.metro.compiler.ir.graph.IrDynamicGraphGenerator
 import dev.zacsweers.metro.compiler.ir.transformers.AssistedFactoryTransformer
 import dev.zacsweers.metro.compiler.ir.transformers.BindingContainerTransformer
 import dev.zacsweers.metro.compiler.ir.transformers.ContributionHintIrTransformer
-import dev.zacsweers.metro.compiler.ir.transformers.ContributionTransformer
+import dev.zacsweers.metro.compiler.ir.transformers.ContributionIrTransformer
 import dev.zacsweers.metro.compiler.ir.transformers.CoreTransformers
 import dev.zacsweers.metro.compiler.ir.transformers.CreateGraphTransformer
 import dev.zacsweers.metro.compiler.ir.transformers.DefaultBindingMirrorTransformer
@@ -142,7 +142,7 @@ public class MetroIrGenerationExtension(
                 metroContext,
                 this,
                 data,
-                ContributionTransformer(metroContext, this, boundTypeResolver),
+                ContributionIrTransformer(metroContext, this, boundTypeResolver),
                 membersInjectorTransformer,
                 injectedClassTransformer,
                 assistedFactoryTransformer,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
@@ -59,6 +59,7 @@ import org.jetbrains.kotlin.ir.util.classIdOrFail
 import org.jetbrains.kotlin.ir.util.copyTo
 import org.jetbrains.kotlin.ir.util.deepCopyWithSymbols
 import org.jetbrains.kotlin.ir.util.defaultType
+import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.isLocal
 import org.jetbrains.kotlin.ir.util.isObject
@@ -208,8 +209,9 @@ internal class ContributionIrTransformer(
     val originClass = context.referenceClass(originClassId)?.owner ?: return
 
     // Find the primary constructor of the origin class
-    val injectConstructor =
-      originClass.findInjectableConstructor(onlyUsePrimaryConstructor = false) ?: return
+    val injectConstructor by memoize {
+      originClass.findInjectableConstructor(onlyUsePrimaryConstructor = false)
+    }
 
     // Add bodies to all @Provides functions
     for (function in declaration.functions) {
@@ -229,10 +231,16 @@ internal class ContributionIrTransformer(
             // Object: just reference the singleton instance
             irExprBodySafe(irGetObject(originClass.symbol))
           } else {
+            val calleeCtor =
+              injectConstructor
+                ?: reportCompilerBug(
+                  "No inject constructor found in IR for provided contribution ${declaration.fqNameWhenAvailable}"
+                )
+
             copyParameterDefaultValues(
-              providerFunction = injectConstructor,
+              providerFunction = calleeCtor,
               sourceMetroParameters = Parameters.empty(),
-              sourceParameters = injectConstructor.regularParameters,
+              sourceParameters = calleeCtor.regularParameters,
               targetParameters = function.regularParameters,
               containerParameter = null,
               isTopLevelFunction = true,
@@ -240,10 +248,10 @@ internal class ContributionIrTransformer(
 
             // Constructor call (synthetic scoped or direct)
             val constructorCall =
-              irCallConstructor(injectConstructor.symbol, emptyList()).apply {
+              irCallConstructor(calleeCtor.symbol, emptyList()).apply {
                 val functionParams = function.regularParameters
                 for ((index, param) in functionParams.withIndex()) {
-                  if (index < injectConstructor.regularParameters.size) {
+                  if (index < calleeCtor.regularParameters.size) {
                     arguments[index] = irGet(param)
                   }
                 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
@@ -16,6 +16,7 @@ import dev.zacsweers.metro.compiler.ir.buildAnnotation
 import dev.zacsweers.metro.compiler.ir.copyParameterDefaultValues
 import dev.zacsweers.metro.compiler.ir.createIrBuilder
 import dev.zacsweers.metro.compiler.ir.findAnnotations
+import dev.zacsweers.metro.compiler.ir.findInjectableConstructor
 import dev.zacsweers.metro.compiler.ir.irExprBodySafe
 import dev.zacsweers.metro.compiler.ir.isAnnotatedWithAny
 import dev.zacsweers.metro.compiler.ir.isBindingContainer
@@ -63,7 +64,6 @@ import org.jetbrains.kotlin.ir.util.isLocal
 import org.jetbrains.kotlin.ir.util.isObject
 import org.jetbrains.kotlin.ir.util.parentAsClass
 import org.jetbrains.kotlin.ir.util.parentClassOrNull
-import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.visitors.IrTransformer
 import org.jetbrains.kotlin.name.ClassId
 
@@ -74,7 +74,7 @@ import org.jetbrains.kotlin.name.ClassId
  *    overrides of them.
  * 3. Collects contribution data while transforming for use by the dependency graph.
  */
-internal class ContributionTransformer(
+internal class ContributionIrTransformer(
   private val context: IrMetroContext,
   traceScope: TraceScope,
   private val boundTypeResolver: IrBoundTypeResolver,
@@ -208,7 +208,8 @@ internal class ContributionTransformer(
     val originClass = context.referenceClass(originClassId)?.owner ?: return
 
     // Find the primary constructor of the origin class
-    val injectConstructor = originClass.primaryConstructor ?: return
+    val injectConstructor =
+      originClass.findInjectableConstructor(onlyUsePrimaryConstructor = false) ?: return
 
     // Add bodies to all @Provides functions
     for (function in declaration.functions) {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/CoreTransformers.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/CoreTransformers.kt
@@ -34,7 +34,7 @@ internal class CoreTransformers(
   private val context: IrMetroContext,
   traceScope: TraceScope,
   private val data: MutableMetroGraphData,
-  private val contributionTransformer: ContributionTransformer,
+  private val contributionTransformer: ContributionIrTransformer,
   private val membersInjectorTransformer: MembersInjectorTransformer,
   private val injectedClassTransformer: InjectedClassTransformer,
   private val assistedFactoryTransformer: AssistedFactoryTransformer,


### PR DESCRIPTION
## Summary
It seems like when a class has non-primary `@Inject` constructor, there's a codegen error if `generateContributionProviders` is enabled
