### PR TITLE
Fix member injection `Invalid type arg` error when class has more generic type parameters than its parent

### DIFF
--- a/compiler-tests/src/test/data/box/inject/member/GenericMemberInjectionWithFewerParentTypeParameters.kt
+++ b/compiler-tests/src/test/data/box/inject/member/GenericMemberInjectionWithFewerParentTypeParameters.kt
@@ -1,0 +1,53 @@
+@HasMemberInjections
+abstract class GrandParent {
+    @Inject lateinit var grandParentString: String
+}
+
+@HasMemberInjections
+abstract class Parent<T : Any> : GrandParent() {
+    @Inject lateinit var parentT: T
+}
+
+@Inject
+class ExampleClass<T : Any, R : Any> : Parent<R>() {
+  @Inject lateinit var value: T
+  @Inject lateinit var values: List<T>
+  @Inject lateinit var mapValues: Map<T, List<T>>
+
+  // Setter mid-properties to ensure ordering doesn't matter
+  lateinit var functionSet: T
+
+  @Inject
+  fun functionMemberInject(value: T) {
+    functionSet = value
+  }
+
+  lateinit var setterSet: T
+    @Inject set
+}
+
+@DependencyGraph
+interface AppGraph {
+  val exampleClass: ExampleClass<Int, String>
+
+  @Provides fun provideString(): String = "Hello, world!"
+
+  @Provides fun provideInt(): Int = 3
+
+  @Provides fun provideInts(): List<Int> = listOf(3)
+
+  @Provides fun provideIntMap(int: Int, ints: List<Int>): Map<Int, List<Int>> = mapOf(3 to ints)
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  val exampleClass = graph.exampleClass
+  assertEquals(3, exampleClass.value)
+  assertEquals(3, exampleClass.setterSet)
+  assertEquals(listOf(3), exampleClass.values)
+  assertEquals(mapOf(3 to listOf(3)), exampleClass.mapValues)
+  assertEquals("Hello, world!", exampleClass.parentT)
+  assertEquals("Hello, world!", exampleClass.grandParentString)
+  assertEquals(3, exampleClass.functionSet)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -2120,6 +2120,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("GenericMemberInjectionWithFewerParentTypeParameters.kt")
+      public void testGenericMemberInjectionWithFewerParentTypeParameters() {
+        runTest("compiler-tests/src/test/data/box/inject/member/GenericMemberInjectionWithFewerParentTypeParameters.kt");
+      }
+
+      @Test
       @TestMetadata("GenericMemberInjectionWithWildcard.kt")
       public void testGenericMemberInjectionWithWildcard() {
         runTest("compiler-tests/src/test/data/box/inject/member/GenericMemberInjectionWithWildcard.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -2120,6 +2120,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
       }
 
       @Test
+      @TestMetadata("GenericMemberInjectionWithFewerParentTypeParameters.kt")
+      public void testGenericMemberInjectionWithFewerParentTypeParameters() {
+        runTest("compiler-tests/src/test/data/box/inject/member/GenericMemberInjectionWithFewerParentTypeParameters.kt");
+      }
+
+      @Test
       @TestMetadata("GenericMemberInjectionWithWildcard.kt")
       public void testGenericMemberInjectionWithWildcard() {
         runTest("compiler-tests/src/test/data/box/inject/member/GenericMemberInjectionWithWildcard.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -2120,6 +2120,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("GenericMemberInjectionWithFewerParentTypeParameters.kt")
+      public void testGenericMemberInjectionWithFewerParentTypeParameters() {
+        runTest("compiler-tests/src/test/data/box/inject/member/GenericMemberInjectionWithFewerParentTypeParameters.kt");
+      }
+
+      @Test
       @TestMetadata("GenericMemberInjectionWithWildcard.kt")
       public void testGenericMemberInjectionWithWildcard() {
         runTest("compiler-tests/src/test/data/box/inject/member/GenericMemberInjectionWithWildcard.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/MembersInjectorTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/MembersInjectorTransformer.kt
@@ -67,7 +67,6 @@ import org.jetbrains.kotlin.ir.declarations.IrField
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrExpression
-import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classOrNull
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.isUnit
@@ -393,11 +392,9 @@ internal class MembersInjectorTransformer(context: IrMetroContext, traceScope: T
     trace("Override injectMembers()") {
       injectorClass.requireSimpleFunction(Symbols.StringNames.INJECT_MEMBERS).owner.apply {
         finalizeFakeOverride(injectorClass.thisReceiverOrFail)
-        val typeArgs = declaration.typeParameters.map { it.defaultType }
         body =
           pluginContext.createIrBuilder(symbol).irBlockBody {
             addMemberInjection(
-              typeArgs = typeArgs,
               callingFunction = this@apply,
               instanceReceiver = regularParameters[0],
               injectorReceiver = dispatchReceiverParameter!!,
@@ -750,7 +747,6 @@ internal class MembersInjectorTransformer(context: IrMetroContext, traceScope: T
 
 context(context: IrMetroContext)
 internal fun IrBlockBodyBuilder.addMemberInjection(
-  typeArgs: List<IrType>?,
   callingFunction: IrSimpleFunction,
   injectFunctions: Map<IrSimpleFunction, Parameters>,
   parametersToFields: Map<Parameter, IrField>,
@@ -761,7 +757,7 @@ internal fun IrBlockBodyBuilder.addMemberInjection(
     trackFunctionCall(callingFunction, function)
     +irInvoke(
       callee = function.symbol,
-      typeArgs = typeArgs,
+      typeArgs = function.typeParameters.map { it.defaultType },
       args =
         buildList {
           add(irGet(instanceReceiver))


### PR DESCRIPTION
<!--
  STOP AND READ!

  Couple small asks to help with review 🥺
  - Please write a description (however long or short as necessary.)
  - If you are showing me AI-generated output (code or otherwise), please be upfront about it, indicate what parts, and de-fluff _before_ opening the PR.
-->

Right now, the build fails when a class has more generic type parameters than its parent and both have member injections (this includes a non-generic parent):

```kotlin
@HasMemberInjections
abstract class Parent<T> {
    @Inject lateinit var foo: String
}

@Inject
class Child<T, R> : Parent<T>() {
    @Inject lateinit var bar: List<Int>
}
```

The reason for this is that, in this example, `Child`'s type paremeters are being passed in to `irInvoke` and are then compared with the type parameters on `Parent`'s inject function:

```kotlin
internal fun IrBuilderWithScope.irInvoke(
  typeArgs: List<IrType>? = null,
  // ...
) {
  // ...
  typeArgs?.let { // `typeArgs` is the Child's types
    for ((i, typeArg) in typeArgs.withIndex()) {
      if (i >= call.typeArguments.size) { // `call` uses the Parent's types
        reportCompilerBug(
          "Invalid type arg $typeArg at index $i for callee ${callee.owner.dumpKotlinLike()}"
        )
      }
      call.typeArguments[i] = typeArg
    }
  }
}
```

Since `Child` has more type parameters than `Parent`, the comparison fails and we get an error:

```
Invalid type arg org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeOnlyClassifierImpl@a2ddaad8 at index 1 for callee @JvmStatic
@JsStatic
fun <T : Any?> injectFoo(@Assisted instance: Parent<T>, foo: String) {
  return instance.#foo = foo
}

. This is possibly a bug in the Metro compiler, please report it with details and/or a reproducer to https://github.com/zacsweers/metro. 
org.jetbrains.kotlin.fir.pipeline.IrGenerationExtensionException: Invalid type arg org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeOnlyClassifierImpl@a2ddaad8 at index 1 for callee @JvmStatic
@JsStatic
fun <T : Any?> injectFoo(@Assisted instance: Parent<T>, foo: String) {
  return instance.#foo = foo
}
```

The fix for this is to pass in the types of the function rather than the child class. I tried this out locally in my use case and it seems to work fine.


