### PR TITLE
Avoid duplicate contributed graph supertypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,19 @@ Changelog
 **Unreleased**
 --------------
 
+### Fixes
+
+- **[FIR]** Avoid duplicate contributed graph supertypes when merging contributions by checking against explicitly declared supertypes.
+
 ### Changes
 
 - Test Kotlin `2.3.21`.
+
+### Contributors
+
+Special thanks to the following contributors for contributing to this release!
+
+- [@vRallev](https://github.com/vRallev)
 
 1.0.0-RC3
 ---------

--- a/compiler-tests/src/test/data/box/aggregation/GraphCanExplicitlyExtendContributedInterface.kt
+++ b/compiler-tests/src/test/data/box/aggregation/GraphCanExplicitlyExtendContributedInterface.kt
@@ -1,0 +1,14 @@
+@ContributesTo(AppScope::class)
+interface ContributedAppComponent {
+  val message: String
+}
+
+@DependencyGraph(AppScope::class)
+interface AppGraph : ContributedAppComponent {
+  @Provides fun provideMessage(): String = "OK"
+}
+
+fun box(): String {
+  assertEquals("OK", createGraph<AppGraph>().message)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -175,6 +175,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("GraphCanExplicitlyExtendContributedInterface.kt")
+    public void testGraphCanExplicitlyExtendContributedInterface() {
+      runTest("compiler-tests/src/test/data/box/aggregation/GraphCanExplicitlyExtendContributedInterface.kt");
+    }
+
+    @Test
     @TestMetadata("InheritedBindingsDoNotCauseDuplicatesFromNestedContainers.kt")
     public void testInheritedBindingsDoNotCauseDuplicatesFromNestedContainers() {
       runTest("compiler-tests/src/test/data/box/aggregation/InheritedBindingsDoNotCauseDuplicatesFromNestedContainers.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -175,6 +175,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     }
 
     @Test
+    @TestMetadata("GraphCanExplicitlyExtendContributedInterface.kt")
+    public void testGraphCanExplicitlyExtendContributedInterface() {
+      runTest("compiler-tests/src/test/data/box/aggregation/GraphCanExplicitlyExtendContributedInterface.kt");
+    }
+
+    @Test
     @TestMetadata("InheritedBindingsDoNotCauseDuplicatesFromNestedContainers.kt")
     public void testInheritedBindingsDoNotCauseDuplicatesFromNestedContainers() {
       runTest("compiler-tests/src/test/data/box/aggregation/InheritedBindingsDoNotCauseDuplicatesFromNestedContainers.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -175,6 +175,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("GraphCanExplicitlyExtendContributedInterface.kt")
+    public void testGraphCanExplicitlyExtendContributedInterface() {
+      runTest("compiler-tests/src/test/data/box/aggregation/GraphCanExplicitlyExtendContributedInterface.kt");
+    }
+
+    @Test
     @TestMetadata("InheritedBindingsDoNotCauseDuplicatesFromNestedContainers.kt")
     public void testInheritedBindingsDoNotCauseDuplicatesFromNestedContainers() {
       runTest("compiler-tests/src/test/data/box/aggregation/InheritedBindingsDoNotCauseDuplicatesFromNestedContainers.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -264,7 +264,11 @@ internal class ContributedInterfaceSupertypeGenerator(
   ): List<ConeKotlinType> {
     // For generated @DependencyGraph classes (from external FIR extensions), FIR calls this
     // method instead of computeAdditionalSupertypes. Delegate to the shared implementation.
-    return computeContributionSupertypes(klass, typeResolver)
+    return computeContributionSupertypes(
+      classLikeDeclaration = klass,
+      typeResolver = typeResolver,
+      existingSupertypeClassIds = emptySet(),
+    )
   }
 
   override fun computeAdditionalSupertypes(
@@ -272,12 +276,18 @@ internal class ContributedInterfaceSupertypeGenerator(
     resolvedSupertypes: List<FirResolvedTypeRef>,
     typeResolver: TypeResolveService,
   ): List<ConeKotlinType> {
-    return computeContributionSupertypes(classLikeDeclaration, typeResolver)
+    return computeContributionSupertypes(
+      classLikeDeclaration = classLikeDeclaration,
+      typeResolver = typeResolver,
+      existingSupertypeClassIds =
+        resolvedSupertypes.mapNotNullTo(mutableSetOf()) { it.coneType.classId },
+    )
   }
 
   private fun computeContributionSupertypes(
     classLikeDeclaration: FirClassLikeDeclaration,
     typeResolver: TypeResolveService,
+    existingSupertypeClassIds: Set<ClassId>,
   ): List<ConeKotlinType> {
     val graphAnnotation = classLikeDeclaration.graphAnnotation() ?: return emptyList()
 
@@ -601,6 +611,7 @@ internal class ContributedInterfaceSupertypeGenerator(
 
         val promoteParent =
           parentSymbol.classKind.isInterface &&
+            parentClassId !in existingSupertypeClassIds &&
             !parentSymbol.isAnnotatedWithAny(
               session,
               session.classIds.graphExtensionFactoryAnnotations,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -31,6 +31,7 @@ import dev.zacsweers.metro.compiler.fir.resolvedScopeClassId
 import dev.zacsweers.metro.compiler.fir.scopeArgument
 import dev.zacsweers.metro.compiler.getAndAdd
 import dev.zacsweers.metro.compiler.ir.IrRankedBindingProcessing
+import dev.zacsweers.metro.compiler.mapNotNullToSet
 import dev.zacsweers.metro.compiler.safePathString
 import dev.zacsweers.metro.compiler.symbols.Symbols
 import java.util.TreeMap
@@ -279,8 +280,7 @@ internal class ContributedInterfaceSupertypeGenerator(
     return computeContributionSupertypes(
       classLikeDeclaration = classLikeDeclaration,
       typeResolver = typeResolver,
-      existingSupertypeClassIds =
-        resolvedSupertypes.mapNotNullTo(mutableSetOf()) { it.coneType.classId },
+      existingSupertypeClassIds = resolvedSupertypes.mapNotNullToSet { it.coneType.classId },
     )
   }
 


### PR DESCRIPTION
Metro now promotes original `@ContributesTo` interfaces as direct graph supertypes for ObjC/Swift export visibility. That broke graphs that already explicitly extend the same contributed interface, because FIR saw the promoted interface and the source-declared interface as duplicate direct supertypes.

This changes FIR supertype generation to track a graph's existing direct supertypes and skip promoting a contributed parent when it is already declared.