### PR TITLE
Fix KMP output collisions in MetroArtifactCopyTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,8 @@ Example rich output (note that in rich terminals this would have color and marku
 Special thanks to the following contributors for contributing to this release!
 
 - [@BraisGabin](https://github.com/BraisGabin)
-- [@ychescale9](https://github.com/ychescale9)
 - [@FletchMcKee](https://github.com/FletchMcKee)
+- [@ychescale9](https://github.com/ychescale9)
 
 ### [Consider sponsoring Metro's development](https://www.zacsweers.dev/sponsoring-metro/)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Example rich output (note that in rich terminals this would have color and marku
 - **[IR/JS]** Fix `Map<K, () -> V>` multibindings accessed through provider-style map factories on Kotlin/JS. Generated maps now store callable function values instead of Metro `Provider` objects.
 - **[IR/KLIB]** Fix generated `@Binds` implementations on KLIB backends. Metro now emits concrete identity bodies for inherited `@Binds` members where JS, Native, and Wasm validate abstract members during deserialization.
 - **[IR/KLIB]** Keep generated graph and shard backing fields private while preserving generated access through properties. This avoids backing-field visibility validation failures on KLIB backends.
+- **[gradle]** Fix multiplatform output collisions in MetroArtifactCopyTask.
 
 ### Changes
 
@@ -89,6 +90,7 @@ Special thanks to the following contributors for contributing to this release!
 
 - [@BraisGabin](https://github.com/BraisGabin)
 - [@ychescale9](https://github.com/ychescale9)
+- [@FletchMcKee](https://github.com/FletchMcKee)
 
 ### [Consider sponsoring Metro's development](https://www.zacsweers.dev/sponsoring-metro/)
 

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/MetroArtifactsTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/MetroArtifactsTest.kt
@@ -5,11 +5,15 @@
 package dev.zacsweers.metro.gradle
 
 import com.autonomousapps.kit.GradleBuilder.build
+import com.autonomousapps.kit.GradleProject
+import com.autonomousapps.kit.GradleProject.DslKind
 import com.google.common.truth.Truth.assertThat
+import java.io.File
 import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 
 class MetroArtifactsTest {
@@ -634,13 +638,6 @@ class MetroArtifactsTest {
   fun `reportsDestination directories do not collide across multiplatform targets`() {
     val fixture =
       object : MetroProject(multiplatform = true, reportsEnabled = true) {
-        override fun multiplatformTargetsBlock(): String = buildString {
-          appendLine("kotlin {")
-          appendLine("  jvm()")
-          appendLine("  ${KmpTarget.NATIVE_HOST.gradleTargetName}()")
-          appendLine("}")
-        }
-
         override fun sources() =
           listOf(
             source(
@@ -651,6 +648,46 @@ class MetroArtifactsTest {
               "AppGraph",
             )
           )
+
+        override fun buildGradleProject(): GradleProject {
+          val projectSources = sources()
+          return newGradleProjectBuilder(DslKind.KOTLIN)
+            .withRootProject {
+              sources = projectSources
+              withBuildScript {
+                plugins(
+                  GradlePlugins.Kotlin.multiplatform(),
+                  GradlePlugins.agpKmp,
+                  GradlePlugins.metro,
+                )
+                withKotlin(
+                  """
+                    kotlin {
+                      jvm()
+
+                      android {
+                        namespace = "com.example.test"
+                        minSdk = 36
+                        compileSdk = 36
+                      }
+                    }
+
+                    ${buildMetroBlock()}
+                  """
+                    .trimIndent()
+                )
+              }
+
+              withMetroSettings()
+
+              val androidHome = System.getProperty("metro.androidHome")
+              assumeTrue(androidHome != null) // skip if environment not set up for Android
+              // Use invariantSeparatorsPath for cross-platform .properties file compatibility
+              val sdkDir = File(androidHome).invariantSeparatorsPath
+              withFile("local.properties", "sdk.dir=$sdkDir")
+            }
+            .write()
+        }
       }
 
     val project = fixture.gradleProject
@@ -665,20 +702,13 @@ class MetroArtifactsTest {
 
     val reportingDir = project.rootDir.toPath().resolve("build/tmp/metro/reporting")
     assertTrue(reportingDir.resolve("jvm/main").exists())
-    assertTrue(reportingDir.resolve("${KmpTarget.NATIVE_HOST.gradleTargetName}/main").exists())
+    assertTrue(reportingDir.resolve("android/main").exists())
   }
 
   @Test
   fun `analysis tasks are skipped when reportsDestination is not present`() {
     val fixture =
-      object : MetroProject(multiplatform = true, reportsEnabled = false) {
-        override fun multiplatformTargetsBlock(): String = buildString {
-          appendLine("kotlin {")
-          appendLine("  jvm()")
-          appendLine("  ${KmpTarget.NATIVE_HOST.gradleTargetName}()")
-          appendLine("}")
-        }
-
+      object : MetroProject(multiplatform = false, reportsEnabled = false) {
         override fun sources() =
           listOf(
             source(

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/MetroArtifactsTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/MetroArtifactsTest.kt
@@ -8,6 +8,7 @@ import com.autonomousapps.kit.GradleBuilder.build
 import com.google.common.truth.Truth.assertThat
 import kotlin.io.path.exists
 import kotlin.io.path.readText
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.Test
 
@@ -627,5 +628,66 @@ class MetroArtifactsTest {
 
     val htmlFile = reports.htmlFileForGraph("test.AppGraph")
     assertTrue(htmlFile.exists(), "Graph HTML file should exist")
+  }
+
+  @Test
+  fun `reportsDestination directories do not collide across multiplatform targets`() {
+    val fixture =
+      object : MetroProject(multiplatform = true, reportsEnabled = true) {
+        override fun sources() =
+          listOf(
+            source(
+              """
+              @DependencyGraph
+              interface AppGraph
+              """,
+              "AppGraph",
+            )
+          )
+      }
+
+    val project = fixture.gradleProject
+    val result = build(project.rootDir, "generateMetroGraphHtml", "--console=plain")
+
+    assertThat(result.task(":generateMetroGraphMetadata")?.outcome)
+      .isEqualTo(org.gradle.testkit.runner.TaskOutcome.SUCCESS)
+    assertThat(result.task(":analyzeMetroGraph")?.outcome)
+      .isEqualTo(org.gradle.testkit.runner.TaskOutcome.SUCCESS)
+    assertThat(result.task(":generateMetroGraphHtml")?.outcome)
+      .isEqualTo(org.gradle.testkit.runner.TaskOutcome.SUCCESS)
+
+    val reportingDir = project.rootDir.toPath().resolve("build/tmp/metro/reporting")
+    assertTrue(reportingDir.resolve("${KmpTarget.JVM.gradleTargetName}/main").exists())
+    assertTrue(reportingDir.resolve("${KmpTarget.JS.gradleTargetName}/main").exists())
+  }
+
+  @Test
+  fun `analysis tasks are skipped when reportsDestination is not present`() {
+    val fixture =
+      object : MetroProject(multiplatform = true, reportsEnabled = false) {
+        override fun sources() =
+          listOf(
+            source(
+              """
+              @DependencyGraph
+              interface AppGraph
+              """,
+              "AppGraph",
+            )
+          )
+      }
+
+    val project = fixture.gradleProject
+    val result = build(project.rootDir, "generateMetroGraphHtml", "--console=plain")
+
+    assertThat(result.task(":generateMetroGraphMetadata")?.outcome)
+      .isEqualTo(org.gradle.testkit.runner.TaskOutcome.SKIPPED)
+    assertThat(result.task(":analyzeMetroGraph")?.outcome)
+      .isEqualTo(org.gradle.testkit.runner.TaskOutcome.SKIPPED)
+    assertThat(result.task(":generateMetroGraphHtml")?.outcome)
+      .isEqualTo(org.gradle.testkit.runner.TaskOutcome.SKIPPED)
+
+    val reportingDir = project.rootDir.toPath().resolve("build/tmp/metro/reporting")
+    assertFalse(reportingDir.exists())
   }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/MetroArtifactsTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/dev/zacsweers/metro/gradle/MetroArtifactsTest.kt
@@ -634,6 +634,13 @@ class MetroArtifactsTest {
   fun `reportsDestination directories do not collide across multiplatform targets`() {
     val fixture =
       object : MetroProject(multiplatform = true, reportsEnabled = true) {
+        override fun multiplatformTargetsBlock(): String = buildString {
+          appendLine("kotlin {")
+          appendLine("  jvm()")
+          appendLine("  ${KmpTarget.NATIVE_HOST.gradleTargetName}()")
+          appendLine("}")
+        }
+
         override fun sources() =
           listOf(
             source(
@@ -657,14 +664,21 @@ class MetroArtifactsTest {
       .isEqualTo(org.gradle.testkit.runner.TaskOutcome.SUCCESS)
 
     val reportingDir = project.rootDir.toPath().resolve("build/tmp/metro/reporting")
-    assertTrue(reportingDir.resolve("${KmpTarget.JVM.gradleTargetName}/main").exists())
-    assertTrue(reportingDir.resolve("${KmpTarget.JS.gradleTargetName}/main").exists())
+    assertTrue(reportingDir.resolve("jvm/main").exists())
+    assertTrue(reportingDir.resolve("${KmpTarget.NATIVE_HOST.gradleTargetName}/main").exists())
   }
 
   @Test
   fun `analysis tasks are skipped when reportsDestination is not present`() {
     val fixture =
       object : MetroProject(multiplatform = true, reportsEnabled = false) {
+        override fun multiplatformTargetsBlock(): String = buildString {
+          appendLine("kotlin {")
+          appendLine("  jvm()")
+          appendLine("  ${KmpTarget.NATIVE_HOST.gradleTargetName}()")
+          appendLine("}")
+        }
+
         override fun sources() =
           listOf(
             source(

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
@@ -288,21 +288,18 @@ public class MetroGradleSubplugin @Inject constructor(problems: Problems) :
           .fold(baseDir) { dir, segment -> dir.dir(segment) }
       }
 
-    val artifactsTask = MetroArtifactCopyTask.register(project, reportsDir, kotlinCompilation)
+    if (extension.reportsDestination.isPresent) {
+      val artifactsTask = MetroArtifactCopyTask.register(project, reportsDir, kotlinCompilation)
 
-    artifactsTask.configure { task ->
-      task.onlyIf("reportsDestination is present") { extension.reportsDestination.isPresent }
-    }
-
-    project.tasks.withType(GenerateGraphMetadataTask::class.java).configureEach { task ->
-      task.onlyIf("reportsDestination is present") { extension.reportsDestination.isPresent }
-      task.projectPath.set(project.path)
-      task.compilationName.set(kotlinCompilation.name)
-      task.graphJsonFiles.from(
-        artifactsTask
-          .flatMap { it.reportsDir.dir("graph-metadata") }
-          .map { it.asFileTree.matching { it.include("*.json") } }
-      )
+      project.tasks.withType(GenerateGraphMetadataTask::class.java).configureEach { task ->
+        task.projectPath.set(project.path)
+        task.compilationName.set(kotlinCompilation.name)
+        task.graphJsonFiles.from(
+          artifactsTask
+            .flatMap { it.reportsDir.dir("graph-metadata") }
+            .map { it.asFileTree.matching { it.include("*.json") } }
+        )
+      }
     }
 
     val metroOptions =

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/MetroGradleSubplugin.kt
@@ -72,7 +72,41 @@ public class MetroGradleSubplugin @Inject constructor(problems: Problems) :
       )
     }
 
-    // Only register analysis tasks when metro's extension is configured
+    // Analysis tasks are registered, but skipped if reportsDestination isn't present.
+    val graphMetadataTask =
+      target.tasks.register(
+        GenerateGraphMetadataTask.NAME,
+        GenerateGraphMetadataTask::class.java,
+      )
+    graphMetadataTask.configure { task ->
+      task.onlyIf("reportsDestination is present") { extension.reportsDestination.isPresent }
+      task.description = "Generates Metro graph metadata for ${target.path}"
+      task.projectPath.convention(target.path)
+      task.outputFile.convention(
+        target.layout.buildDirectory.file("reports/metro/graphMetadata.json")
+      )
+    }
+
+    // Analysis task - comprehensive graph analysis
+    val analyzeTask = target.tasks.register(AnalyzeGraphTask.NAME, AnalyzeGraphTask::class.java)
+    analyzeTask.configure { task ->
+      task.onlyIf("reportsDestination is present") { extension.reportsDestination.isPresent }
+      task.description = "Analyzes Metro dependency graphs and produces a comprehensive report"
+      task.inputFile.convention(graphMetadataTask.flatMap { it.outputFile })
+      task.outputFile.convention(target.layout.buildDirectory.file("reports/metro/analysis.json"))
+    }
+
+    // HTML visualization task - interactive ECharts graphs
+    val htmlTask =
+      target.tasks.register(GenerateGraphHtmlTask.NAME, GenerateGraphHtmlTask::class.java)
+    htmlTask.configure { task ->
+      task.onlyIf("reportsDestination is present") { extension.reportsDestination.isPresent }
+      task.description = "Generates interactive HTML visualizations of Metro dependency graphs"
+      task.inputFile.convention(graphMetadataTask.flatMap { it.outputFile })
+      task.analysisFile.convention(analyzeTask.flatMap { it.outputFile })
+      task.outputDirectory.convention(target.layout.buildDirectory.dir("reports/metro/html"))
+    }
+
     target.afterEvaluate {
       // Check version and show warning by default.
       val checkVersions =
@@ -142,41 +176,6 @@ public class MetroGradleSubplugin @Inject constructor(problems: Problems) :
               "$label. $details.\n$solution.\nDocs: $compatibilityUrl\n($disableSolution)"
             )
           }
-        }
-      }
-
-      if (extension.reportsDestination.isPresent) {
-        val graphMetadataTask =
-          target.tasks.register(
-            GenerateGraphMetadataTask.NAME,
-            GenerateGraphMetadataTask::class.java,
-          )
-        graphMetadataTask.configure { task ->
-          task.description = "Generates Metro graph metadata for ${target.path}"
-          task.projectPath.convention(target.path)
-          task.outputFile.convention(
-            target.layout.buildDirectory.file("reports/metro/graphMetadata.json")
-          )
-        }
-
-        // Analysis task - comprehensive graph analysis
-        val analyzeTask = target.tasks.register(AnalyzeGraphTask.NAME, AnalyzeGraphTask::class.java)
-        analyzeTask.configure { task ->
-          task.description = "Analyzes Metro dependency graphs and produces a comprehensive report"
-          task.inputFile.convention(graphMetadataTask.flatMap { it.outputFile })
-          task.outputFile.convention(
-            target.layout.buildDirectory.file("reports/metro/analysis.json")
-          )
-        }
-
-        // HTML visualization task - interactive ECharts graphs
-        val htmlTask =
-          target.tasks.register(GenerateGraphHtmlTask.NAME, GenerateGraphHtmlTask::class.java)
-        htmlTask.configure { task ->
-          task.description = "Generates interactive HTML visualizations of Metro dependency graphs"
-          task.inputFile.convention(graphMetadataTask.flatMap { it.outputFile })
-          task.analysisFile.convention(analyzeTask.flatMap { it.outputFile })
-          task.outputDirectory.convention(target.layout.buildDirectory.dir("reports/metro/html"))
         }
       }
     }
@@ -289,18 +288,21 @@ public class MetroGradleSubplugin @Inject constructor(problems: Problems) :
           .fold(baseDir) { dir, segment -> dir.dir(segment) }
       }
 
-    if (extension.reportsDestination.isPresent) {
-      val artifactsTask = MetroArtifactCopyTask.register(project, reportsDir, kotlinCompilation)
+    val artifactsTask = MetroArtifactCopyTask.register(project, reportsDir, kotlinCompilation)
 
-      project.tasks.withType(GenerateGraphMetadataTask::class.java).configureEach { task ->
-        task.projectPath.set(project.path)
-        task.compilationName.set(kotlinCompilation.name)
-        task.graphJsonFiles.from(
-          artifactsTask
-            .flatMap { it.reportsDir.dir("graph-metadata") }
-            .map { it.asFileTree.matching { it.include("*.json") } }
-        )
-      }
+    artifactsTask.configure { task ->
+      task.onlyIf("reportsDestination is present") { extension.reportsDestination.isPresent }
+    }
+
+    project.tasks.withType(GenerateGraphMetadataTask::class.java).configureEach { task ->
+      task.onlyIf("reportsDestination is present") { extension.reportsDestination.isPresent }
+      task.projectPath.set(project.path)
+      task.compilationName.set(kotlinCompilation.name)
+      task.graphJsonFiles.from(
+        artifactsTask
+          .flatMap { it.reportsDir.dir("graph-metadata") }
+          .map { it.asFileTree.matching { it.include("*.json") } }
+      )
     }
 
     val metroOptions =

--- a/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/artifacts/MetroArtifactCopyTask.kt
+++ b/gradle-plugin/src/main/kotlin/dev/zacsweers/metro/gradle/artifacts/MetroArtifactCopyTask.kt
@@ -87,7 +87,11 @@ internal abstract class MetroArtifactCopyTask : DefaultTask(), MetroArtifacts {
         task.compilationName.set(sourceCompilation.name)
         task.kotlincReportsDir.set(reportsDir)
         task.reportsDir.set(
-          project.layout.buildDirectory.dir("tmp/metro/reporting/${sourceCompilation.name}")
+          listOf(sourceCompilation.target.name, sourceCompilation.name)
+            .filter(String::isNotBlank)
+            .fold(project.layout.buildDirectory.dir("tmp/metro/reporting")) { dir, segment ->
+              dir.map { it.dir(segment) }
+            }
         )
         task.dependsOn(sourceCompilation.compileTaskProvider)
       }


### PR DESCRIPTION
First I just want to say that this is an amazing framework. I can't imagine how much thought and effort went into this, and the analysis reports are awesome. I've been integrating Metro into a KMP project and the only issue we've had is the Android reports wouldn't generate which I didn't think warranted creating an issue. However I believe I found a simple fix for this.

The main cause of missing analysis reports in a KMP project is the targets would collide in MetroArtifactCopyTask. 
MetroGradleSubplugin was correctly doing this:
```kotlin
val reportsDir =
  extension.reportsDestination.map { baseDir ->
    // Include target name to avoid collisions in KMP projects where multiple targets
    // may have compilations with the same name (e.g., both jvm and android have "main")
    // Use chained dir() calls instead of joining with "/" to avoid Windows path issues
    listOf(kotlinCompilation.target.name, kotlinCompilation.name)
      .filter(String::isNotBlank)
      .fold(baseDir) { dir, segment -> dir.dir(segment) }
  }
```

But MetroArtifactCopyTask wasn't repeating the same pattern:
```kotlin
task.reportsDir.set(
  project.layout.buildDirectory.dir("tmp/metro/reporting/${sourceCompilation.name}")
)
```

Replicating the pattern fixed this issue and I could revert the `reportsDestination.isPresent` changes if desired. That was my first hunch since we apply Metro in a convention plugin and alter whether `reportsDestination` is set based on a few things. But I think this will also help improve the consistency of these tasks since they're no longer registered in an `afterEvaluate` block and the `isPresent` read is deferred until task execution. The tasks are always registered, but they're skipped if `reportsDestination.isPresent` is false.

I added some test cases but also tested it locally on FieldSpottr, and without the change it would yield the same results I had seen in our project:

Before:
```console
Project: :shared
Graphs analyzed: 1

Graph: dev.zacsweers.fieldspottr.di.IosFSGraph
  Total bindings: 48
  Scoped: 10, Unscoped: 38
  Avg dependencies: 1.31
  Binding types: {Alias=19, BoundInstance=1, ConstructorInjected=21, Multibinding=2, Provided=5}
  Longest path: 5 nodes
    PermitRepository -> PermitRepositoryImpl -> Logger -> FSGraph -> IosFSGraph
  Highest fan-in: PermitRepository (5 dependents)

> Task :shared:generateMetroGraphHtml
Generating Metro graph visualizations from file:///.../FieldSpottr/shared/build/reports/metro/graphMetadata.json
Including analysis data from file:///.../FieldSpottr/shared/build/reports/metro/analysis.json
Generated file:///.../FieldSpottr/shared/build/reports/metro/html/dev-zacsweers-fieldspottr-di-IosFSGraph.html
Generated file:///.../FieldSpottr/shared/build/reports/metro/html/index.html
```
After:
```console
Project: :shared
Graphs analyzed: 3

Graph: dev.zacsweers.fieldspottr.di.AndroidFSGraph
  Total bindings: 49
  Scoped: 9, Unscoped: 40
  Avg dependencies: 1.35
  Binding types: {Alias=19, BoundInstance=2, ConstructorInjected=21, Multibinding=2, Provided=5}
  Longest path: 7 nodes
    PermitRepository -> PermitRepositoryImpl -> FSAppDirs -> ContextFSAppDirs -> FileSystem -> FSGraph -> AndroidFSGraph
  Highest fan-in: PermitRepository (5 dependents)

Graph: dev.zacsweers.fieldspottr.di.IosFSGraph
  Total bindings: 48
  Scoped: 10, Unscoped: 38
  Avg dependencies: 1.31
  Binding types: {Alias=19, BoundInstance=1, ConstructorInjected=21, Multibinding=2, Provided=5}
  Longest path: 5 nodes
    PermitRepository -> PermitRepositoryImpl -> Logger -> FSGraph -> IosFSGraph
  Highest fan-in: PermitRepository (5 dependents)

Graph: dev.zacsweers.fieldspottr.di.JvmFSGraph
  Total bindings: 48
  Scoped: 10, Unscoped: 38
  Avg dependencies: 1.35
  Binding types: {Alias=19, BoundInstance=1, ConstructorInjected=21, Multibinding=2, Provided=5}
  Longest path: 6 nodes
    PermitRepository -> PermitRepositoryImpl -> SqlDriverFactory -> JvmSqlDriverFactory -> FSAppDirs -> DesktopFSAppDirs
  Highest fan-in: PermitRepository (5 dependents)

> Task :shared:generateMetroGraphHtml
Generating Metro graph visualizations from file:///.../FieldSpottr/shared/build/reports/metro/graphMetadata.json
Including analysis data from file:///.../FieldSpottr/shared/build/reports/metro/analysis.json
Generated file:///.../FieldSpottr/shared/build/reports/metro/html/dev-zacsweers-fieldspottr-di-AndroidFSGraph.html
Generated file:///.../FieldSpottr/shared/build/reports/metro/html/dev-zacsweers-fieldspottr-di-IosFSGraph.html
Generated file:///.../FieldSpottr/shared/build/reports/metro/html/dev-zacsweers-fieldspottr-di-JvmFSGraph.html
Generated file:///.../FieldSpottr/shared/build/reports/metro/html/index.html
```