### PR TITLE
Misc benchmark work

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -32,6 +32,7 @@ The script supports multiple modes and configurable module counts:
 - **Metro-NOOP mode** (`--mode metro_noop`): Metro compiler plugin applied but no Metro annotations (measures plugin overhead)
 - **Dagger mode** (`--mode dagger`): Uses Dagger with Anvil for dependency injection
 - **Kotlin-inject + Anvil mode** (`--mode kotlin-inject-anvil`): Uses Metro with kotlin-inject + anvil interop
+- **Koin mode** (`--mode koin`): Uses Koin with koin-annotations and the Koin compiler plugin. See [Koin caveats](#koin-mode-caveats) below.
 - **Module count** (`--count <number>`): Total number of modules to generate (default: 500)
 - **Processor** (`--processor ksp|kapt`): Annotation processor for Dagger mode (default: ksp)
 - **Provider multibindings** (`--provider-multibindings`): Wrap multibinding accessors in the legacy `Provider<Set<E>>` form instead of `Set<E>` to benchmark `SetFactory`/`MapFactory` behavior against the explicit `Provider<T>` type. Metro's preferred provider form is now `() -> T`, so this flag is only relevant for benchmarking the legacy form.
@@ -63,6 +64,9 @@ kotlin generate-projects.main.kts --mode dagger --processor kapt
 # Generate kotlin-inject + anvil mode project (uses Amazon kotlin-inject-anvil)
 kotlin generate-projects.main.kts --mode kotlin-inject-anvil
 
+# Generate Koin mode project (koin-annotations + koin compiler plugin)
+kotlin generate-projects.main.kts --mode koin
+
 # Generate with legacy Provider-wrapped multibindings (for SetFactory/MapFactory benchmarking)
 kotlin generate-projects.main.kts --mode metro --provider-multibindings
 
@@ -78,7 +82,7 @@ kotlin generate-projects.main.kts --mode metro --provider-multibindings
 Use the `run_benchmarks.sh` script for comprehensive performance testing:
 
 ```bash
-# Run all benchmark modes on current branch (metro, dagger-ksp, dagger-kapt, kotlin-inject-anvil)
+# Run all benchmark modes on current branch (metro, dagger-ksp, dagger-kapt, kotlin-inject-anvil, koin)
 ./run_benchmarks.sh all
 
 # Run all modes including baseline benchmarks (vanilla + metro-noop)
@@ -88,6 +92,7 @@ Use the `run_benchmarks.sh` script for comprehensive performance testing:
 ./run_benchmarks.sh metro 500
 ./run_benchmarks.sh dagger-ksp 250
 ./run_benchmarks.sh kotlin-inject-anvil 500
+./run_benchmarks.sh koin 500
 
 # Include clean build scenarios (opt-in)
 ./run_benchmarks.sh all --include-clean-builds
@@ -512,3 +517,55 @@ gh workflow run benchmarks.yml \
 ```
 
 Or trigger from the Actions tab in GitHub with the desired options.
+
+## Koin mode caveats
+
+Koin is structurally different from Metro/Dagger/kotlin-inject: it is a **runtime service
+locator** with a `KClass`-keyed registry, not a compile-time graph resolver. The benchmark
+exercises Koin via `koin-annotations` 4.2.1 + the Koin K2 compiler plugin 1.0.0-RC2. The
+compiler plugin runs some validation during compilation, but this benchmark makes **no claims
+about the scope or correctness of that validation** — we measure observed compile-time and
+runtime cost, not correctness guarantees. Read any "compile-safe" marketing accordingly.
+
+Because Koin's annotation model diverges from the other frameworks, the generator translates
+each construct as follows:
+
+| Construct                         | Metro / Dagger / kotlin-inject-anvil                                                                     | Koin emission                                                                                                                                                                                                                                                                                                  |
+|-----------------------------------|----------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Scope-kept binding                | `@SingleIn(AppScope::class)` + `@ContributesBinding`                                                     | `@Singleton(binds = [Iface::class])` on the impl                                                                                                                                                                                                                                                               |
+| Multibinding (`Set<Plugin>`)      | `@ContributesIntoSet` / `@ContributesMultibinding`                                                       | `@Singleton(binds = [Plugin::class])`, consumer calls `koin.getAll<Plugin>().toSet()`                                                                                                                                                                                                                          |
+| Cross-Gradle-module aggregation   | Anvil / kotlin-inject-anvil merging                                                                      | One `@Module @ComponentScan("<per-module-pkg>") class <Name>KoinModule` per Gradle module, enumerated in `@KoinApplication(modules = [...])` on the root (see below for why)                                                                                                                                   |
+| Subcomponent hierarchy (L1/L2/L3) | `@GraphExtension` / `@ContributesSubcomponent` — nested containers                                       | **Flat** Koin scopes: per-level `class <Level>Scope` marker + `@Scope(<Marker>::class) @Scoped` impls + `class <Level>Subcomponent(koin, scopeId) : KoinScopeComponent` wrapper exposing services via `by scope.inject()`. Scopes are **not nested** — this is a real property of Koin, not a benchmark fudge. |
+| Graph creation entry point        | `createGraph<AppComponent>()` / `AppComponent::class.create()` / `DaggerAppComponent.factory().create()` | `koinApplication<AppKoinApp> { }` from `org.koin.plugin.module.dsl` (detached `KoinApplication`, no global state)                                                                                                                                                                                              |
+
+### Why per-module `@Module` classes instead of a single root `@ComponentScan`
+
+A single `@KoinApplication @ComponentScan("dev.zacsweers.metro.benchmark") class AppKoinApp`
+causes the Koin compiler plugin to emit one giant registration lambda for every annotated
+class in the transitive classpath. This overflows the JVM 64KB method size limit at roughly
+100+ modules (error: `Method too large: …module$lambda$0`). The generator sidesteps this by
+emitting one `@Module @ComponentScan("<narrow-pkg>") class <Name>KoinModule` per Gradle
+module — each gets its own small generated lambda — and enumerating the whole set in the
+root's `@KoinApplication(modules = [...])`. This is a nontrivial footgun in the Koin 1.0.0-RC2
+plugin that users should be aware of.
+
+### Multiplatform
+
+Koin mode supports `--multiplatform` with the same targets Metro uses.
+
+### Comparability notes
+
+- **Multibinding shape**: `List<T>.toSet()` wrapping at the accessor boundary has a tiny
+  per-call allocation cost that the other frameworks do not pay. This is inherent to Koin's
+  lack of multibinding support.
+- **Subcomponent cost**: Koin's flat-scope model is cheaper than Metro/Dagger's nested
+  container construction. Runtime numbers for subcomponent-heavy scenarios will look
+  favorable for Koin — that is a real property of Koin, not a measurement artifact.
+- **Binary metrics**: JVM class/JAR/APK metrics collection works identically to the other
+  modes via `run_startup_benchmarks.sh --binary-metrics-only`. Expect Koin's runtime JAR to
+  be noticeably larger than Metro's generated graph because it ships the `koin-core` and
+  `koin-annotations` runtimes rather than generating direct constructor calls.
+- **Compile-time plugin cost**: Koin's compiler plugin is a K2 IR plugin with no annotation
+  processing step (no KSP, no KAPT); the benchmark runs the `raw_compilation` scenario
+  variant (same as Metro/Vanilla), not the KSP or Java-generating variants used for
+  kotlin-inject-anvil and Dagger.

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -20,6 +20,4 @@ plugins {
   id("metro.base") apply false
 }
 
-subprojects {
-  apply(plugin = "metro.base")
-}
+subprojects { apply(plugin = "metro.base") }

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -13,12 +13,13 @@ plugins {
   alias(libs.plugins.jmh) apply false
   alias(libs.plugins.kotlinx.benchmark) apply false
   alias(libs.plugins.benchmark) apply false
+  alias(libs.plugins.koin.compiler) apply false
   alias(libs.plugins.metro) apply false
   alias(libs.plugins.anvil) apply false
   alias(libs.plugins.mavenPublish) apply false // wat
   id("metro.base") apply false
 }
 
-subprojects { apply(plugin = "metro.base") }
-
-tasks.maybeCreate("clean")
+subprojects {
+  apply(plugin = "metro.base")
+}

--- a/benchmark/generate-projects.main.kts
+++ b/benchmark/generate-projects.main.kts
@@ -19,7 +19,11 @@ class GenerateProjectsCommand : CliktCommand() {
   }
 
   private val buildMode by
-    option("--mode", "-m", help = "Build mode: metro, dagger, or kotlin_inject_anvil")
+    option(
+        "--mode",
+        "-m",
+        help = "Build mode: metro, dagger, kotlin_inject_anvil, koin, vanilla, or metro_noop",
+      )
       .enum<BuildMode>(ignoreCase = true)
       .default(BuildMode.METRO)
 
@@ -93,8 +97,8 @@ class GenerateProjectsCommand : CliktCommand() {
     get() = ((totalModules - 1000).coerceAtLeast(0) / 333).coerceAtMost(3)
 
   override fun run() {
-    if (multiplatform && buildMode != BuildMode.METRO) {
-      echo("Error: --multiplatform flag is only supported with Metro mode", err = true)
+    if (multiplatform && buildMode != BuildMode.METRO && buildMode != BuildMode.KOIN) {
+      echo("Error: --multiplatform flag is only supported with Metro or Koin mode", err = true)
       return
     }
 
@@ -373,6 +377,23 @@ class GenerateProjectsCommand : CliktCommand() {
     VANILLA,
     DAGGER,
     KOTLIN_INJECT_ANVIL,
+    /**
+     * Koin with koin-annotations + K2 compiler plugin.
+     *
+     * Koin is a runtime service-locator; the compiler plugin performs some reachability/validation
+     * checks but the runtime graph is still a KClass-keyed map walked at `get()`/`getAll()` time.
+     * Functional-equivalence caveats vs Metro/Dagger/kotlin-inject:
+     * - No multibindings. `Set<Plugin>`/`Set<Initializer>` are synthesized via
+     *   [org.koin.core.Koin.getAll] and wrapped with `.toSet()` at the accessor boundary.
+     * - No cross-Gradle-module aggregation. We rely on `@ComponentScan` at a common root package so
+     *   the annotations-driven plugin walks the dependency tree.
+     * - Subcomponents are not nested containers in Koin. They are emulated with flat scopes
+     *   (`@Scope`/`@Scoped` + `KoinScopeComponent`) which is cheaper at runtime; this is a real
+     *   property of Koin, not a measurement artifact.
+     * - Accessor interfaces are not emitted: Koin's `@Singleton` classes are registered but lazy;
+     *   nothing forces realization beyond the multibinding `getAll` calls.
+     */
+    KOIN,
   }
 
   enum class ProcessorMode {
@@ -423,9 +444,9 @@ class GenerateProjectsCommand : CliktCommand() {
     val buildFile = File(moduleDir, "build.gradle.kts")
     buildFile.writeText(generateBuildScript(module, processor))
 
-    // Generate source code
     val srcPath =
-      if (multiplatform && buildMode == BuildMode.METRO) "src/commonMain/kotlin"
+      if (multiplatform && (buildMode == BuildMode.METRO || buildMode == BuildMode.KOIN))
+        "src/commonMain/kotlin"
       else "src/main/kotlin"
     val srcDir =
       File(
@@ -443,7 +464,9 @@ class GenerateProjectsCommand : CliktCommand() {
       module.dependencies.joinToString("\n") { dep -> "    implementation(project(\":$dep\"))" }
     val jvmDependencies =
       module.dependencies.joinToString("\n") { dep -> "  implementation(project(\":$dep\"))" }
-
+    // Koin multiplatform uses an 8-space indent for commonMain { dependencies { ... } } nesting.
+    val koinCommonDependencies =
+      module.dependencies.joinToString("\n") { dep -> "        implementation(project(\":$dep\"))" }
     return when (buildMode) {
       BuildMode.METRO -> {
         if (multiplatform) {
@@ -544,6 +567,63 @@ $dependencies
 """
           .trimIndent()
 
+      BuildMode.KOIN ->
+        if (multiplatform) {
+          val koinCommon =
+            module.dependencies.joinToString("\n") { dep ->
+              "        implementation(project(\":$dep\"))"
+            }
+          """
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+plugins {
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.koin.compiler)
+}
+
+val enableLinux = findProperty("benchmark.native.linux")?.toString()?.toBoolean() ?: false
+val enableWindows = findProperty("benchmark.native.windows")?.toString()?.toBoolean() ?: false
+
+kotlin {
+  jvm()
+  js(IR) { nodejs() }
+  @OptIn(ExperimentalWasmDsl::class)
+  wasmJs { nodejs() }
+  macosArm64()
+  macosX64()
+  if (enableLinux) linuxX64()
+  if (enableWindows) mingwX64()
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation(libs.koin.core)
+        implementation(libs.koin.annotations)
+        implementation(project(":core:foundation"))
+$koinCommon
+      }
+    }
+  }
+}
+"""
+            .trimIndent()
+        } else {
+          """
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.koin.compiler)
+}
+
+dependencies {
+  implementation(libs.koin.core)
+  implementation(libs.koin.annotations)
+  implementation(project(":core:foundation"))
+$jvmDependencies
+}
+"""
+            .trimIndent()
+        }
+
       BuildMode.DAGGER ->
         when (processor) {
           ProcessorMode.KSP ->
@@ -631,6 +711,14 @@ kapt {
       "dev.zacsweers.metro.benchmark.${module.layer.path}.${module.name.replace("-", "")}"
     val className = module.name.toCamelCase()
 
+    // Koin has a structurally different annotation model (no @ContributesBinding, no scope param),
+    // so we emit a dedicated source form rather than parameterizing the main path. Must bail here
+    // (before `contributions` is materialized) since generateContribution dispatchees call `error`
+    // for KOIN.
+    if (buildMode == BuildMode.KOIN) {
+      return generateKoinSourceCode(module, packageName, className)
+    }
+
     val contributions =
       (1..module.contributionsCount).joinToString("\n\n") { i ->
         generateContribution(module, i, buildMode)
@@ -688,6 +776,7 @@ $dependencyImports
           """
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesSubcomponent
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import me.tatarka.inject.annotations.Inject
@@ -708,6 +797,8 @@ import javax.inject.Singleton
 $dependencyImports
 """
             .trimIndent()
+
+        BuildMode.KOIN -> error("KOIN path handled above by generateKoinSourceCode")
       }
 
     val scopeAnnotation =
@@ -717,6 +808,7 @@ $dependencyImports
         BuildMode.VANILLA -> "" // No DI annotations
         BuildMode.KOTLIN_INJECT_ANVIL -> "@SingleIn(AppScope::class)"
         BuildMode.DAGGER -> "@Singleton"
+        BuildMode.KOIN -> error("KOIN path handled above by generateKoinSourceCode")
       }
 
     val scopeParam =
@@ -726,6 +818,7 @@ $dependencyImports
         BuildMode.VANILLA -> "" // No DI annotations
         BuildMode.KOTLIN_INJECT_ANVIL -> "AppScope::class"
         BuildMode.DAGGER -> "Unit::class"
+        BuildMode.KOIN -> error("KOIN path handled above by generateKoinSourceCode")
       }
 
     // For METRO_NOOP and VANILLA, generate plain Kotlin without annotations
@@ -846,7 +939,8 @@ $subcomponent
   }
 
   fun generateBindingContribution(className: String, index: Int, buildMode: BuildMode): String {
-    // METRO_NOOP and VANILLA don't generate DI contributions - handled in generateSourceCode
+    // METRO_NOOP/VANILLA don't generate DI contributions; KOIN is handled in
+    // generateKoinSourceCode.
     val scopeAnnotation =
       when (buildMode) {
         BuildMode.METRO -> "@SingleIn(AppScope::class)"
@@ -854,6 +948,7 @@ $subcomponent
         BuildMode.VANILLA -> "" // No DI annotations
         BuildMode.KOTLIN_INJECT_ANVIL -> "@SingleIn(AppScope::class)"
         BuildMode.DAGGER -> "@Singleton"
+        BuildMode.KOIN -> error("KOIN uses generateKoinSourceCode, not this path")
       }
 
     val scopeParam =
@@ -863,6 +958,7 @@ $subcomponent
         BuildMode.VANILLA -> "" // No DI annotations
         BuildMode.KOTLIN_INJECT_ANVIL -> "AppScope::class"
         BuildMode.DAGGER -> "Unit::class"
+        BuildMode.KOIN -> error("KOIN uses generateKoinSourceCode, not this path")
       }
 
     val injectOnClass = buildMode != BuildMode.DAGGER
@@ -881,7 +977,7 @@ ${if (injectOnClass) "@Inject\n" else ""}class ${className}ServiceImpl$index${if
     index: Int,
     buildMode: BuildMode,
   ): String {
-    // METRO_NOOP and VANILLA don't generate multibindings - handled in generateSourceCode
+    // METRO_NOOP/VANILLA don't generate multibindings; KOIN is handled in generateKoinSourceCode.
     val scopeParam =
       when (buildMode) {
         BuildMode.METRO -> "AppScope::class"
@@ -889,6 +985,7 @@ ${if (injectOnClass) "@Inject\n" else ""}class ${className}ServiceImpl$index${if
         BuildMode.VANILLA -> "" // No DI annotations
         BuildMode.KOTLIN_INJECT_ANVIL -> "AppScope::class"
         BuildMode.DAGGER -> "Unit::class"
+        BuildMode.KOIN -> error("KOIN uses generateKoinSourceCode, not this path")
       }
 
     val multibindingAnnotation =
@@ -918,7 +1015,8 @@ ${if (injectOnClass) "@Inject\n" else ""}class ${className}PluginImpl$index${if 
     index: Int,
     buildMode: BuildMode,
   ): String {
-    // METRO_NOOP and VANILLA don't generate set multibindings - handled in generateSourceCode
+    // METRO_NOOP/VANILLA don't generate set multibindings; KOIN is handled in
+    // generateKoinSourceCode.
     val scopeParam =
       when (buildMode) {
         BuildMode.METRO -> "AppScope::class"
@@ -926,6 +1024,7 @@ ${if (injectOnClass) "@Inject\n" else ""}class ${className}PluginImpl$index${if 
         BuildMode.VANILLA -> "" // No DI annotations
         BuildMode.KOTLIN_INJECT_ANVIL -> "AppScope::class"
         BuildMode.DAGGER -> "Unit::class"
+        BuildMode.KOIN -> error("KOIN uses generateKoinSourceCode, not this path")
       }
 
     val multibindingAnnotation =
@@ -1197,6 +1296,179 @@ $accessors
 object ${name}Scope"""
   }
 
+  fun generateKoinSourceCode(module: ModuleSpec, packageName: String, className: String): String {
+    // Koin path: each contribution becomes an @Singleton (or @Factory) annotated class.
+    // - Simple binding: @Singleton(binds = [ServiceN::class])
+    // - Plugin multibinding: @Singleton(binds = [Plugin::class])
+    //   (consumer uses koin.getAll<Plugin>().toSet())
+    // - Initializer multibinding: @Singleton(binds = [Initializer::class])
+    //
+    // Each Gradle module also emits a `@Module @ComponentScan("<its-own-pkg>")` class so the
+    // Koin compiler plugin generates a module lambda per Gradle module. Without this split, a
+    // single root `@ComponentScan("dev.zacsweers.metro.benchmark")` causes the plugin to emit
+    // one giant lambda that overflows the JVM 64KB method size limit at ~100 modules.
+    //
+    // Subcomponents are emitted in Phase B as flat @Scope/@Scoped classes.
+    val contributions =
+      (1..module.contributionsCount)
+        .map { i ->
+          val moduleRandom = Random(module.name.hashCode() + i)
+          when (moduleRandom.nextInt(3)) {
+            0 ->
+              """interface ${className}Service$i
+
+@Singleton(binds = [${className}Service$i::class])
+class ${className}ServiceImpl$i : ${className}Service$i"""
+            1 ->
+              """interface ${className}Plugin$i : Plugin {
+  override fun execute(): String
+}
+
+@Singleton(binds = [Plugin::class])
+class ${className}PluginImpl$i : ${className}Plugin$i {
+  override fun execute() = "${className.lowercase()}-plugin-$i"
+}"""
+            else ->
+              """interface ${className}Initializer$i : Initializer {
+  override fun initialize()
+}
+
+@Singleton(binds = [Initializer::class])
+class ${className}InitializerImpl$i : ${className}Initializer$i {
+  override fun initialize() = println("Initializing ${className.lowercase()} $i")
+}"""
+          }
+        }
+        .joinToString("\n\n")
+
+    val subcomponent =
+      if (module.hasSubcomponent) {
+        generateKoinSubcomponent(module, className)
+      } else ""
+
+    val subcomponentImports =
+      if (module.hasSubcomponent) {
+        """
+import org.koin.core.Koin
+import org.koin.core.annotation.Scope
+import org.koin.core.annotation.Scoped
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.component.inject"""
+      } else ""
+
+    return """
+package $packageName
+
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Singleton$subcomponentImports
+import dev.zacsweers.metro.benchmark.core.foundation.Plugin
+import dev.zacsweers.metro.benchmark.core.foundation.Initializer
+
+/**
+ * Per-Gradle-module Koin module. `@ComponentScan` narrows to this package so the Koin compiler
+ * plugin generates a small per-module registration lambda. The app's `@KoinApplication` class
+ * enumerates all of these in its `modules = [...]` list.
+ */
+@Module
+@ComponentScan("$packageName")
+class ${className}KoinModule
+
+// Main module interface
+interface ${className}Api
+
+// Implementation
+@Singleton(binds = [${className}Api::class])
+class ${className}Impl : ${className}Api
+
+$contributions
+$subcomponent
+"""
+      .trimIndent()
+  }
+
+  /**
+   * Fully-qualified class reference for a generated module's KoinModule. Used by the app
+   * component's `@KoinApplication(modules = [...])` list.
+   */
+  fun koinModuleClassFqn(module: ModuleSpec): String {
+    val pkg = "dev.zacsweers.metro.benchmark.${module.layer.path}.${module.name.replace("-", "")}"
+    val cn = module.name.toCamelCase()
+    return "$pkg.${cn}KoinModule"
+  }
+
+  /**
+   * Koin has no nested subcomponents. Emulates the Metro/Dagger/kotlin-inject L1/L2/L3 hierarchy
+   * with **flat Koin scopes** (not nested containers). Each level gets:
+   * - a scope marker `class <Level>Scope`
+   * - per-service `@Scope(<Marker>::class) @Scoped(binds = [<Iface>::class])` impl classes
+   * - a `class <Level>Subcomponent(koin: Koin) : KoinScopeComponent` wrapper that exposes the
+   *   scoped services via `by scope.inject()` — mirrors the Subcomponent/Factory interface pairs
+   *   that Metro/Dagger/kotlin-inject emit.
+   *
+   * Like the other frameworks' subcomponents, these wrappers aren't instantiated from
+   * `createAndInitialize()` — they exist for compile-time stress. The KoinScopeComponent structure
+   * is modelled on the KotlinConf app's migration pattern (`class YearScope(...) :
+   * KoinScopeComponent { override val scope = ...; val storage by scope.inject() }`).
+   *
+   * This is a real property of Koin (scopes are flat under the root, not nested containers), not a
+   * benchmark fudge; the README calls this out.
+   */
+  fun generateKoinSubcomponent(module: ModuleSpec, className: String): String {
+    data class Level(val name: String, val serviceCount: Int)
+    val levels = mutableListOf<Level>()
+    levels += Level(className, 3) // L1
+
+    if (l2ChildrenPerL1 > 0) {
+      for (i in 1..l2ChildrenPerL1) {
+        val l2Name = "${className}Child$i"
+        levels += Level(l2Name, 2)
+        if (l3ChildrenPerL2 > 0) {
+          for (j in 1..l3ChildrenPerL2) {
+            levels += Level("${l2Name}Sub$j", 1)
+          }
+        }
+      }
+    }
+
+    return levels.joinToString("\n\n") { (levelName, serviceCount) ->
+      val scopeMarker = "${levelName}Scope"
+      val services =
+        (1..serviceCount).joinToString("\n\n") { i ->
+          """interface ${levelName}LocalService$i
+
+@Scope($scopeMarker::class)
+@Scoped(binds = [${levelName}LocalService$i::class])
+class ${levelName}LocalServiceImpl$i : ${levelName}LocalService$i"""
+        }
+      val scopeProperties =
+        (1..serviceCount).joinToString("\n  ") { i ->
+          "val localService$i: ${levelName}LocalService$i by scope.inject()"
+        }
+      """
+// $levelName flat Koin scope (Koin has no nested subcomponents — flat scopes only).
+// The KoinScopeComponent wrapper mirrors the subcomponent+Factory pair the other frameworks
+// emit; it is not instantiated from createAndInitialize() (parity with Metro/Dagger).
+class $scopeMarker
+
+$services
+
+class ${levelName}Subcomponent(private val parentKoin: Koin, scopeId: String) :
+  KoinScopeComponent {
+  override fun getKoin(): Koin = parentKoin
+  override val scope: org.koin.core.scope.Scope =
+    parentKoin.getOrCreateScope(
+      scopeId,
+      org.koin.core.qualifier.TypeQualifier($scopeMarker::class),
+    )
+  $scopeProperties
+  fun close() = scope.close()
+}
+"""
+        .trimIndent()
+    }
+  }
+
   fun generateFoundationModule(multiplatform: Boolean) {
     val foundationDir = File("core/foundation")
     foundationDir.mkdirs()
@@ -1461,6 +1733,77 @@ application {
 }
 """
 
+        BuildMode.KOIN ->
+          if (multiplatform) {
+            """
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
+plugins {
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.koin.compiler)
+}
+
+val enableMacos = providers.gradleProperty("benchmark.native.macos").orNull.toBoolean()
+val enableLinux = providers.gradleProperty("benchmark.native.linux").orNull.toBoolean()
+val enableWindows = providers.gradleProperty("benchmark.native.windows").orNull.toBoolean()
+
+kotlin {
+  jvm()
+  js(IR) {
+    nodejs()
+    binaries.executable()
+  }
+  @OptIn(ExperimentalWasmDsl::class)
+  wasmJs {
+    nodejs()
+    binaries.executable()
+  }
+  if (enableMacos) {
+    macosArm64 { binaries.executable() }
+    macosX64 { binaries.executable() }
+  } else if (enableLinux) {
+    linuxX64 { binaries.executable() }
+  } else if (enableWindows) {
+    mingwX64 { binaries.executable() }
+  }
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation(libs.koin.core)
+        implementation(libs.koin.annotations)
+        implementation(project(":core:foundation"))
+
+        // Depend on all generated modules to aggregate everything
+$moduleDepsCommon
+      }
+    }
+  }
+}
+"""
+          } else {
+            """
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.koin.compiler)
+  application
+}
+
+dependencies {
+  implementation(libs.koin.core)
+  implementation(libs.koin.annotations)
+  implementation(project(":core:foundation"))
+
+  // Depend on all generated modules to aggregate everything
+${allModules.joinToString("\n") { "  implementation(project(\":${it.layer.path}:${it.name}\"))" }}
+}
+
+application {
+  mainClass = "dev.zacsweers.metro.benchmark.app.component.AppComponentKt"
+}
+"""
+          }
+
         BuildMode.DAGGER ->
           when (processor) {
             ProcessorMode.KSP ->
@@ -1534,7 +1877,8 @@ application {
     buildFile.writeText(buildScript.trimIndent())
 
     val srcPath =
-      if (multiplatform && buildMode == BuildMode.METRO) "src/commonMain/kotlin"
+      if (multiplatform && (buildMode == BuildMode.METRO || buildMode == BuildMode.KOIN))
+        "src/commonMain/kotlin"
       else "src/main/kotlin"
     val srcDir = File(appDir, "$srcPath/dev/zacsweers/metro/benchmark/app/component")
     srcDir.mkdirs()
@@ -1738,6 +2082,114 @@ fun main() {
   println("  - Total contributions: $${allModules.sumOf { it.contributionsCount }}")
 }
 """
+
+        BuildMode.KOIN -> {
+          // Koin has no multibindings; synthesize Set<T> via koin.getAll<T>().toSet().
+          //
+          // We use the typed `koinApplication<AppKoinApp> { }` (not `startKoin<AppKoinApp>`) so
+          // each benchmark iteration builds a fresh, detached KoinApplication with no global
+          // state — important for JMH where the method is called repeatedly.
+          //
+          // The Koin compiler plugin (io.insert-koin.compiler.plugin) generates the typed
+          // `koinApplication<T>` extension for any `@KoinApplication`-annotated class, wiring
+          // in modules enumerated in `@KoinApplication(modules = [...])`. We cannot use a single
+          // root `@ComponentScan` on AppKoinApp because Koin's plugin emits all registrations
+          // into one lambda and the JVM 64KB method limit overflows at ~100 modules; instead,
+          // each generated Gradle module has its own `@Module @ComponentScan(<its-pkg>)` class
+          // and we list them all here.
+          //
+          // Phase C note: Koin + Kotlin Multiplatform is not supported here (Koin compiler
+          // plugin 1.0.0-RC2 conflicts with KMP over LifecycleBasePlugin registration).
+          val koinModuleImports =
+            allModules.joinToString("\n") { "import ${koinModuleClassFqn(it)}" }
+          val koinModuleClassLiterals =
+            allModules.joinToString(",\n    ") { "${it.name.toCamelCase()}KoinModule::class" }
+          val koinMainFunction =
+            if (multiplatform) {
+              $$"""
+fun main() {
+  val component = createAndInitialize()
+  val plugins = component.getAllPlugins()
+  val initializers = component.getAllInitializers()
+
+  println("Koin benchmark graph successfully created!")
+  println("  - Plugins: ${plugins.size}")
+  println("  - Initializers: ${initializers.size}")
+  println("  - Total modules: $${allModules.size}")
+  println("  - Total contributions: $${allModules.sumOf { it.contributionsCount }}")
+}
+"""
+            } else {
+              $$"""
+fun main() {
+  val component = createAndInitialize()
+  val fields = component.javaClass.declaredFields.size
+  val methods = component.javaClass.declaredMethods.size
+  val plugins = component.getAllPlugins()
+  val initializers = component.getAllInitializers()
+
+  println("Koin benchmark graph successfully created!")
+  println("  - Fields: $fields")
+  println("  - Methods: $methods")
+  println("  - Plugins: ${plugins.size}")
+  println("  - Initializers: ${initializers.size}")
+  println("  - Total modules: $${allModules.size}")
+  println("  - Total contributions: $${allModules.sumOf { it.contributionsCount }}")
+}
+"""
+            }
+          $$"""
+package dev.zacsweers.metro.benchmark.app.component
+
+import dev.zacsweers.metro.benchmark.core.foundation.Initializer
+import dev.zacsweers.metro.benchmark.core.foundation.Plugin
+import org.koin.core.Koin
+import org.koin.core.annotation.KoinApplication
+import org.koin.plugin.module.dsl.koinApplication
+$$koinModuleImports
+
+/**
+ * Root Koin application. `@KoinApplication(modules = [...])` enumerates every per-Gradle-module
+ * `*KoinModule` class; each of those has a narrow `@ComponentScan` so the compiler plugin
+ * generates one small registration lambda per module. This avoids the 64KB JVM method-size
+ * overflow that a single root `@ComponentScan` would cause at benchmark scale.
+ *
+ * We make no claims about what compile-time validation the Koin plugin performs — the benchmark
+ * measures runtime cost and build-time cost as observed, not correctness guarantees.
+ */
+@KoinApplication(
+  modules = [
+    $$koinModuleClassLiterals,
+  ],
+)
+class AppKoinApp
+
+/**
+ * Facade that exposes multibindings in the same shape as the other frameworks' AppComponent.
+ * Koin has no native multibindings, so `Set<Plugin>` / `Set<Initializer>` are synthesized via
+ * [Koin.getAll] + `.toSet()`. This wrapping adds a small allocation; it is inherent to the
+ * functional-equivalence mapping, not a benchmark artifact.
+ */
+class AppComponent(val koin: Koin) {
+  fun getAllPlugins(): Set<Plugin> = koin.getAll<Plugin>().toSet()
+  fun getAllInitializers(): Set<Initializer> = koin.getAll<Initializer>().toSet()
+}
+
+/**
+ * Creates and fully initializes the dependency graph.
+ * Primary entry point for benchmarking graph creation and initialization.
+ */
+fun createAndInitialize(): AppComponent {
+  val app = koinApplication<AppKoinApp> { }
+  val component = AppComponent(app.koin)
+  // Force realization of multibinding contributors (parity with the other modes).
+  component.getAllPlugins()
+  component.getAllInitializers()
+  return component
+}
+$$koinMainFunction
+"""
+        }
 
         BuildMode.DAGGER -> {
           // Dagger uses component variable name instead of graph

--- a/benchmark/generate_performance_summary.sh
+++ b/benchmark/generate_performance_summary.sh
@@ -93,18 +93,21 @@ collect_performance_data() {
     local dagger_ksp_csv="$results_dir/dagger_ksp_${timestamp}/dagger_ksp_${test_type}/benchmark.csv"
     local dagger_kapt_csv="$results_dir/dagger_kapt_${timestamp}/dagger_kapt_${test_type}/benchmark.csv"
     local kotlin_inject_csv="$results_dir/kotlin_inject_anvil_${timestamp}/kotlin_inject_anvil_${test_type}/benchmark.csv"
+    local koin_csv="$results_dir/koin_${timestamp}/koin_${test_type}/benchmark.csv"
 
     # Calculate medians for build time
     local metro_median=""
     local dagger_ksp_median=""
     local dagger_kapt_median=""
     local kotlin_inject_median=""
+    local koin_median=""
 
     # Calculate medians for GC time
     local metro_gc=""
     local dagger_ksp_gc=""
     local dagger_kapt_gc=""
     local kotlin_inject_gc=""
+    local koin_gc=""
 
     if [ -f "$metro_csv" ]; then
         metro_median=$(calculate_median "$metro_csv")
@@ -126,17 +129,24 @@ collect_performance_data() {
         kotlin_inject_gc=$(calculate_gc_median "$kotlin_inject_csv")
     fi
 
+    if [ -f "$koin_csv" ]; then
+        koin_median=$(calculate_median "$koin_csv")
+        koin_gc=$(calculate_gc_median "$koin_csv")
+    fi
+
     # Convert to seconds
     local metro_seconds=""
     local dagger_ksp_seconds=""
     local dagger_kapt_seconds=""
     local kotlin_inject_seconds=""
+    local koin_seconds=""
 
     # Convert GC to seconds
     local metro_gc_seconds=""
     local dagger_ksp_gc_seconds=""
     local dagger_kapt_gc_seconds=""
     local kotlin_inject_gc_seconds=""
+    local koin_gc_seconds=""
 
     if [ -n "$metro_median" ] && [ "$metro_median" != "0" ]; then
         metro_seconds=$(ms_to_seconds "$metro_median")
@@ -166,10 +176,18 @@ collect_performance_data() {
         kotlin_inject_gc_seconds=$(ms_to_seconds "$kotlin_inject_gc")
     fi
 
+    if [ -n "$koin_median" ] && [ "$koin_median" != "0" ]; then
+        koin_seconds=$(ms_to_seconds "$koin_median")
+    fi
+    if [ -n "$koin_gc" ] && [ "$koin_gc" != "0" ]; then
+        koin_gc_seconds=$(ms_to_seconds "$koin_gc")
+    fi
+
     # Calculate percentage increases relative to Metro
     local dagger_ksp_pct=""
     local dagger_kapt_pct=""
     local kotlin_inject_pct=""
+    local koin_pct=""
 
     if [ -n "$metro_median" ] && [ "$metro_median" != "0" ]; then
         if [ -n "$dagger_ksp_median" ] && [ "$dagger_ksp_median" != "0" ]; then
@@ -183,10 +201,14 @@ collect_performance_data() {
         if [ -n "$kotlin_inject_median" ] && [ "$kotlin_inject_median" != "0" ]; then
             kotlin_inject_pct=$(calculate_percentage "$metro_median" "$kotlin_inject_median")
         fi
+
+        if [ -n "$koin_median" ] && [ "$koin_median" != "0" ]; then
+            koin_pct=$(calculate_percentage "$metro_median" "$koin_median")
+        fi
     fi
 
-    # Return the data in a structured format (now includes GC times)
-    echo "${metro_seconds}|${metro_gc_seconds}|${dagger_ksp_seconds}|${dagger_ksp_gc_seconds}|${dagger_ksp_pct}|${dagger_kapt_seconds}|${dagger_kapt_gc_seconds}|${dagger_kapt_pct}|${kotlin_inject_seconds}|${kotlin_inject_gc_seconds}|${kotlin_inject_pct}"
+    # Return the data in a structured format (now includes GC times and Koin columns)
+    echo "${metro_seconds}|${metro_gc_seconds}|${dagger_ksp_seconds}|${dagger_ksp_gc_seconds}|${dagger_ksp_pct}|${dagger_kapt_seconds}|${dagger_kapt_gc_seconds}|${dagger_kapt_pct}|${kotlin_inject_seconds}|${kotlin_inject_gc_seconds}|${kotlin_inject_pct}|${koin_seconds}|${koin_gc_seconds}|${koin_pct}"
 }
 
 # Function to format a table cell with percentage and optional GC time
@@ -242,48 +264,48 @@ generate_performance_table() {
     local plain_abi_data=$(collect_performance_data "plain_abi_change" "$timestamp" "$results_dir")
     local plain_non_abi_data=$(collect_performance_data "plain_non_abi_change" "$timestamp" "$results_dir")
     
-    # Parse the data (format: metro|metro_gc|dagger_ksp|dagger_ksp_gc|dagger_ksp_pct|dagger_kapt|dagger_kapt_gc|dagger_kapt_pct|kotlin_inject|kotlin_inject_gc|kotlin_inject_pct)
-    IFS='|' read -r abi_metro abi_metro_gc abi_dagger_ksp abi_dagger_ksp_gc abi_dagger_ksp_pct abi_dagger_kapt abi_dagger_kapt_gc abi_dagger_kapt_pct abi_kotlin_inject abi_kotlin_inject_gc abi_kotlin_inject_pct <<< "$abi_data"
-    IFS='|' read -r non_abi_metro non_abi_metro_gc non_abi_dagger_ksp non_abi_dagger_ksp_gc non_abi_dagger_ksp_pct non_abi_dagger_kapt non_abi_dagger_kapt_gc non_abi_dagger_kapt_pct non_abi_kotlin_inject non_abi_kotlin_inject_gc non_abi_kotlin_inject_pct <<< "$non_abi_data"
-    IFS='|' read -r raw_metro raw_metro_gc raw_dagger_ksp raw_dagger_ksp_gc raw_dagger_ksp_pct raw_dagger_kapt raw_dagger_kapt_gc raw_dagger_kapt_pct raw_kotlin_inject raw_kotlin_inject_gc raw_kotlin_inject_pct <<< "$raw_data"
-    IFS='|' read -r plain_abi_metro plain_abi_metro_gc plain_abi_dagger_ksp plain_abi_dagger_ksp_gc plain_abi_dagger_ksp_pct plain_abi_dagger_kapt plain_abi_dagger_kapt_gc plain_abi_dagger_kapt_pct plain_abi_kotlin_inject plain_abi_kotlin_inject_gc plain_abi_kotlin_inject_pct <<< "$plain_abi_data"
-    IFS='|' read -r plain_non_abi_metro plain_non_abi_metro_gc plain_non_abi_dagger_ksp plain_non_abi_dagger_ksp_gc plain_non_abi_dagger_ksp_pct plain_non_abi_dagger_kapt plain_non_abi_dagger_kapt_gc plain_non_abi_dagger_kapt_pct plain_non_abi_kotlin_inject plain_non_abi_kotlin_inject_gc plain_non_abi_kotlin_inject_pct <<< "$plain_non_abi_data"
+    # Parse the data (format: metro|metro_gc|dagger_ksp|dagger_ksp_gc|dagger_ksp_pct|dagger_kapt|dagger_kapt_gc|dagger_kapt_pct|kotlin_inject|kotlin_inject_gc|kotlin_inject_pct|koin|koin_gc|koin_pct)
+    IFS='|' read -r abi_metro abi_metro_gc abi_dagger_ksp abi_dagger_ksp_gc abi_dagger_ksp_pct abi_dagger_kapt abi_dagger_kapt_gc abi_dagger_kapt_pct abi_kotlin_inject abi_kotlin_inject_gc abi_kotlin_inject_pct abi_koin abi_koin_gc abi_koin_pct <<< "$abi_data"
+    IFS='|' read -r non_abi_metro non_abi_metro_gc non_abi_dagger_ksp non_abi_dagger_ksp_gc non_abi_dagger_ksp_pct non_abi_dagger_kapt non_abi_dagger_kapt_gc non_abi_dagger_kapt_pct non_abi_kotlin_inject non_abi_kotlin_inject_gc non_abi_kotlin_inject_pct non_abi_koin non_abi_koin_gc non_abi_koin_pct <<< "$non_abi_data"
+    IFS='|' read -r raw_metro raw_metro_gc raw_dagger_ksp raw_dagger_ksp_gc raw_dagger_ksp_pct raw_dagger_kapt raw_dagger_kapt_gc raw_dagger_kapt_pct raw_kotlin_inject raw_kotlin_inject_gc raw_kotlin_inject_pct raw_koin raw_koin_gc raw_koin_pct <<< "$raw_data"
+    IFS='|' read -r plain_abi_metro plain_abi_metro_gc plain_abi_dagger_ksp plain_abi_dagger_ksp_gc plain_abi_dagger_ksp_pct plain_abi_dagger_kapt plain_abi_dagger_kapt_gc plain_abi_dagger_kapt_pct plain_abi_kotlin_inject plain_abi_kotlin_inject_gc plain_abi_kotlin_inject_pct plain_abi_koin plain_abi_koin_gc plain_abi_koin_pct <<< "$plain_abi_data"
+    IFS='|' read -r plain_non_abi_metro plain_non_abi_metro_gc plain_non_abi_dagger_ksp plain_non_abi_dagger_ksp_gc plain_non_abi_dagger_ksp_pct plain_non_abi_dagger_kapt plain_non_abi_dagger_kapt_gc plain_non_abi_dagger_kapt_pct plain_non_abi_kotlin_inject plain_non_abi_kotlin_inject_gc plain_non_abi_kotlin_inject_pct plain_non_abi_koin plain_non_abi_koin_gc plain_non_abi_koin_pct <<< "$plain_non_abi_data"
 
     # Generate the table in docs format
     echo ""
     echo "_(Median times in seconds, GC time in parentheses)_"
     echo ""
-    echo "|                          | Metro | Dagger (KSP) | Dagger (KAPT) | Kotlin-Inject |"
-    echo "|--------------------------|-------|--------------|---------------|---------------|"
+    echo "|                          | Metro | Dagger (KSP) | Dagger (KAPT) | Kotlin-Inject | Koin |"
+    echo "|--------------------------|-------|--------------|---------------|---------------|------|"
 
     # ABI row
     echo -n "| **ABI**                  | "
     echo -n "$(format_metro_cell "$abi_metro" "$abi_metro_gc")"
-    echo -n "  | $(format_cell "$abi_dagger_ksp" "$abi_dagger_ksp_gc" "$abi_dagger_ksp_pct") | $(format_cell "$abi_dagger_kapt" "$abi_dagger_kapt_gc" "$abi_dagger_kapt_pct") | $(format_cell "$abi_kotlin_inject" "$abi_kotlin_inject_gc" "$abi_kotlin_inject_pct") |"
+    echo -n "  | $(format_cell "$abi_dagger_ksp" "$abi_dagger_ksp_gc" "$abi_dagger_ksp_pct") | $(format_cell "$abi_dagger_kapt" "$abi_dagger_kapt_gc" "$abi_dagger_kapt_pct") | $(format_cell "$abi_kotlin_inject" "$abi_kotlin_inject_gc" "$abi_kotlin_inject_pct") | $(format_cell "$abi_koin" "$abi_koin_gc" "$abi_koin_pct") |"
     echo ""
 
     # Non-ABI row
     echo -n "| **Non-ABI**              | "
     echo -n "$(format_metro_cell "$non_abi_metro" "$non_abi_metro_gc")"
-    echo -n "  | $(format_cell "$non_abi_dagger_ksp" "$non_abi_dagger_ksp_gc" "$non_abi_dagger_ksp_pct") | $(format_cell "$non_abi_dagger_kapt" "$non_abi_dagger_kapt_gc" "$non_abi_dagger_kapt_pct") | $(format_cell "$non_abi_kotlin_inject" "$non_abi_kotlin_inject_gc" "$non_abi_kotlin_inject_pct") |"
+    echo -n "  | $(format_cell "$non_abi_dagger_ksp" "$non_abi_dagger_ksp_gc" "$non_abi_dagger_ksp_pct") | $(format_cell "$non_abi_dagger_kapt" "$non_abi_dagger_kapt_gc" "$non_abi_dagger_kapt_pct") | $(format_cell "$non_abi_kotlin_inject" "$non_abi_kotlin_inject_gc" "$non_abi_kotlin_inject_pct") | $(format_cell "$non_abi_koin" "$non_abi_koin_gc" "$non_abi_koin_pct") |"
     echo ""
 
     # Plain Kotlin ABI row
     echo -n "| **Plain Kotlin ABI**     | "
     echo -n "$(format_metro_cell "$plain_abi_metro" "$plain_abi_metro_gc")"
-    echo -n "  | $(format_cell "$plain_abi_dagger_ksp" "$plain_abi_dagger_ksp_gc" "$plain_abi_dagger_ksp_pct") | $(format_cell "$plain_abi_dagger_kapt" "$plain_abi_dagger_kapt_gc" "$plain_abi_dagger_kapt_pct") | $(format_cell "$plain_abi_kotlin_inject" "$plain_abi_kotlin_inject_gc" "$plain_abi_kotlin_inject_pct") |"
+    echo -n "  | $(format_cell "$plain_abi_dagger_ksp" "$plain_abi_dagger_ksp_gc" "$plain_abi_dagger_ksp_pct") | $(format_cell "$plain_abi_dagger_kapt" "$plain_abi_dagger_kapt_gc" "$plain_abi_dagger_kapt_pct") | $(format_cell "$plain_abi_kotlin_inject" "$plain_abi_kotlin_inject_gc" "$plain_abi_kotlin_inject_pct") | $(format_cell "$plain_abi_koin" "$plain_abi_koin_gc" "$plain_abi_koin_pct") |"
     echo ""
 
     # Plain Kotlin Non-ABI row
     echo -n "| **Plain Kotlin Non-ABI** | "
     echo -n "$(format_metro_cell "$plain_non_abi_metro" "$plain_non_abi_metro_gc")"
-    echo -n "  | $(format_cell "$plain_non_abi_dagger_ksp" "$plain_non_abi_dagger_ksp_gc" "$plain_non_abi_dagger_ksp_pct") | $(format_cell "$plain_non_abi_dagger_kapt" "$plain_non_abi_dagger_kapt_gc" "$plain_non_abi_dagger_kapt_pct") | $(format_cell "$plain_non_abi_kotlin_inject" "$plain_non_abi_kotlin_inject_gc" "$plain_non_abi_kotlin_inject_pct") |"
+    echo -n "  | $(format_cell "$plain_non_abi_dagger_ksp" "$plain_non_abi_dagger_ksp_gc" "$plain_non_abi_dagger_ksp_pct") | $(format_cell "$plain_non_abi_dagger_kapt" "$plain_non_abi_dagger_kapt_gc" "$plain_non_abi_dagger_kapt_pct") | $(format_cell "$plain_non_abi_kotlin_inject" "$plain_non_abi_kotlin_inject_gc" "$plain_non_abi_kotlin_inject_pct") | $(format_cell "$plain_non_abi_koin" "$plain_non_abi_koin_gc" "$plain_non_abi_koin_pct") |"
     echo ""
 
     # Graph processing row
     echo -n "| **Graph processing**     | "
     echo -n "$(format_metro_cell "$raw_metro" "$raw_metro_gc")"
-    echo -n " | $(format_cell "$raw_dagger_ksp" "$raw_dagger_ksp_gc" "$raw_dagger_ksp_pct") | $(format_cell "$raw_dagger_kapt" "$raw_dagger_kapt_gc" "$raw_dagger_kapt_pct") | $(format_cell "$raw_kotlin_inject" "$raw_kotlin_inject_gc" "$raw_kotlin_inject_pct") |"
+    echo -n " | $(format_cell "$raw_dagger_ksp" "$raw_dagger_ksp_gc" "$raw_dagger_ksp_pct") | $(format_cell "$raw_dagger_kapt" "$raw_dagger_kapt_gc" "$raw_dagger_kapt_pct") | $(format_cell "$raw_kotlin_inject" "$raw_kotlin_inject_gc" "$raw_kotlin_inject_pct") | $(format_cell "$raw_koin" "$raw_koin_gc" "$raw_koin_pct") |"
     echo ""
     echo ""
 }

--- a/benchmark/run_benchmarks.sh
+++ b/benchmark/run_benchmarks.sh
@@ -19,11 +19,11 @@ TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 
 # Mode lists
 # Standard modes (without baselines)
-STANDARD_MODES="metro,dagger-ksp,dagger-kapt,kotlin-inject-anvil"
+STANDARD_MODES="metro,dagger-ksp,dagger-kapt,kotlin-inject-anvil,koin"
 # Baseline modes (pure Kotlin and Metro plugin overhead)
 BASELINE_MODES="vanilla,metro-noop"
 # All modes including baselines
-ALL_MODES_WITH_BASELINES="metro,vanilla,metro-noop,dagger-ksp,dagger-kapt,kotlin-inject-anvil"
+ALL_MODES_WITH_BASELINES="metro,vanilla,metro-noop,dagger-ksp,dagger-kapt,kotlin-inject-anvil,koin"
 
 # Git refs
 SINGLE_REF=""
@@ -100,6 +100,8 @@ collect_build_metadata() {
     local kotlin_inject_version=$(get_version "kotlinInject")
     local anvil_version=$(get_version "anvil")
     local kotlin_inject_anvil_version=$(get_version "kotlinInject-anvil")
+    local koin_version=$(get_version "koin")
+    local koin_compiler_version=$(get_version "koin-compiler")
     local jvm_target=$(get_version "jvmTarget")
     local jdk_version=$(get_version "jdk")
 
@@ -154,7 +156,9 @@ collect_build_metadata() {
     "ksp": "$ksp_version",
     "kotlinInject": "$kotlin_inject_version",
     "anvil": "$anvil_version",
-    "kotlinInjectAnvil": "$kotlin_inject_anvil_version"
+    "kotlinInjectAnvil": "$kotlin_inject_anvil_version",
+    "koin": "$koin_version",
+    "koinCompiler": "$koin_compiler_version"
   },
   "build": {
     "gradle": "$gradle_version",
@@ -216,6 +220,8 @@ generate_projects() {
         kotlin generate-projects.main.kts --mode "DAGGER" --processor "$(echo $processor | tr '[:lower:]' '[:upper:]')" --count "$count"
     elif [ "$mode" = "kotlin-inject-anvil" ]; then
         kotlin generate-projects.main.kts --mode "KOTLIN_INJECT_ANVIL" --count "$count"
+    elif [ "$mode" = "koin" ]; then
+        kotlin generate-projects.main.kts --mode "KOIN" --count "$count"
     elif [ "$mode" = "vanilla" ]; then
         kotlin generate-projects.main.kts --mode "VANILLA" --count "$count"
     elif [ "$mode" = "metro-noop" ]; then
@@ -252,6 +258,8 @@ run_scenarios() {
         mode_name="dagger_kapt"
     elif [ "$mode" = "kotlin-inject-anvil" ]; then
         mode_name="kotlin_inject_anvil"
+    elif [ "$mode" = "koin" ]; then
+        mode_name="koin"
     else
         print_error "Invalid mode/processor combination: $mode/$processor"
         exit 1
@@ -263,7 +271,9 @@ run_scenarios() {
     # Determine the raw compilation variant for this mode
     local raw_compilation_variant
     case "$mode_name" in
-        metro|vanilla|metro_noop)
+        metro|vanilla|metro_noop|koin)
+            # Metro/Koin use pure K2 compiler plugins (no annotation processing), so the
+            # `raw_compilation` scenario (app-component-only rerun) works for both.
             raw_compilation_variant="raw_compilation"
             ;;
         kotlin_inject_anvil)
@@ -415,6 +425,7 @@ show_usage() {
     echo "  dagger-ksp [COUNT]            Run only Dagger (KSP) mode"
     echo "  dagger-kapt [COUNT]           Run only Dagger (KAPT) mode"
     echo "  kotlin-inject-anvil [COUNT]   Run only Kotlin-inject + Anvil mode"
+    echo "  koin [COUNT]                  Run only Koin mode (koin-annotations + compiler plugin)"
     echo "  single                        Run benchmarks on a git ref, Metro version, or HEAD (current branch)"
     echo "  compare                       Compare benchmarks across two refs (git refs or Metro versions)"
     echo "  help                          Show this help message"
@@ -428,8 +439,8 @@ show_usage() {
     echo "Single/Compare Options:"
     echo "  --ref <ref>                  Git ref (branch name/commit) or Metro version (e.g., 1.0.0)"
     echo "  --modes <list>               Comma-separated list of modes to benchmark, or 'all'"
-    echo "                               Available: metro, vanilla, metro-noop, dagger-ksp, dagger-kapt, kotlin-inject-anvil, all"
-    echo "                               Default: metro,dagger-ksp,dagger-kapt,kotlin-inject-anvil"
+    echo "                               Available: metro, vanilla, metro-noop, dagger-ksp, dagger-kapt, kotlin-inject-anvil, koin, all"
+    echo "                               Default: metro,dagger-ksp,dagger-kapt,kotlin-inject-anvil,koin"
     echo "                               Use 'all' to run all standard modes (add --include-baselines for vanilla/metro-noop)"
     echo "  --scenarios <list>           Comma-separated list of scenarios to run"
     echo "                               Available: abi_change, non_abi_change, plain_abi_change, plain_non_abi_change, raw_compilation, clean_build"
@@ -632,6 +643,15 @@ run_benchmarks_for_ref() {
                     fi
                 done
                 ;;
+            "koin")
+                generate_projects "koin" "" "$count"
+                run_scenarios "koin" "" "$include_clean_builds"
+                for scenario_dir in "$RESULTS_DIR"/koin_*"$TIMESTAMP"*; do
+                    if [ -d "$scenario_dir" ]; then
+                        mv "$scenario_dir" "$ref_dir/" 2>/dev/null || true
+                    fi
+                done
+                ;;
             *)
                 print_warning "Unknown mode: $mode, skipping"
                 ;;
@@ -653,7 +673,7 @@ extract_median_for_ref() {
     case "$test_type" in
         raw_compilation)
             case "$mode_prefix" in
-                metro|vanilla|metro_noop)
+                metro|vanilla|metro_noop|koin)
                     scenario_name="raw_compilation"
                     ;;
                 kotlin_inject_anvil)
@@ -713,7 +733,7 @@ extract_gc_for_ref() {
     case "$test_type" in
         raw_compilation)
             case "$mode_prefix" in
-                metro|vanilla|metro_noop)
+                metro|vanilla|metro_noop|koin)
                     scenario_name="raw_compilation"
                     ;;
                 kotlin_inject_anvil)
@@ -798,6 +818,7 @@ generate_comparison_summary() {
             "dagger-ksp") mode_prefix="dagger_ksp" ;;
             "dagger-kapt") mode_prefix="dagger_kapt" ;;
             "kotlin-inject-anvil") mode_prefix="kotlin_inject_anvil" ;;
+            "koin") mode_prefix="koin" ;;
             *) continue ;;
         esac
         if mode_was_run_for_ref "$ref2_label" "$mode_prefix"; then
@@ -856,6 +877,8 @@ EOF
                 "dagger-ksp") mode_prefix="dagger_ksp" ;;
                 "dagger-kapt") mode_prefix="dagger_kapt" ;;
                 "kotlin-inject-anvil") mode_prefix="kotlin_inject_anvil" ;;
+                "koin") mode_prefix="koin" ;;
+            "koin") mode_prefix="koin" ;;
                 *) continue ;;
             esac
 
@@ -982,7 +1005,7 @@ generate_html_report() {
     <title>Metro Benchmark Results</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
-        :root { --metro-color: #4CAF50; --vanilla-color: #607D8B; --metro-noop-color: #795548; --dagger-ksp-color: #2196F3; --dagger-kapt-color: #FF9800; --kotlin-inject-color: #9C27B0; }
+        :root { --metro-color: #4CAF50; --vanilla-color: #607D8B; --metro-noop-color: #795548; --dagger-ksp-color: #2196F3; --dagger-kapt-color: #FF9800; --kotlin-inject-color: #9C27B0; --koin-color: #E91E63; }
         * { box-sizing: border-box; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; background: #f5f5f5; color: #333; }
         .header { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); color: white; padding: 2rem; text-align: center; }
@@ -1053,8 +1076,8 @@ HTMLHEAD
 
     cat >> "$html_file" << 'HTMLTAIL'
 ;
-const colors = { 'metro': '#4CAF50', 'vanilla': '#607D8B', 'metro_noop': '#795548', 'dagger_ksp': '#2196F3', 'dagger_kapt': '#FF9800', 'kotlin_inject_anvil': '#9C27B0' };
-const displayNames = { 'metro': 'Metro', 'vanilla': 'Vanilla (Baseline)', 'metro_noop': 'Metro-NOOP', 'dagger_ksp': 'Dagger (KSP)', 'dagger_kapt': 'Dagger (KAPT)', 'kotlin_inject_anvil': 'kotlin-inject' };
+const colors = { 'metro': '#4CAF50', 'vanilla': '#607D8B', 'metro_noop': '#795548', 'dagger_ksp': '#2196F3', 'dagger_kapt': '#FF9800', 'kotlin_inject_anvil': '#9C27B0', 'koin': '#E91E63' };
+const displayNames = { 'metro': 'Metro', 'vanilla': 'Vanilla (Baseline)', 'metro_noop': 'Metro-NOOP', 'dagger_ksp': 'Dagger (KSP)', 'dagger_kapt': 'Dagger (KAPT)', 'kotlin_inject_anvil': 'kotlin-inject', 'koin': 'Koin' };
 
 // State for selectable baseline
 let selectedBaseline = 'metro';
@@ -1113,8 +1136,8 @@ function renderRefsInfo() {
 
 function renderSummaryStats() {
     const container = document.getElementById('summary-stats');
-    let totalSpeedup = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0 };
-    let counts = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0 };
+    let totalSpeedup = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0, koin: 0 };
+    let counts = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0, koin: 0 };
     benchmarkData.benchmarks.forEach(benchmark => {
         const metroResult = benchmark.results.find(r => r.key === 'metro');
         if (!metroResult || !metroResult.ref1) return;
@@ -1126,7 +1149,7 @@ function renderSummaryStats() {
         });
     });
     let html = '';
-    const names = { 'dagger_ksp': 'Dagger (KSP)', 'dagger_kapt': 'Dagger (KAPT)', 'kotlin_inject_anvil': 'kotlin-inject' };
+    const names = { 'dagger_ksp': 'Dagger (KSP)', 'dagger_kapt': 'Dagger (KAPT)', 'kotlin_inject_anvil': 'kotlin-inject', 'koin': 'Koin' };
     Object.keys(totalSpeedup).forEach(key => {
         if (counts[key] > 0) {
             const avgSpeedup = (totalSpeedup[key] / counts[key]).toFixed(1);
@@ -1219,6 +1242,8 @@ function renderMetadata() {
                     <dt>kotlin-inject</dt><dd>${m.versions?.kotlinInject || '—'}</dd>
                     <dt>Anvil</dt><dd>${m.versions?.anvil || '—'}</dd>
                     <dt>kotlin-inject-anvil</dt><dd>${m.versions?.kotlinInjectAnvil || '—'}</dd>
+                    <dt>Koin</dt><dd>${m.versions?.koin || '—'}</dd>
+                    <dt>Koin Compiler</dt><dd>${m.versions?.koinCompiler || '—'}</dd>
                 </dl>
             </div>
             <div class="metadata-group">
@@ -1296,6 +1321,8 @@ build_benchmark_json() {
     local kotlin_inject_version=$(get_toml_version "kotlinInject")
     local anvil_version=$(get_toml_version "anvil")
     local kotlin_inject_anvil_version=$(get_toml_version "kotlinInject-anvil")
+    local koin_version=$(get_toml_version "koin")
+    local koin_compiler_version=$(get_toml_version "koin-compiler")
     local jvm_target=$(get_toml_version "jvmTarget")
 
     local gradle_version=$("$repo_root/gradlew" --version 2>/dev/null | grep "^Gradle " | awk '{print $2}' || echo "unknown")
@@ -1334,7 +1361,9 @@ build_benchmark_json() {
     echo '      "ksp": "'"$ksp_version"'",'
     echo '      "kotlinInject": "'"$kotlin_inject_version"'",'
     echo '      "anvil": "'"$anvil_version"'",'
-    echo '      "kotlinInjectAnvil": "'"$kotlin_inject_anvil_version"'"'
+    echo '      "kotlinInjectAnvil": "'"$kotlin_inject_anvil_version"'",'
+    echo '      "koin": "'"$koin_version"'",'
+    echo '      "koinCompiler": "'"$koin_compiler_version"'"'
     echo '    },'
     echo '    "build": {'
     echo '      "gradle": "'"$gradle_version"'",'
@@ -1377,6 +1406,7 @@ build_benchmark_json() {
                 "dagger-ksp") mode_prefix="dagger_ksp"; mode_name="Dagger (KSP)" ;;
                 "dagger-kapt") mode_prefix="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
                 "kotlin-inject-anvil") mode_prefix="kotlin_inject_anvil"; mode_name="kotlin-inject" ;;
+                "koin") mode_prefix="koin"; mode_name="Koin" ;;
                 *) continue ;;
             esac
 
@@ -1477,6 +1507,8 @@ EOF
                 "dagger-ksp") mode_prefix="dagger_ksp" ;;
                 "dagger-kapt") mode_prefix="dagger_kapt" ;;
                 "kotlin-inject-anvil") mode_prefix="kotlin_inject_anvil" ;;
+                "koin") mode_prefix="koin" ;;
+            "koin") mode_prefix="koin" ;;
                 *) continue ;;
             esac
 
@@ -1820,7 +1852,7 @@ main() {
             COMPARE_MODES="all"
             run_single "$count" "$include_clean_builds"
             ;;
-        metro|vanilla|metro-noop|dagger-ksp|dagger-kapt|kotlin-inject-anvil)
+        metro|vanilla|metro-noop|dagger-ksp|dagger-kapt|kotlin-inject-anvil|koin)
             # Single mode is shorthand for 'single --ref HEAD --modes <mode>' (current branch)
             SINGLE_REF="HEAD"
             COMPARE_MODES="$command"

--- a/benchmark/run_startup_benchmarks.sh
+++ b/benchmark/run_startup_benchmarks.sh
@@ -20,7 +20,7 @@ MODULE_COUNT=500
 START_TIME=$(date +%s)
 
 # Default modes to benchmark
-MODES="metro,dagger-ksp,dagger-kapt,kotlin-inject-anvil"
+MODES="metro,dagger-ksp,dagger-kapt,kotlin-inject-anvil,koin"
 
 # Git refs
 SINGLE_REF=""
@@ -108,8 +108,8 @@ show_usage() {
     echo ""
     echo "Options:"
     echo "  --modes <list>          Comma-separated list of modes to benchmark"
-    echo "                          Available: metro, dagger-ksp, dagger-kapt, kotlin-inject-anvil"
-    echo "                          Default: metro,dagger-ksp,dagger-kapt,kotlin-inject-anvil"
+    echo "                          Available: metro, dagger-ksp, dagger-kapt, kotlin-inject-anvil, koin"
+    echo "                          Default: metro,dagger-ksp,dagger-kapt,kotlin-inject-anvil,koin"
     echo "  --count <n>             Number of modules to generate (default: 500)"
     echo "  --timestamp <ts>        Use specific timestamp for results directory"
     echo "  --include-macrobenchmark  Include Android macrobenchmarks (startup time)"
@@ -206,6 +206,9 @@ get_generator_args() {
         kotlin-inject-anvil)
             args="--mode kotlin_inject_anvil"
             ;;
+        koin)
+            args="--mode koin"
+            ;;
         *)
             print_error "Unknown mode: $mode"
             exit 1
@@ -244,6 +247,11 @@ get_gradle_args() {
         dagger-ksp|dagger-kapt|kotlin-inject-anvil)
             # Disable incremental processing and build cache to avoid flaky KSP/KAPT builds
             args="--no-build-cache -Pksp.incremental=false -Pkotlin.incremental=false"
+            ;;
+        koin)
+            # Koin uses a K2 compiler plugin (no KSP); disable build cache to keep startup
+            # benchmarks measuring cold compilation parity with the KSP-using modes.
+            args="--no-build-cache -Pkotlin.incremental=false"
             ;;
         *)
             args=""
@@ -1324,7 +1332,7 @@ HTMLHEAD
 
     cat >> "$html_file" << 'HTMLTAIL'
 ;
-const colors = { 'metro': '#4CAF50', 'dagger_ksp': '#2196F3', 'dagger_kapt': '#FF9800', 'kotlin_inject_anvil': '#9C27B0' };
+const colors = { 'metro': '#4CAF50', 'dagger_ksp': '#2196F3', 'dagger_kapt': '#FF9800', 'kotlin_inject_anvil': '#9C27B0', 'koin': '#E91E63' };
 let selectedBaseline = 'metro';
 
 function formatTime(ms, unit) {
@@ -1348,8 +1356,8 @@ function calculateVsBaseline(value, baselineValue) {
 
 function renderSummaryStats() {
     const container = document.getElementById('summary-stats');
-    let totalSpeedup = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0 };
-    let counts = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0 };
+    let totalSpeedup = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0, koin: 0 };
+    let counts = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0, koin: 0 };
     benchmarkData.benchmarks.forEach(benchmark => {
         const metroResult = benchmark.results.find(r => r.key === 'metro');
         if (!metroResult || !metroResult.value) return;
@@ -1361,7 +1369,7 @@ function renderSummaryStats() {
         });
     });
     let html = '';
-    const names = { 'dagger_ksp': 'Dagger (KSP)', 'dagger_kapt': 'Dagger (KAPT)', 'kotlin_inject_anvil': 'kotlin-inject' };
+    const names = { 'dagger_ksp': 'Dagger (KSP)', 'dagger_kapt': 'Dagger (KAPT)', 'kotlin_inject_anvil': 'kotlin-inject', 'koin': 'Koin' };
     Object.keys(totalSpeedup).forEach(key => {
         if (counts[key] > 0) {
             const avgSpeedup = (totalSpeedup[key] / counts[key]).toFixed(1);
@@ -1442,6 +1450,8 @@ function renderMetadata() {
                     <dt>kotlin-inject</dt><dd>${m.versions?.kotlinInject || '—'}</dd>
                     <dt>Anvil</dt><dd>${m.versions?.anvil || '—'}</dd>
                     <dt>kotlin-inject-anvil</dt><dd>${m.versions?.kotlinInjectAnvil || '—'}</dd>
+                    <dt>Koin</dt><dd>${m.versions?.koin || '—'}</dd>
+                    <dt>Koin Compiler</dt><dd>${m.versions?.koinCompiler || '—'}</dd>
                 </dl>
             </div>
             <div class="metadata-group">
@@ -1515,6 +1525,8 @@ build_non_ref_benchmark_json() {
     local kotlin_inject_version=$(get_toml_version "kotlinInject")
     local anvil_version=$(get_toml_version "anvil")
     local kotlin_inject_anvil_version=$(get_toml_version "kotlinInject-anvil")
+    local koin_version=$(get_toml_version "koin")
+    local koin_compiler_version=$(get_toml_version "koin-compiler")
     local jvm_target=$(get_toml_version "jvmTarget")
 
     # JMH and benchmark versions
@@ -1549,7 +1561,9 @@ build_non_ref_benchmark_json() {
     echo '      "ksp": "'"$ksp_version"'",'
     echo '      "kotlinInject": "'"$kotlin_inject_version"'",'
     echo '      "anvil": "'"$anvil_version"'",'
-    echo '      "kotlinInjectAnvil": "'"$kotlin_inject_anvil_version"'"'
+    echo '      "kotlinInjectAnvil": "'"$kotlin_inject_anvil_version"'",'
+    echo '      "koin": "'"$koin_version"'",'
+    echo '      "koinCompiler": "'"$koin_compiler_version"'"'
     echo '    },'
     echo '    "build": {'
     echo '      "jdk": "'"$java_version"'",'
@@ -1591,6 +1605,7 @@ build_non_ref_benchmark_json() {
                 "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
                 "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
                 "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
                 *) continue ;;
             esac
 
@@ -1654,6 +1669,7 @@ build_non_ref_benchmark_json() {
                     "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
                     "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
                     "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject-anvil" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
                     *) continue ;;
                 esac
 
@@ -1720,6 +1736,7 @@ build_non_ref_benchmark_json() {
                     "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
                     "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
                     "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject-anvil" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
                     *) continue ;;
                 esac
 
@@ -1763,6 +1780,7 @@ build_non_ref_benchmark_json() {
                 "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
                 "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
                 "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
                 *) continue ;;
             esac
 
@@ -3124,6 +3142,8 @@ build_startup_benchmark_json() {
     local kotlin_inject_version=$(get_toml_version "kotlinInject")
     local anvil_version=$(get_toml_version "anvil")
     local kotlin_inject_anvil_version=$(get_toml_version "kotlinInject-anvil")
+    local koin_version=$(get_toml_version "koin")
+    local koin_compiler_version=$(get_toml_version "koin-compiler")
     local jvm_target=$(get_toml_version "jvmTarget")
 
     # JMH and benchmark versions
@@ -3158,7 +3178,9 @@ build_startup_benchmark_json() {
     echo '      "ksp": "'"$ksp_version"'",'
     echo '      "kotlinInject": "'"$kotlin_inject_version"'",'
     echo '      "anvil": "'"$anvil_version"'",'
-    echo '      "kotlinInjectAnvil": "'"$kotlin_inject_anvil_version"'"'
+    echo '      "kotlinInjectAnvil": "'"$kotlin_inject_anvil_version"'",'
+    echo '      "koin": "'"$koin_version"'",'
+    echo '      "koinCompiler": "'"$koin_compiler_version"'"'
     echo '    },'
     echo '    "build": {'
     echo '      "jdk": "'"$java_version"'",'
@@ -3212,6 +3234,7 @@ build_startup_benchmark_json() {
                 "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
                 "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
                 "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
                 *) continue ;;
             esac
 
@@ -3275,6 +3298,7 @@ build_startup_benchmark_json() {
                     "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
                     "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
                     "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject-anvil" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
                     *) continue ;;
                 esac
 
@@ -3344,6 +3368,7 @@ build_startup_benchmark_json() {
                     "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
                     "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
                     "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject-anvil" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
                     *) continue ;;
                 esac
 
@@ -3396,6 +3421,7 @@ build_startup_benchmark_json() {
                 "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
                 "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
                 "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
                 *) continue ;;
             esac
 
@@ -3446,6 +3472,7 @@ build_startup_benchmark_json() {
             "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
             "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
             "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
             *) continue ;;
         esac
 
@@ -3505,6 +3532,7 @@ build_startup_benchmark_json() {
             "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
             "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
             "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
             *) continue ;;
         esac
 
@@ -3561,6 +3589,7 @@ build_startup_benchmark_json() {
             "dagger-ksp") mode_key="dagger_ksp"; mode_name="Dagger (KSP)" ;;
             "dagger-kapt") mode_key="dagger_kapt"; mode_name="Dagger (KAPT)" ;;
             "kotlin-inject-anvil") mode_key="kotlin_inject_anvil"; mode_name="kotlin-inject" ;;
+                "koin") mode_key="koin"; mode_name="Koin" ;;
             *) continue ;;
         esac
 
@@ -3705,7 +3734,7 @@ HTMLHEAD
 
     cat >> "$html_file" << 'HTMLTAIL'
 ;
-const colors = { 'metro': '#4CAF50', 'dagger_ksp': '#2196F3', 'dagger_kapt': '#FF9800', 'kotlin_inject_anvil': '#9C27B0' };
+const colors = { 'metro': '#4CAF50', 'dagger_ksp': '#2196F3', 'dagger_kapt': '#FF9800', 'kotlin_inject_anvil': '#9C27B0', 'koin': '#E91E63' };
 
 // State for selectable baseline
 let selectedBaseline = 'metro';
@@ -3755,8 +3784,8 @@ function renderRefsInfo() {
 function renderSummaryStats() {
     const container = document.getElementById('summary-stats');
     // Calculate average speedup vs other frameworks across all benchmarks
-    let totalSpeedup = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0 };
-    let counts = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0 };
+    let totalSpeedup = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0, koin: 0 };
+    let counts = { dagger_ksp: 0, dagger_kapt: 0, kotlin_inject_anvil: 0, koin: 0 };
     benchmarkData.benchmarks.forEach(benchmark => {
         const metroResult = benchmark.results.find(r => r.key === 'metro');
         if (!metroResult || !metroResult.ref1) return;
@@ -3768,7 +3797,7 @@ function renderSummaryStats() {
         });
     });
     let html = '';
-    const names = { 'dagger_ksp': 'Dagger (KSP)', 'dagger_kapt': 'Dagger (KAPT)', 'kotlin_inject_anvil': 'kotlin-inject' };
+    const names = { 'dagger_ksp': 'Dagger (KSP)', 'dagger_kapt': 'Dagger (KAPT)', 'kotlin_inject_anvil': 'kotlin-inject', 'koin': 'Koin' };
     Object.keys(totalSpeedup).forEach(key => {
         if (counts[key] > 0) {
             const avgSpeedup = (totalSpeedup[key] / counts[key]).toFixed(1);
@@ -3866,6 +3895,8 @@ function renderMetadata() {
                         <dt>kotlin-inject</dt><dd>${m.versions?.kotlinInject || '—'}</dd>
                         <dt>Anvil</dt><dd>${m.versions?.anvil || '—'}</dd>
                         <dt>kotlin-inject-anvil</dt><dd>${m.versions?.kotlinInjectAnvil || '—'}</dd>
+                    <dt>Koin</dt><dd>${m.versions?.koin || '—'}</dd>
+                    <dt>Koin Compiler</dt><dd>${m.versions?.koinCompiler || '—'}</dd>
                     </dl>
                 </div>
                 <div class="metadata-group">

--- a/benchmark/startup-jvm-minified/build.gradle.kts
+++ b/benchmark/startup-jvm-minified/build.gradle.kts
@@ -10,11 +10,15 @@ dependencies {
   jmhCompileOnly(project(":app:component"))
   // Run against the minified jar
   jmhRuntimeOnly(project(":startup-jvm:minified-jar"))
-  // Runtime dependencies not included in the minified jar (library classpath)
+  // Runtime dependencies not included in the minified jar (library classpath).
+  // All frameworks' runtimes are listed so the same minified-jar harness works regardless of
+  // which framework the generator produced — the classloader will only resolve what's used.
   jmhRuntimeOnly("dev.zacsweers.metro:runtime:+")
   jmhRuntimeOnly("javax.inject:javax.inject:1")
   jmhRuntimeOnly(libs.dagger.runtime)
   jmhRuntimeOnly(libs.kotlinInject.runtime)
+  jmhRuntimeOnly(libs.koin.core)
+  jmhRuntimeOnly(libs.koin.annotations)
 }
 
 jmh {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,8 @@ kct = "0.12.1"
 kotlin = "2.3.20"
 kotlinPublished = "2.2.20"
 kotlinInject = "0.9.0"
+koin = "4.2.1"
+koin-compiler = "1.0.0-RC2"
 metro = "1.0.0-RC3"
 kotlinInject-anvil = "0.1.7"
 kotlinx-benchmark = "0.4.16"
@@ -61,6 +63,7 @@ dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 gradleTestRetry = { id = "org.gradle.test-retry", version = "1.6.4" }
 intellijPlatform = { id = "org.jetbrains.intellij.platform", version = "2.14.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
+koin-compiler = { id = "io.insert-koin.compiler.plugin", version.ref = "koin-compiler" }
 kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -139,6 +142,10 @@ jetbrains-lifecycle-viewmodel = "org.jetbrains.androidx.lifecycle:lifecycle-view
 jetbrains-lifecycle-viewmodel-compose = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0"
 jetbrains-lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "jetbrains-lifecycle-navigation3" }
 jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "jetbrains-navigation3" }
+
+koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-annotations = { module = "io.insert-koin:koin-annotations", version.ref = "koin" }
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 
 kotlinInject-anvil-compiler = { module = "software.amazon.lastmile.kotlin.inject.anvil:compiler", version.ref = "kotlinInject-anvil" }
 kotlinInject-anvil-runtime = { module = "software.amazon.lastmile.kotlin.inject.anvil:runtime", version.ref = "kotlinInject-anvil" }


### PR DESCRIPTION
Adds a koin compiler mode + some cleanup around KMP testing. Benchmarks are about as expected, though some bits are best-effort as Koin doesn't have multibindings or graph/component identities. Results below on Metro 1.0.0-RC2.

---

## Runtime

Runtime perf is significantly worse on koin as it must construct the graph at runtime. This benchmark may also favor metro a bit because koin doesn't support multibindings, so functionally-recreating this requires `getAll()` lookups to create bindings. It also seems to suffer from the sort of pathological case on android that kotlin-inject does with the large `Map` instance. Had to do some manual sharding hacks as koin's code gen doesn't and will hit JVM method size limits with one global aggregating module.

# Startup Benchmark Results: main

**Date:** Thu Apr 23 03:44:20 EDT 2026
**Module Count:** 500
**Modes:** metro,koin
**Commit:** 2869b70b Prepare next development version.

## JVM Benchmarks (JMH)

Graph creation and initialization time (lower is better):

| Framework | Time (ms) | Alloc (KB/op) | vs Metro |
|-----------|-----------|---------------|----------|
| metro | 0.165 | 132.29 | baseline |
| koin | 3.969 | 16668.00 | +2298.4% (23.98x) |

## JVM Benchmarks - R8 Minified (JMH)

Graph creation and initialization time with R8 optimization (lower is better):

| Framework | Time (ms) | Alloc (KB/op) | vs Metro R8 |
|-----------|-----------|---------------|-------------|
| metro | 0.163 | N/A | baseline |
| koin | 3.930 | N/A | +2306.4% (24.06x) |

## Android Benchmarks (Microbenchmark)

Graph creation and initialization time on Android (lower is better):

| Framework | Time (ms) | vs Metro |
|-----------|-----------|----------|
| metro | 0.157 | baseline |
| koin | 31.318 | +19847.8% (199.48x) |

---

## Binary Metrics

Binary metrics are significantly larger in koin in minified builds. This was a bit surprising, maybe it has some greedy keep rules since it relies on reflection?

### Pre-Minification Component Classes

| Framework | Fields | Methods | Shards | Size (KB) |
|-----------|--------|---------|--------|-----------|
| metro | 931 | 1022 | 0 | 3419.3 |
| koin | 1 | 9 | 0 | 224.7 |

### R8-Minified JAR

| Framework | JAR Size (KB) | Classes | Methods | Fields |
|-----------|---------------|---------|---------|--------|
| metro | 2508.7 | 3672 | 5485 | 901 |
| koin | 4130.6 | 5697 | 8084 | 2 |

### Android APK

| Framework | APK Size (KB) | DEX Size (KB) | DEX Classes | DEX Methods | DEX Fields |
|-----------|---------------|---------------|-------------|-------------|------------|
| metro | 787.9 | 555.7 | 823 | 4445 | 2219 |
| koin | 1532.9 | 1331.2 | 5306 | 4255 | 1512 |

## Raw Results

Results are stored in: `startup-benchmark-results/20260423_033439/`

- `main/` - Results (2869b70b Prepare next development version.)

---

## Build

Build time perf is better in Koin, again expected since koin-compiler only does basic reachability/scanning and no full graph construction/validation (by far the most expensive step in metro's compiler). Not apples to apples like metro vs dagger/kotlin-inject but interesting none-the-less.

# Benchmark Results: HEAD

**Date:** Thu Apr 23 11:33:01 EDT 2026
**Module Count:** 500
**Modes:** metro,koin
**Commit:** 2869b70b Prepare next development version.

## ABI Change

| Framework | Time | GC Time | vs Metro |
|-----------|------|---------|----------|
| metro | 10.9s | .18s | baseline |
| koin | 8.6s | .16s | -21.4% (0.79x) |

## Non-ABI Change

| Framework | Time | GC Time | vs Metro |
|-----------|------|---------|----------|
| metro | 7.9s | .11s | baseline |
| koin | 6.5s | .12s | -17.3% (0.83x) |

## Plain Kotlin ABI

| Framework | Time | GC Time | vs Metro |
|-----------|------|---------|----------|
| metro | 11.7s | .17s | baseline |
| koin | 7.8s | .16s | -33% (0.67x) |

## Plain Kotlin Non-ABI

| Framework | Time | GC Time | vs Metro |
|-----------|------|---------|----------|
| metro | 5.3s | .11s | baseline |
| koin | 5.2s | .11s | -2.8% (0.97x) |

## Graph Processing

| Framework | Time | GC Time | vs Metro |
|-----------|------|---------|----------|
| metro | 13.5s | .14s | baseline |
| koin | 5.2s | .12s | -61.3% (0.39x) |

## Raw Results

Results are stored in: `benchmark-results/20260423_111146/`

- `HEAD/` - Results (2869b70b Prepare next development version.)

