### PR TITLE
Fix supertype merging not handling replaces from containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ Changelog
 
 ### New
 
-- Add support for generating metadata-visible classes entirely in IR, allowing Metro to move much of its current FIR code gen entirely to IR. This is enabled by default on Kotlin `2.4.20-dev-6138` or newer and can be configured via the `generateClassesInIr` option.
+- **[IR]** Add support for generating metadata-visible classes entirely in IR, allowing Metro to move much of its current FIR code gen entirely to IR. This is enabled by default on Kotlin `2.4.20-dev-6138` or newer and can be configured via the `generateClassesInIr` option.
+
+### Fixes
+
+- **[FIR]** Fix supertype merging not accounting for `replaces` coming from binding container contributions.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Changelog
 - Test Kotlin `2.4.20-dev-6138`.
 - Test IntelliJ `2026.2` EAPs.
 
+### Contributors
+
+Special thanks to the following contributors for contributing to this release!
+
+- [@hossain-khan](https://github.com/hossain-khan)
+- [@kevinguitar](https://github.com/kevinguitar)
+
 1.2.0
 -----
 

--- a/compiler-tests/src/test/data/box/aggregation/BindingReplacesProvider.kt
+++ b/compiler-tests/src/test/data/box/aggregation/BindingReplacesProvider.kt
@@ -1,0 +1,28 @@
+interface Base {
+  val value: String
+}
+
+@ContributesTo(AppScope::class)
+interface RealProvider {
+  @Provides
+  fun provideReal(): Base = object : Base {
+    override val value: String = "Real"
+  }
+}
+
+@Inject
+@ContributesBinding(AppScope::class, replaces = [RealProvider::class])
+class Fake: Base {
+  override val value: String = "Fake"
+}
+
+@DependencyGraph(AppScope::class)
+interface AppGraph {
+  val base: Base
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertEquals("Fake", graph.base.value)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/aggregation/BindingReplacesProvider.kt
+++ b/compiler-tests/src/test/data/box/aggregation/BindingReplacesProvider.kt
@@ -1,3 +1,5 @@
+// Regression test for https://github.com/ZacSweers/metro/pull/2434
+
 interface Base {
   val value: String
 }

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -51,6 +51,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("BindingReplacesProvider.kt")
+    public void testBindingReplacesProvider() {
+      run("BindingReplacesProvider.kt");
+    }
+
+    @Test
     @TestMetadata("ChunkMergedSupertypesBasic.kt")
     public void testChunkMergedSupertypesBasic() {
       run("ChunkMergedSupertypesBasic.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -51,6 +51,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     }
 
     @Test
+    @TestMetadata("BindingReplacesProvider.kt")
+    public void testBindingReplacesProvider() {
+      run("BindingReplacesProvider.kt");
+    }
+
+    @Test
     @TestMetadata("ChunkMergedSupertypesBasic.kt")
     public void testChunkMergedSupertypesBasic() {
       run("ChunkMergedSupertypesBasic.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -51,6 +51,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("BindingReplacesProvider.kt")
+    public void testBindingReplacesProvider() {
+      run("BindingReplacesProvider.kt");
+    }
+
+    @Test
     @TestMetadata("ChunkMergedSupertypesBasic.kt")
     public void testChunkMergedSupertypesBasic() {
       run("ChunkMergedSupertypesBasic.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
@@ -51,6 +51,12 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
     }
 
     @Test
+    @TestMetadata("BindingReplacesProvider.kt")
+    public void testBindingReplacesProvider() {
+      run("BindingReplacesProvider.kt");
+    }
+
+    @Test
     @TestMetadata("ChunkMergedSupertypesBasic.kt")
     public void testChunkMergedSupertypesBasic() {
       run("ChunkMergedSupertypesBasic.kt");
@@ -3108,6 +3114,18 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
     @TestMetadata("InlineProvidesBytecodeCheck.kt")
     public void testInlineProvidesBytecodeCheck() {
       run("InlineProvidesBytecodeCheck.kt");
+    }
+
+    @Test
+    @TestMetadata("InlinedProviderValueNotOnConsumerClasspath.kt")
+    public void testInlinedProviderValueNotOnConsumerClasspath() {
+      run("InlinedProviderValueNotOnConsumerClasspath.kt");
+    }
+
+    @Test
+    @TestMetadata("InlinedProvidersWithNonPublicValues.kt")
+    public void testInlinedProvidersWithNonPublicValues() {
+      run("InlinedProvidersWithNonPublicValues.kt");
     }
 
     @Test

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -238,18 +238,6 @@ internal class ContributedInterfaceSupertypeGenerator(
           continue
         }
 
-        if (
-          session.metroFirBuiltIns.options.bindingContributionsAsContainers &&
-            originClass.hasBindingContribution() &&
-            !originClass.hasDirectContributesTo()
-        ) {
-          // Pure binding contributions are consumed as binding containers, not graph supertypes.
-          // Do not depend on FIR-generated nested marker classes for this path. Non-Metro
-          // extension contributions, such as Hilt entry points, do not carry binding-contribution
-          // annotations and still use their generated markers in legacy FIR mode.
-          continue
-        }
-
         val classDeclarationContainer =
           originClass.declaredMemberScope(session, memberRequiredPhase = null)
 
@@ -266,21 +254,15 @@ internal class ContributedInterfaceSupertypeGenerator(
               ?.annotationsIn(session, setOf(Symbols.ClassIds.metroContribution))
               ?.single()
               ?.resolvedScopeClassId(session, typeResolver)
+
           if (scopeId == scopeClassId) {
-            put(originClass.classId.createNestedClassId(nestedClassName), false)
+            val nestedClassSymbol = nestedClass.expectAsOrNull<FirClassLikeSymbol<*>>()
+            val isBindingContainer = nestedClassSymbol?.isBindingContainer(session) == true
+            put(originClass.classId.createNestedClassId(nestedClassName), isBindingContainer)
           }
         }
       }
     }
-  }
-
-  private fun FirRegularClassSymbol.hasDirectContributesTo(): Boolean {
-    return annotationsIn(session, session.classIds.contributesToAnnotations).any()
-  }
-
-  private fun FirRegularClassSymbol.hasBindingContribution(): Boolean {
-    return annotationsIn(session, session.classIds.contributesBindingLikeAnnotationsWithContainers)
-      .any()
   }
 
   private fun FirRegularClassSymbol.directlyContributesTo(

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/generators/ContributedInterfaceSupertypeGenerator.kt
@@ -229,11 +229,14 @@ internal class ContributedInterfaceSupertypeGenerator(
         val generateClassesInIr = session.metroFirBuiltIns.options.generateClassesInIr
         if (generateClassesInIr) {
           // In IR-only mode MetroContribution marker classes are not generated in FIR. Keep only
-          // source interfaces that directly contribute a user-visible supertype; IR generates the
-          // hidden marker classes and binding containers later.
+          // source interfaces that directly contribute a user-visible supertype. Binding-like
+          // contributions are still tracked for replacement/rank logic, but filtered out when
+          // building supertypes.
           val contributesDirectly = originClass.directlyContributesTo(scopeClassId, typeResolver)
           if (contributesDirectly) {
             put(originClass.classId, false)
+          } else if (originClass.bindingLikeContributionMatchesScope(scopeClassId, typeResolver)) {
+            put(originClass.classId, true)
           }
           continue
         }
@@ -273,6 +276,14 @@ internal class ContributedInterfaceSupertypeGenerator(
       annotationsIn(session, session.classIds.contributesToAnnotations).any {
         it.resolvedScopeClassId(session, typeResolver) == scopeClassId
       }
+  }
+
+  private fun FirRegularClassSymbol.bindingLikeContributionMatchesScope(
+    scopeClassId: ClassId,
+    typeResolver: TypeResolveService,
+  ): Boolean {
+    return annotationsIn(session, session.classIds.contributesBindingLikeAnnotationsWithContainers)
+      .any { it.resolvedScopeClassId(session, typeResolver) == scopeClassId }
   }
 
   /**

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContributionData.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContributionData.kt
@@ -162,6 +162,10 @@ internal class IrContributionData(
     if (isAnnotatedWithAny(metroContext.metroSymbols.classIds.graphExtensionFactoryAnnotations)) {
       return false
     }
+    return isDirectContributionTo(scope)
+  }
+
+  private fun IrClass.isDirectContributionTo(scope: Scope): Boolean {
     return annotationsIn(metroContext.metroSymbols.classIds.contributesToAnnotations).any {
       it.scopeOrNull() == scope
     }
@@ -284,6 +288,14 @@ internal class IrContributionData(
               ?.owner
               ?.takeIf { irClass -> metroDeclarations.findBindingContainer(irClass) != null }
               ?.let(finalSet::add)
+          }
+          contributingClasses.forEach { irClass ->
+            if (!irClass.isDirectContributionTo(scope)) {
+              return@forEach
+            }
+            if (metroDeclarations.findBindingContainer(irClass) != null) {
+              finalSet.add(irClass)
+            }
           }
           if (metroContext.options.generateContributionProviders) {
             contributingClasses.forEach { irClass ->

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContributionData.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrContributionData.kt
@@ -157,6 +157,8 @@ internal class IrContributionData(
 
   private fun IrClass.isDirectContributedInterface(scope: Scope): Boolean {
     if (kind != ClassKind.INTERFACE) return false
+    val irClass = this
+    if (with(metroContext) { irClass.isBindingContainer() }) return false
     if (isAnnotatedWithAny(metroContext.metroSymbols.classIds.graphExtensionFactoryAnnotations)) {
       return false
     }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -369,9 +369,7 @@ internal fun IrClass.isBindingContainer(): Boolean {
     isAnnotatedWithAny(context.metroSymbols.classIds.bindingContainerAnnotations) -> true
     context.options.enableGuiceRuntimeInterop -> {
       // Guice interop
-      with(context.pluginContext) {
-        return implements(GuiceSymbols.ClassIds.module)
-      }
+      implements(GuiceSymbols.ClassIds.module)
     }
     else -> false
   }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -1049,7 +1049,15 @@ internal fun IrConstructorCall.getConstBooleanArgumentOrNull(name: Name): Boolea
   (getValueArgument(name) as IrConst?)?.value as Boolean?
 
 internal fun IrConstructorCall.replacesArgument() =
-  getValueArgument(Symbols.Names.replaces)?.expectAsOrNull<IrVararg>()
+  (getValueArgument(Symbols.Names.replaces) ?: arguments.getOrNull(replacesArgumentIndex()))
+    ?.expectAsOrNull<IrVararg>()
+
+private fun IrConstructorCall.replacesArgumentIndex(): Int {
+  // ContributesTo(scope, replaces) has two parameters. Binding-like Metro contribution annotations
+  // have scope/binding/replaces. Prefer the name-based lookup above, but fall back to the stable
+  // runtime constructor order for compiler versions that don't preserve value argument names in IR.
+  return if (arguments.size > 2) 2 else 1
+}
 
 internal fun IrConstructorCall.replacedClasses(): Set<IrClassReference> {
   return replacesArgument().toClassReferences()

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
@@ -247,13 +247,15 @@ internal class ContributionIrTransformer(
 
     val contributionsByScope = contributions.groupBy { it.annotation.requireScope() }
     for ((scope, scopedContributions) in contributionsByScope) {
-      if (declaration.shouldContributeDirectSupertype(scopedContributions)) {
+      val container = bindingContainerTransformer.findContainer(declaration)
+      val contributesDirectSupertype =
+        declaration.shouldContributeDirectSupertype(scopedContributions, container != null)
+      if (contributesDirectSupertype) {
         // Preserve user-visible @ContributesTo interface supertypes in FIR/IDE. Hidden
         // MetroContribution markers are generated below only for metadata and replacement logic.
         data.addDirectSupertypeContribution(scope, declaration)
-        if (bindingContainerTransformer.findContainer(declaration) != null) {
-          data.addBindingContainerContribution(scope, declaration)
-        }
+      } else if (container != null) {
+        data.addBindingContainerContribution(scope, declaration)
       }
 
       val bindingContributions =
@@ -292,10 +294,11 @@ internal class ContributionIrTransformer(
   }
 
   private fun IrClass.shouldContributeDirectSupertype(
-    scopedContributions: List<Contribution>
+    scopedContributions: List<Contribution>,
+    isBindingContainer: Boolean,
   ): Boolean {
     if (kind != ClassKind.INTERFACE) return false
-    if (isBindingContainer()) return false
+    if (isBindingContainer) return false
     if (isAnnotatedWithAny(metroSymbols.classIds.graphExtensionFactoryAnnotations)) return false
     return scopedContributions.any { it is Contribution.ContributesTo }
   }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
@@ -295,6 +295,7 @@ internal class ContributionIrTransformer(
     scopedContributions: List<Contribution>
   ): Boolean {
     if (kind != ClassKind.INTERFACE) return false
+    if (isBindingContainer()) return false
     if (isAnnotatedWithAny(metroSymbols.classIds.graphExtensionFactoryAnnotations)) return false
     return scopedContributions.any { it is Contribution.ContributesTo }
   }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/ContributionIrTransformer.kt
@@ -248,14 +248,15 @@ internal class ContributionIrTransformer(
     val contributionsByScope = contributions.groupBy { it.annotation.requireScope() }
     for ((scope, scopedContributions) in contributionsByScope) {
       val container = bindingContainerTransformer.findContainer(declaration)
-      val contributesDirectSupertype =
-        declaration.shouldContributeDirectSupertype(scopedContributions, container != null)
-      if (contributesDirectSupertype) {
-        // Preserve user-visible @ContributesTo interface supertypes in FIR/IDE. Hidden
-        // MetroContribution markers are generated below only for metadata and replacement logic.
-        data.addDirectSupertypeContribution(scope, declaration)
-      } else if (container != null) {
+      if (container != null) {
         data.addBindingContainerContribution(scope, declaration)
+      }
+      val contributesDirectSupertype =
+        declaration.shouldContributeDirectSupertype(scopedContributions)
+      if (contributesDirectSupertype) {
+        // Preserve user-visible @ContributesTo interfaces as graph supertypes. Hidden
+        // MetroContribution markers are generated below for metadata and replacement logic.
+        data.addDirectSupertypeContribution(scope, declaration)
       }
 
       val bindingContributions =
@@ -294,11 +295,10 @@ internal class ContributionIrTransformer(
   }
 
   private fun IrClass.shouldContributeDirectSupertype(
-    scopedContributions: List<Contribution>,
-    isBindingContainer: Boolean,
+    scopedContributions: List<Contribution>
   ): Boolean {
     if (kind != ClassKind.INTERFACE) return false
-    if (isBindingContainer) return false
+    if (isBindingContainer()) return false
     if (isAnnotatedWithAny(metroSymbols.classIds.graphExtensionFactoryAnnotations)) return false
     return scopedContributions.any { it is Contribution.ContributesTo }
   }


### PR DESCRIPTION
We have a use case in the TestApp to replace a provider with a fake binding. It works on 1.1.1, but not on 1.2.0. Though I'm not sure if it was a coincidence that it just worked.

The test fails with duplicate binding:
```
java.lang.IllegalStateException: //private/var/folders/bd/d_2bbffj1733nwpf_4vrw5rh0000gn/T/dev.zacsweers.metro.compiler.BoxTestGenerated$AggregationtestBindingReplacesProvider/kotlin-sources/main/BindingReplacesProvider.kt:[DUPLICATE_BINDING] (433,441): error: [Metro/DuplicateBinding] Multiple bindings found for Base

  BindingReplacesProvider.kt:10:3
    @Provides fun provideReal(): Base
                                 ~~~~
  BindingReplacesProvider.kt:15:1
    Fake contributes a binding of Base
                                  ~~~~
```

It's not the biggest deal, as we can simply refactor the provider to a binding (or change the fake from a binding to a provider).