### PR TITLE
minor: update dokka generate command for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Generally you should run with `--quiet` to reduce noise. Failures would be repor
 
 ### Documentation
 
-- `./gradlew dokkaHtml` - Generate API documentation
+- `./gradlew dokkaGenerateHtml` - Generate API documentation
 - `docs/` - Contains all Markdown documentation
 
 ### Benchmarks


### PR DESCRIPTION
I was playing with some dokka configuration and found this command to be deprecated and failed with following

```
Execution failed for task ':metrox-android:dokkaHtml' (registered by plugin 'org.jetbrains.dokka').
> Cannot run Dokka V1 tasks when V2 mode is enabled.
  Dokka Gradle plugin V1 mode is deprecated, and scheduled to be removed in Dokka v2.2.0.
```

Now that we are using Dokka 2, this task works `./gradlew dokkaGenerateHtml`

<!--
  STOP AND READ!

  Couple small asks to help with review 🥺
  - Please write a description (however long or short as necessary.)
  - If you are showing me AI-generated output (code or otherwise), please be upfront about it, indicate what parts, and de-fluff _before_ opening the PR.
-->
