### PR TITLE
Fix Markdown links in `injection-types.md`

### DIFF
--- a/docs/injection-types.md
+++ b/docs/injection-types.md
@@ -91,7 +91,7 @@ If a nested class called `Factory` is already present, Metro will do nothing.
 
 ### Why opt-in?
 
-The main reason this is behind an opt-in option at the moment is because compiler plugin IDE support requires some rudimentary configuration to work. See [the docs for how to enable IDE support](installation.md/#ide-support).
+The main reason this is behind an opt-in option at the moment is because compiler plugin IDE support requires some rudimentary configuration to work. See [the docs for how to enable IDE support](installation.md#ide-support).
 
 Because of this, it's likely better for now to just hand-write the equivalent class that Metro generates. If you still wish to proceed with using this, it can be enabled via the Gradle DSL.
 
@@ -333,7 +333,7 @@ There are three reasons this is behind an opt-in option at the moment.
 2. Generating top-level declarations in Kotlin compiler plugins (in FIR specifically) is not
    currently compatible with non-JVM targets.
 3. IDE support is rudimentary at best and currently requires enabling a custom registry flag.
-   See [the docs for how to enable IDE support](installation.md/#ide-support).
+   See [the docs for how to enable IDE support](installation.md#ide-support).
 
 Because of this, it's likely better for now to just hand-write the equivalent class that Metro generates. If you still wish to proceed with using this, it can be enabled via the Gradle DSL.
 


### PR DESCRIPTION
`installation.md/#ide-support` results in `https://zacsweers.github.io/metro/[version]/installation.md/#ide-support` instead `https://zacsweers.github.io/metro/[version]/installation/#ide-support`, which defaults to the homepage

You can see the behavior here: https://zacsweers.github.io/metro/latest/injection-types/?h=enable+IDE+support#why-opt-in