### PR TITLE
Add a test for generating providers in a generated dependency graph

### DIFF
--- a/compiler-tests/src/test/data/box/api/GeneratedProvidesInGraph.kt
+++ b/compiler-tests/src/test/data/box/api/GeneratedProvidesInGraph.kt
@@ -14,6 +14,7 @@ interface StringComponent {
 class Application
 
 // The extension generates a nested interface inside Application:
+//   @IROnlyFactories
 //   @DependencyGraph(AppScope::class)
 //   interface AppGraph {
 //     @Provides

--- a/compiler-tests/src/test/data/box/api/GeneratedProvidesInGraph.kt
+++ b/compiler-tests/src/test/data/box/api/GeneratedProvidesInGraph.kt
@@ -1,0 +1,29 @@
+package test
+
+// Custom annotation that triggers the test extension to generate a @DependencyGraph
+// with a provider inside the annotated class
+@Target(AnnotationTarget.CLASS)
+annotation class GenerateProvidesInGraph
+
+@ContributesTo(AppScope::class)
+interface StringComponent {
+  val text: String
+}
+
+@GenerateProvidesInGraph
+class Application
+
+// The extension generates a nested interface inside Application:
+//   @DependencyGraph(AppScope::class)
+//   interface AppGraph {
+//     @Provides
+//     fun provideString(): String {
+//       return "Hello, @GenerateProvidesInGraph!"
+//     }
+//   }
+
+fun box(): String {
+  val graph = createGraph<Application.AppGraph>()
+  assertEquals("Hello, @GenerateProvidesInGraph!", (graph as StringComponent).text)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/api/GeneratedProvidesInGraph.kt
+++ b/compiler-tests/src/test/data/box/api/GeneratedProvidesInGraph.kt
@@ -24,6 +24,6 @@ class Application
 
 fun box(): String {
   val graph = createGraph<Application.AppGraph>()
-  assertEquals("Hello, @GenerateProvidesInGraph!", (graph as StringComponent).text)
+  assertEquals("Hello, @GenerateProvidesInGraph!", graph.text)
   return "OK"
 }

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -493,6 +493,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("GeneratedProvidesInGraph.kt")
+    public void testGeneratedProvidesInGraph() {
+      runTest("compiler-tests/src/test/data/box/api/GeneratedProvidesInGraph.kt");
+    }
+
+    @Test
     @TestMetadata("MetroFirExtensionSample.kt")
     public void testMetroFirExtensionSample() {
       runTest("compiler-tests/src/test/data/box/api/MetroFirExtensionSample.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -493,6 +493,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     }
 
     @Test
+    @TestMetadata("GeneratedProvidesInGraph.kt")
+    public void testGeneratedProvidesInGraph() {
+      runTest("compiler-tests/src/test/data/box/api/GeneratedProvidesInGraph.kt");
+    }
+
+    @Test
     @TestMetadata("MetroFirExtensionSample.kt")
     public void testMetroFirExtensionSample() {
       runTest("compiler-tests/src/test/data/box/api/MetroFirExtensionSample.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -493,6 +493,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("GeneratedProvidesInGraph.kt")
+    public void testGeneratedProvidesInGraph() {
+      runTest("compiler-tests/src/test/data/box/api/GeneratedProvidesInGraph.kt");
+    }
+
+    @Test
     @TestMetadata("MetroFirExtensionSample.kt")
     public void testMetroFirExtensionSample() {
       runTest("compiler-tests/src/test/data/box/api/MetroFirExtensionSample.kt");

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroExtensionRegistrarConfigurator.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroExtensionRegistrarConfigurator.kt
@@ -10,9 +10,11 @@ import dev.zacsweers.metro.compiler.api.GenerateDependencyGraphExtension
 import dev.zacsweers.metro.compiler.api.GenerateImplContributionExtension
 import dev.zacsweers.metro.compiler.api.GenerateImplExtension
 import dev.zacsweers.metro.compiler.api.GenerateImplIrExtension
+import dev.zacsweers.metro.compiler.api.GenerateProvidersInGraphIrExtension
 import dev.zacsweers.metro.compiler.api.GenerateProvidesContributionExtension
 import dev.zacsweers.metro.compiler.api.GenerateProvidesContributionIrExtension
 import dev.zacsweers.metro.compiler.api.GenerateProvidesContributionMetroExtension
+import dev.zacsweers.metro.compiler.api.GenerateProvidesInGraphExtension
 import dev.zacsweers.metro.compiler.circuit.CircuitContributionExtension
 import dev.zacsweers.metro.compiler.circuit.CircuitFirExtension
 import dev.zacsweers.metro.compiler.circuit.CircuitIrExtension
@@ -201,6 +203,7 @@ class MetroExtensionRegistrarConfigurator(testServices: TestServices) :
               GenerateBindsContributionExtension.Factory().create(session, options, compatContext)
             )
             add(GenerateDependencyGraphExtension.Factory().create(session, options, compatContext))
+            add(GenerateProvidesInGraphExtension.Factory().create(session, options, compatContext))
             if (options.enableCircuitCodegen) {
               add(CircuitFirExtension.Factory().create(session, options, compatContext)!!)
             }
@@ -230,6 +233,7 @@ class MetroExtensionRegistrarConfigurator(testServices: TestServices) :
     }
     IrGenerationExtension.registerExtension(GenerateImplIrExtension())
     IrGenerationExtension.registerExtension(GenerateProvidesContributionIrExtension())
+    IrGenerationExtension.registerExtension(GenerateProvidersInGraphIrExtension())
     IrGenerationExtension.registerExtension(
       MetroIrGenerationExtension(
         messageCollector = configuration.messageCollector,

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/api/GenerateProvidesInGraphExtension.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/api/GenerateProvidesInGraphExtension.kt
@@ -1,0 +1,279 @@
+// Copyright (C) 2025 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.compiler.api
+
+import dev.zacsweers.metro.compiler.MetroOptions
+import dev.zacsweers.metro.compiler.api.fir.MetroFirDeclarationGenerationExtension
+import dev.zacsweers.metro.compiler.compat.CompatContext
+import org.jetbrains.kotlin.GeneratedDeclarationKey
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
+import org.jetbrains.kotlin.fir.declarations.builder.buildRegularClass
+import org.jetbrains.kotlin.fir.declarations.impl.FirResolvedDeclarationStatusImpl
+import org.jetbrains.kotlin.fir.declarations.origin
+import org.jetbrains.kotlin.fir.expressions.FirAnnotation
+import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotation
+import org.jetbrains.kotlin.fir.expressions.builder.buildAnnotationArgumentMapping
+import org.jetbrains.kotlin.fir.expressions.builder.buildArgumentList
+import org.jetbrains.kotlin.fir.expressions.builder.buildGetClassCall
+import org.jetbrains.kotlin.fir.expressions.builder.buildResolvedQualifier
+import org.jetbrains.kotlin.fir.extensions.FirDeclarationPredicateRegistrar
+import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
+import org.jetbrains.kotlin.fir.extensions.NestedClassGenerationContext
+import org.jetbrains.kotlin.fir.extensions.predicate.LookupPredicate
+import org.jetbrains.kotlin.fir.extensions.predicateBasedProvider
+import org.jetbrains.kotlin.fir.moduleData
+import org.jetbrains.kotlin.fir.plugin.createMemberFunction
+import org.jetbrains.kotlin.fir.resolve.defaultType
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
+import org.jetbrains.kotlin.fir.scopes.kotlinScopeProvider
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassLikeSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
+import org.jetbrains.kotlin.fir.toEffectiveVisibility
+import org.jetbrains.kotlin.fir.types.ConeKotlinType
+import org.jetbrains.kotlin.fir.types.FirResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.builder.buildResolvedTypeRef
+import org.jetbrains.kotlin.fir.types.impl.ConeClassLikeTypeImpl
+import org.jetbrains.kotlin.fir.types.toLookupTag
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.ir.visitors.transformChildrenVoid
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.StandardClassIds
+
+private val DEPENDENCY_GRAPH_CLASS_ID =
+  ClassId(FqName("dev.zacsweers.metro"), Name.identifier("DependencyGraph"))
+private val PROVIDES_CLASS_ID = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("Provides"))
+
+private val APP_GRAPH_NAME = Name.identifier("AppGraph")
+private val PROVIDER_NAME = Name.identifier("provideString")
+
+/**
+ * Test extension that generates a `@DependencyGraph(AppScope::class)` interface with a string
+ * provider for classes annotated with `@GenerateProvidesInGraph`.
+ *
+ * For a class like:
+ * ```
+ * @GenerateProvidesInGraph
+ * class Application
+ * ```
+ *
+ * This generates a nested interface:
+ * ```
+ * class Application {
+ *   @DependencyGraph(AppScope::class)
+ *   interface AppGraph {
+ *     @Provides
+ *     fun provideString(): String {
+ *       return "Hello, @GenerateProvidesInGraph!"
+ *     }
+ *   }
+ * }
+ * ```
+ */
+internal class GenerateProvidesInGraphExtension(session: FirSession) :
+  MetroFirDeclarationGenerationExtension(session) {
+
+  companion object {
+    val ANNOTATION_FQ_NAME = FqName("test.GenerateProvidesInGraph")
+  }
+
+  object Key : GeneratedDeclarationKey()
+
+  private val predicate = LookupPredicate.BuilderContext.annotated(ANNOTATION_FQ_NAME)
+
+  private val annotatedClasses by lazy {
+    session.predicateBasedProvider
+      .getSymbolsByPredicate(predicate)
+      .filterIsInstance<FirRegularClassSymbol>()
+      .toList()
+  }
+
+  /** ClassIds of AppGraph interfaces we generate (nested inside annotated classes). */
+  private val generatedGraphClassIds by lazy {
+    annotatedClasses.map { it.classId.createNestedClassId(APP_GRAPH_NAME) }.toSet()
+  }
+
+  override fun FirDeclarationPredicateRegistrar.registerPredicates() {
+    register(predicate)
+  }
+
+  override fun getNestedClassifiersNames(
+    classSymbol: FirClassSymbol<*>,
+    context: NestedClassGenerationContext,
+  ): Set<Name> {
+    return if (classSymbol in annotatedClasses) {
+      setOf(APP_GRAPH_NAME)
+    } else {
+      emptySet()
+    }
+  }
+
+  override fun generateNestedClassLikeDeclaration(
+    owner: FirClassSymbol<*>,
+    name: Name,
+    context: NestedClassGenerationContext,
+  ): FirClassLikeSymbol<*>? {
+    return when (name) {
+      APP_GRAPH_NAME -> generateAppGraph(owner, name)
+      else -> null
+    }
+  }
+
+  private fun generateAppGraph(owner: FirClassSymbol<*>, name: Name): FirClassLikeSymbol<*>? {
+    if (owner !in annotatedClasses) return null
+
+    val nestedClassId = owner.classId.createNestedClassId(name)
+    val classSymbol = FirRegularClassSymbol(nestedClassId)
+
+    buildRegularClass {
+      resolvePhase = FirResolvePhase.BODY_RESOLVE
+      moduleData = session.moduleData
+      origin = Key.origin
+      source = owner.source
+      classKind = ClassKind.INTERFACE
+      scopeProvider = session.kotlinScopeProvider
+      this.name = nestedClassId.shortClassName
+      symbol = classSymbol
+      status =
+        FirResolvedDeclarationStatusImpl(
+          Visibilities.Public,
+          Modality.ABSTRACT,
+          Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
+        )
+      superTypeRefs += session.builtinTypes.anyType
+      annotations += buildDependencyGraphAnnotation(APP_SCOPE_CLASS_ID)
+    }
+
+    return classSymbol
+  }
+
+  override fun getCallableNamesForClass(
+    classSymbol: FirClassSymbol<*>,
+    context: MemberGenerationContext,
+  ): Set<Name> {
+    if (classSymbol.classId in generatedGraphClassIds) return setOf(PROVIDER_NAME)
+    return emptySet()
+  }
+
+  override fun generateFunctions(
+    callableId: CallableId,
+    context: MemberGenerationContext?,
+  ): List<FirNamedFunctionSymbol> {
+    if (context == null) return emptyList()
+    val owner = context.owner
+    if (owner.classId !in generatedGraphClassIds) return emptyList()
+    if (callableId.callableName != PROVIDER_NAME) return emptyList()
+
+    // String type for the @Provides return type
+    val stringSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(StandardClassIds.String)
+        as FirRegularClassSymbol
+    val stringType = stringSymbol.defaultType()
+
+    // @Provides fun provideString(): String
+    val provideStringFunction = createMemberFunction(owner, Key, PROVIDER_NAME, stringType)
+    provideStringFunction.replaceAnnotations(listOf(buildProvidesAnnotation()))
+
+    return listOf(provideStringFunction.symbol)
+  }
+
+  // -- Annotation builders --
+
+  private fun buildDependencyGraphAnnotation(scopeClassId: ClassId): FirAnnotation {
+    val annotationClassSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(DEPENDENCY_GRAPH_CLASS_ID)
+        as FirRegularClassSymbol
+    val scopeSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(scopeClassId) as FirRegularClassSymbol
+    val scopeType = scopeSymbol.defaultType()
+
+    return buildAnnotation {
+      annotationTypeRef = annotationClassSymbol.defaultType().toFirResolvedTypeRef()
+      argumentMapping = buildAnnotationArgumentMapping {
+        mapping[Name.identifier("scope")] = buildGetClassCall {
+          argumentList = buildArgumentList {
+            arguments += buildResolvedQualifier {
+              packageFqName = scopeClassId.packageFqName
+              relativeClassFqName = scopeClassId.relativeClassName
+              symbol = scopeSymbol
+              resolvedToCompanionObject = false
+              isFullyQualified = true
+              coneTypeOrNull = scopeType
+            }
+          }
+          coneTypeOrNull =
+            ConeClassLikeTypeImpl(
+              StandardClassIds.KClass.toLookupTag(),
+              arrayOf(scopeType),
+              isMarkedNullable = false,
+            )
+        }
+      }
+    }
+  }
+
+  private fun buildProvidesAnnotation(): FirAnnotation {
+    val annotationClassSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(PROVIDES_CLASS_ID) as FirRegularClassSymbol
+    return buildAnnotation {
+      annotationTypeRef = annotationClassSymbol.defaultType().toFirResolvedTypeRef()
+      argumentMapping = buildAnnotationArgumentMapping()
+    }
+  }
+
+  private fun ConeKotlinType.toFirResolvedTypeRef(): FirResolvedTypeRef {
+    return buildResolvedTypeRef { coneType = this@toFirResolvedTypeRef }
+  }
+
+  class Factory : MetroFirDeclarationGenerationExtension.Factory {
+    override fun create(
+      session: FirSession,
+      options: MetroOptions,
+      compatContext: CompatContext,
+    ): MetroFirDeclarationGenerationExtension = GenerateProvidesInGraphExtension(session)
+  }
+}
+
+/**
+ * IR extension that fills in the `@Provides` function body with `return
+ * "Hello, @GenerateProvidesInGraph!"`.
+ */
+class GenerateProvidersInGraphIrExtension : IrGenerationExtension {
+  companion object {
+    val ORIGIN = IrDeclarationOrigin.GeneratedByPlugin(GenerateProvidesInGraphExtension.Key)
+  }
+
+  override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+    moduleFragment.transformChildrenVoid(
+      object : IrElementTransformerVoid() {
+        override fun visitSimpleFunction(declaration: IrSimpleFunction): IrStatement {
+          if (declaration.origin == ORIGIN) {
+            declaration.body =
+              DeclarationIrBuilder(pluginContext, declaration.symbol).irBlockBody {
+                +irReturn(irString("Hello, @GenerateProvidesInGraph!"))
+              }
+          }
+          return super.visitSimpleFunction(declaration)
+        }
+      }
+    )
+  }
+}

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/api/GenerateProvidesInGraphExtension.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/api/GenerateProvidesInGraphExtension.kt
@@ -61,6 +61,8 @@ import org.jetbrains.kotlin.name.StandardClassIds
 private val DEPENDENCY_GRAPH_CLASS_ID =
   ClassId(FqName("dev.zacsweers.metro"), Name.identifier("DependencyGraph"))
 private val PROVIDES_CLASS_ID = ClassId(FqName("dev.zacsweers.metro"), Name.identifier("Provides"))
+private val IR_ONLY_FACTORIES_CLASS_ID =
+  ClassId(FqName("dev.zacsweers.metro.internal"), Name.identifier("IROnlyFactories"))
 
 private val APP_GRAPH_NAME = Name.identifier("AppGraph")
 private val PROVIDER_NAME = Name.identifier("provideString")
@@ -78,6 +80,7 @@ private val PROVIDER_NAME = Name.identifier("provideString")
  * This generates a nested interface:
  * ```
  * class Application {
+ *   @IROnlyFactories
  *   @DependencyGraph(AppScope::class)
  *   interface AppGraph {
  *     @Provides
@@ -159,6 +162,7 @@ internal class GenerateProvidesInGraphExtension(session: FirSession) :
           Visibilities.Public.toEffectiveVisibility(owner, forClass = true),
         )
       superTypeRefs += session.builtinTypes.anyType
+      annotations += buildIROnlyFactoriesAnnotation()
       annotations += buildDependencyGraphAnnotation(APP_SCOPE_CLASS_ID)
     }
 
@@ -196,6 +200,16 @@ internal class GenerateProvidesInGraphExtension(session: FirSession) :
   }
 
   // -- Annotation builders --
+
+  private fun buildIROnlyFactoriesAnnotation(): FirAnnotation {
+    val annotationClassSymbol =
+      session.symbolProvider.getClassLikeSymbolByClassId(IR_ONLY_FACTORIES_CLASS_ID)
+        as FirRegularClassSymbol
+    return buildAnnotation {
+      annotationTypeRef = annotationClassSymbol.defaultType().toFirResolvedTypeRef()
+      argumentMapping = buildAnnotationArgumentMapping()
+    }
+  }
 
   private fun buildDependencyGraphAnnotation(scopeClassId: ClassId): FirAnnotation {
     val annotationClassSymbol =

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindingContainerTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindingContainerTransformer.kt
@@ -84,7 +84,6 @@ import org.jetbrains.kotlin.ir.builders.irGetField
 import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
-import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrField
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrOverridableDeclaration
@@ -116,6 +115,7 @@ import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.nestedClasses
 import org.jetbrains.kotlin.ir.util.packageFqName
 import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.util.propertyIfAccessor
 import org.jetbrains.kotlin.name.CallableId
@@ -322,9 +322,6 @@ internal class BindingContainerTransformer(context: IrMetroContext, traceScope: 
 
     val generatedClassId = reference.generatedClassId
 
-    // For in-compilation, we already have the real declaration from the reference
-    val realDeclaration = reference.callee?.owner ?: reference.backingField
-
     val factoryCls =
       trace("Find factory class") {
         reference.parent.owner.nestedClasses.singleOrNull {
@@ -332,14 +329,10 @@ internal class BindingContainerTransformer(context: IrMetroContext, traceScope: 
             it.classIdOrFail == generatedClassId
         }
           ?: run {
-            // For @IROnlyFactories-annotated containers and generated declarations, factory classes
-            // are not generated in FIR. Create the factory class entirely in IR.
+            // For @IROnlyFactories-annotated containers, factory classes are not generated in FIR.
+            // Create the factory class entirely in IR.
             val parentClass = reference.parent.owner
-            val isGeneratedDeclaration =
-              realDeclaration?.origin is IrDeclarationOrigin.GeneratedByPlugin
-            if (
-              parentClass.hasAnnotation(Symbols.ClassIds.irOnlyFactories) || isGeneratedDeclaration
-            ) {
+            if (parentClass.hasAnnotation(Symbols.ClassIds.irOnlyFactories)) {
               createContributionProviderFactory(parentClass, generatedClassId, reference)
             } else {
               reportCompilerBug(
@@ -409,15 +402,20 @@ internal class BindingContainerTransformer(context: IrMetroContext, traceScope: 
       // If it's got no parameters we'll generate it in FIR as an object
       ctor = factoryCls.primaryConstructor!!
     } else {
-      // For @IROnlyFactories containers and generated declarations, the factory stub already has a
-      // no-arg primary constructor shell. Reuse it. For FIR-generated factories, add a new
-      // constructor.
+      // For @IROnlyFactories containers, the factory stub already has a no-arg primary
+      // constructor shell. Reuse it. For FIR-generated factories, add a new constructor.
+      val isIROnlyFactory =
+        factoryCls.parentClassOrNull?.hasAnnotation(Symbols.ClassIds.irOnlyFactories) == true
+
       ctor =
-        factoryCls.primaryConstructor
-          ?: factoryCls.addConstructor {
+        if (isIROnlyFactory) {
+          factoryCls.primaryConstructor!!
+        } else {
+          factoryCls.addConstructor {
             visibility = DescriptorVisibilities.PRIVATE
             isPrimary = true
           }
+        }
 
       trace("Build factory constructor") {
         ctor.apply {
@@ -494,6 +492,9 @@ internal class BindingContainerTransformer(context: IrMetroContext, traceScope: 
           factoryCls.irCallableMetadata(mirrorFunction, reference.annotations, isInterop = false)
         }
       }
+
+    // For in-compilation, we already have the real declaration from the reference
+    val realDeclaration = reference.callee?.owner ?: reference.backingField
 
     val providerFactory =
       trace("Construct ProviderFactory") {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindingContainerTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindingContainerTransformer.kt
@@ -84,6 +84,7 @@ import org.jetbrains.kotlin.ir.builders.irGetField
 import org.jetbrains.kotlin.ir.builders.irGetObject
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrField
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrOverridableDeclaration
@@ -115,7 +116,6 @@ import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.nestedClasses
 import org.jetbrains.kotlin.ir.util.packageFqName
 import org.jetbrains.kotlin.ir.util.parentAsClass
-import org.jetbrains.kotlin.ir.util.parentClassOrNull
 import org.jetbrains.kotlin.ir.util.primaryConstructor
 import org.jetbrains.kotlin.ir.util.propertyIfAccessor
 import org.jetbrains.kotlin.name.CallableId
@@ -322,6 +322,9 @@ internal class BindingContainerTransformer(context: IrMetroContext, traceScope: 
 
     val generatedClassId = reference.generatedClassId
 
+    // For in-compilation, we already have the real declaration from the reference
+    val realDeclaration = reference.callee?.owner ?: reference.backingField
+
     val factoryCls =
       trace("Find factory class") {
         reference.parent.owner.nestedClasses.singleOrNull {
@@ -329,10 +332,14 @@ internal class BindingContainerTransformer(context: IrMetroContext, traceScope: 
             it.classIdOrFail == generatedClassId
         }
           ?: run {
-            // For @IROnlyFactories-annotated containers, factory classes are not generated in FIR.
-            // Create the factory class entirely in IR.
+            // For @IROnlyFactories-annotated containers and generated declarations, factory classes
+            // are not generated in FIR. Create the factory class entirely in IR.
             val parentClass = reference.parent.owner
-            if (parentClass.hasAnnotation(Symbols.ClassIds.irOnlyFactories)) {
+            val isGeneratedDeclaration =
+              realDeclaration?.origin is IrDeclarationOrigin.GeneratedByPlugin
+            if (
+              parentClass.hasAnnotation(Symbols.ClassIds.irOnlyFactories) || isGeneratedDeclaration
+            ) {
               createContributionProviderFactory(parentClass, generatedClassId, reference)
             } else {
               reportCompilerBug(
@@ -402,20 +409,15 @@ internal class BindingContainerTransformer(context: IrMetroContext, traceScope: 
       // If it's got no parameters we'll generate it in FIR as an object
       ctor = factoryCls.primaryConstructor!!
     } else {
-      // For @IROnlyFactories containers, the factory stub already has a no-arg primary
-      // constructor shell. Reuse it. For FIR-generated factories, add a new constructor.
-      val isIROnlyFactory =
-        factoryCls.parentClassOrNull?.hasAnnotation(Symbols.ClassIds.irOnlyFactories) == true
-
+      // For @IROnlyFactories containers and generated declarations, the factory stub already has a
+      // no-arg primary constructor shell. Reuse it. For FIR-generated factories, add a new
+      // constructor.
       ctor =
-        if (isIROnlyFactory) {
-          factoryCls.primaryConstructor!!
-        } else {
-          factoryCls.addConstructor {
+        factoryCls.primaryConstructor
+          ?: factoryCls.addConstructor {
             visibility = DescriptorVisibilities.PRIVATE
             isPrimary = true
           }
-        }
 
       trace("Build factory constructor") {
         ctor.apply {
@@ -492,9 +494,6 @@ internal class BindingContainerTransformer(context: IrMetroContext, traceScope: 
           factoryCls.irCallableMetadata(mirrorFunction, reference.annotations, isInterop = false)
         }
       }
-
-    // For in-compilation, we already have the real declaration from the reference
-    val realDeclaration = reference.callee?.owner ?: reference.backingField
 
     val providerFactory =
       trace("Construct ProviderFactory") {


### PR DESCRIPTION
This PR adds a compiler test for generating providers in a generated dependency graph. 
~This PR supports FIR-generated providers to be processed in a generated dependency graph.~

Previously, when you added a provider in a generated graph:
```kotlin
@DependencyGraph
interface FeatureGraph {
  @Provides
  fun provideParam(): String = "foo"
}
```
the compilation would fail with this error:
```
No expected factory class generated for /MyActivity.FeatureGraph.provideParam. Report this bug with a repro case at https://github.com/zacsweers/metro/issues/new. This is possibly a bug in the Metro compiler, please report it with details and/or a reproducer to https://github.com/zacsweers/metro.
org.jetbrains.kotlin.fir.pipeline.IrGenerationExtensionException: No expected factory class generated for /MyActivity.FeatureGraph.provideParam. Report this bug with a repro case at https://github.com/zacsweers/metro/issues/new. This is possibly a bug in the Metro compiler, please report it with details and/or a reproducer to https://github.com/zacsweers/metro.
```
**Edit**: Annotated the dependency graph with `@IROnlyFactories` resolves the issue.

~and this is because when a `@Provides` function is generated by a FIR extension, it's generated at a phase after Metro's `ProvidesFactoryFirGenerator` has already looked at the `classSymbol.declarationSymbols` (is this expected?!) to find provider functions and generate corresponding factory classes.~

~Generating the factory in IR phase (`BindingContainerTransformer`) resolves the issue.~