### PR TITLE
Allow MetroFirDeclarationGenerationExtension.enableFirInIde to be overridden

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/api/fir/MetroFirDeclarationGenerationExtension.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/api/fir/MetroFirDeclarationGenerationExtension.kt
@@ -70,7 +70,7 @@ public abstract class MetroFirDeclarationGenerationExtension(session: FirSession
   FirDeclarationGenerationExtension(session) {
 
   /** Enable only if this extension generates code in FIR that should be visible in the IDE. */
-  public val enableFirInIde: Boolean
+  public open val enableFirInIde: Boolean
     get() = false
 
   /**


### PR DESCRIPTION
Realized that `enableFirInIde` is not opened, but I'm not sure if it's not ready to be used yet, or it was a mistake. Be free to close it if it's irrelevant. 🙇 