### PR TITLE
Support parameterless Binds declarations

### DIFF
--- a/compiler-tests/src/test/data/box/bindingcontainers/ParameterlessBinds.kt
+++ b/compiler-tests/src/test/data/box/bindingcontainers/ParameterlessBinds.kt
@@ -1,0 +1,20 @@
+@DependencyGraph(bindingContainers = [Bindings::class])
+interface AppGraph {
+  val validFoo: ValidFoo
+}
+
+@BindingContainer
+interface Bindings {
+  @Binds fun bindValidFoo(): ValidFoo
+}
+
+@Inject
+class ValidFoo {
+  val value: String = "constructor"
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertEquals("constructor", graph.validFoo.value)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/diagnostic/dependencygraph/ParameterlessBindsDuplicate.ir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/dependencygraph/ParameterlessBindsDuplicate.ir.diag.txt
@@ -1,0 +1,14 @@
+/ParameterlessBindsDuplicate.kt:6:11: error:
+[Metro/DuplicateBinding] Multiple bindings found for ValidFoo
+
+      ParameterlessBindsDuplicate.kt:11:13
+        @Provides fun provideValidFoo(): ValidFoo
+                                         ~~~~~~~~
+
+      ParameterlessBindsDuplicate.kt:9:10
+        @Binds fun bindValidFoo(): ValidFoo
+                                   ~~~~~~~~
+
+  help: remove or disambiguate the duplicate bindings (e.g. with distinct qualifiers), or use
+        @IntoSet/@IntoMap if you intended a multibinding
+  docs: https://zacsweers.github.io/metro/latest/diagnostics/#duplicatebinding

--- a/compiler-tests/src/test/data/diagnostic/dependencygraph/ParameterlessBindsDuplicate.kt
+++ b/compiler-tests/src/test/data/diagnostic/dependencygraph/ParameterlessBindsDuplicate.kt
@@ -1,0 +1,13 @@
+// RUN_PIPELINE_TILL: FIR2IR
+// RENDER_IR_DIAGNOSTICS_FULL_TEXT
+
+@DependencyGraph
+interface <!DUPLICATE_BINDING!>AppGraph<!> {
+  val validFoo: ValidFoo
+
+  @Binds fun bindValidFoo(): ValidFoo
+
+  @Provides fun <!REDUNDANT_PROVIDES!>provideValidFoo<!>(): ValidFoo = ValidFoo()
+}
+
+@Inject class ValidFoo

--- a/compiler-tests/src/test/data/diagnostic/provides/ParameterlessBindsDiagnostics.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/provides/ParameterlessBindsDiagnostics.diag.txt
@@ -1,0 +1,19 @@
+/ParameterlessBindsDiagnostics.kt:23:14: error: Parameterless @Binds declarations must be functions.
+
+/ParameterlessBindsDiagnostics.kt:25:30: error: Parameterless @Binds declarations must return a class with exactly one @Inject constructor.
+
+/ParameterlessBindsDiagnostics.kt:27:29: error: Parameterless @Binds declarations must return a non-generic class type.
+
+/ParameterlessBindsDiagnostics.kt:29:30: error: Parameterless @Binds declarations must return a concrete class type.
+
+/ParameterlessBindsDiagnostics.kt:31:10: error: Parameterless @Binds declarations may not have qualifiers.
+
+/ParameterlessBindsDiagnostics.kt:33:10: error: @Binds declarations may not have scopes.
+
+/ParameterlessBindsDiagnostics.kt:35:28: error: Parameterless @Binds declarations may not be @GraphPrivate.
+
+/ParameterlessBindsDiagnostics.kt:37:23: error: Parameterless @Binds declarations may not use multibinding or map key annotations.
+
+/ParameterlessBindsDiagnostics.kt:39:50: error: Parameterless @Binds declarations may not use multibinding or map key annotations.
+
+/ParameterlessBindsDiagnostics.kt:41:34: error: Parameterless @Binds declarations may not return scoped injected classes.

--- a/compiler-tests/src/test/data/diagnostic/provides/ParameterlessBindsDiagnostics.kt
+++ b/compiler-tests/src/test/data/diagnostic/provides/ParameterlessBindsDiagnostics.kt
@@ -1,0 +1,41 @@
+// RENDER_DIAGNOSTICS_FULL_TEXT
+
+interface Base
+
+@Inject class ValidFoo
+@Inject class Impl : Base
+class NoInject
+@Inject class GenericFoo<T>
+abstract class AbstractFoo
+
+@SingleIn(AppScope::class)
+@Inject class ScopedFoo
+
+interface ExampleGraph {
+  // Ok: parameterless @Binds explicitly claims ValidFoo's constructor-injected key.
+  @Binds fun bindValid(): ValidFoo
+
+  // Ok: classic @Binds still has a real source key.
+  @Binds fun Impl.bindClassicExtension(): Base
+  @Binds fun bindClassicParameter(impl: Impl): Base
+
+  @Binds val <!BINDS_ERROR!>propertyBind<!>: ValidFoo
+
+  @Binds fun bindNoInject(): <!BINDS_ERROR!>NoInject<!>
+
+  @Binds fun bindGeneric(): <!BINDS_ERROR!>GenericFoo<String><!>
+
+  @Binds fun bindAbstract(): <!BINDS_ERROR!>AbstractFoo<!>
+
+  @Binds <!BINDS_ERROR!>@Named("named")<!> fun bindQualified(): ValidFoo
+
+  @Binds <!BINDS_ERROR!>@SingleIn(AppScope::class)<!> fun bindScoped(): ValidFoo
+
+  @GraphPrivate @Binds fun <!BINDS_ERROR!>bindGraphPrivate<!>(): ValidFoo
+
+  @IntoSet @Binds fun <!BINDS_ERROR!>bindIntoSet<!>(): ValidFoo
+
+  @IntoMap @ClassKey(ValidFoo::class) @Binds fun <!BINDS_ERROR!>bindIntoMap<!>(): ValidFoo
+
+  @Binds fun bindScopedReturn(): <!BINDS_ERROR!>ScopedFoo<!>
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -823,6 +823,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("ParameterlessBinds.kt")
+    public void testParameterlessBinds() {
+      run("ParameterlessBinds.kt");
+    }
+
+    @Test
     @TestMetadata("PrivateBindsProperty.kt")
     public void testPrivateBindsProperty() {
       run("PrivateBindsProperty.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -823,6 +823,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     }
 
     @Test
+    @TestMetadata("ParameterlessBinds.kt")
+    public void testParameterlessBinds() {
+      run("ParameterlessBinds.kt");
+    }
+
+    @Test
     @TestMetadata("PrivateBindsProperty.kt")
     public void testPrivateBindsProperty() {
       run("PrivateBindsProperty.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/DiagnosticTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/DiagnosticTestGenerated.java
@@ -543,6 +543,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
     }
 
     @Test
+    @TestMetadata("ParameterlessBindsDuplicate.kt")
+    public void testParameterlessBindsDuplicate() {
+      run("ParameterlessBindsDuplicate.kt");
+    }
+
+    @Test
     @TestMetadata("RuntimeTracingRequiresGraphFactory.kt")
     public void testRuntimeTracingRequiresGraphFactory() {
       run("RuntimeTracingRequiresGraphFactory.kt");
@@ -1380,6 +1386,12 @@ public class DiagnosticTestGenerated extends AbstractDiagnosticTest {
     @TestMetadata("LazyAssistedFactoryProvides.kt")
     public void testLazyAssistedFactoryProvides() {
       run("LazyAssistedFactoryProvides.kt");
+    }
+
+    @Test
+    @TestMetadata("ParameterlessBindsDiagnostics.kt")
+    public void testParameterlessBindsDiagnostics() {
+      run("ParameterlessBindsDiagnostics.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -823,6 +823,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("ParameterlessBinds.kt")
+    public void testParameterlessBinds() {
+      run("ParameterlessBinds.kt");
+    }
+
+    @Test
     @TestMetadata("PrivateBindsProperty.kt")
     public void testPrivateBindsProperty() {
       run("PrivateBindsProperty.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
@@ -823,6 +823,12 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
     }
 
     @Test
+    @TestMetadata("ParameterlessBinds.kt")
+    public void testParameterlessBinds() {
+      run("ParameterlessBinds.kt");
+    }
+
+    @Test
     @TestMetadata("PrivateBindsProperty.kt")
     public void testPrivateBindsProperty() {
       run("PrivateBindsProperty.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
@@ -561,6 +561,12 @@ public class JsBoxTestGenerated extends AbstractJsBoxTest {
     }
 
     @Test
+    @TestMetadata("ParameterlessBinds.kt")
+    public void testParameterlessBinds() {
+      run("ParameterlessBinds.kt");
+    }
+
+    @Test
     @TestMetadata("PrivateBindsProperty.kt")
     public void testPrivateBindsProperty() {
       run("PrivateBindsProperty.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
@@ -561,6 +561,12 @@ public class JsContributionProvidersBoxTestGenerated extends AbstractJsContribut
     }
 
     @Test
+    @TestMetadata("ParameterlessBinds.kt")
+    public void testParameterlessBinds() {
+      run("ParameterlessBinds.kt");
+    }
+
+    @Test
     @TestMetadata("PrivateBindsProperty.kt")
     public void testPrivateBindsProperty() {
       run("PrivateBindsProperty.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsDiagnosticTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsDiagnosticTestGenerated.java
@@ -451,6 +451,12 @@ public class JsDiagnosticTestGenerated extends AbstractJsDiagnosticTest {
     }
 
     @Test
+    @TestMetadata("ParameterlessBindsDuplicate.kt")
+    public void testParameterlessBindsDuplicate() {
+      run("ParameterlessBindsDuplicate.kt");
+    }
+
+    @Test
     @TestMetadata("RuntimeTracingRequiresGraphFactory.kt")
     public void testRuntimeTracingRequiresGraphFactory() {
       run("RuntimeTracingRequiresGraphFactory.kt");
@@ -1218,6 +1224,12 @@ public class JsDiagnosticTestGenerated extends AbstractJsDiagnosticTest {
     @TestMetadata("LazyAssistedFactoryProvides.kt")
     public void testLazyAssistedFactoryProvides() {
       run("LazyAssistedFactoryProvides.kt");
+    }
+
+    @Test
+    @TestMetadata("ParameterlessBindsDiagnostics.kt")
+    public void testParameterlessBindsDiagnostics() {
+      run("ParameterlessBindsDiagnostics.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
@@ -561,6 +561,12 @@ public class JsFastInitBoxTestGenerated extends AbstractJsFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("ParameterlessBinds.kt")
+    public void testParameterlessBinds() {
+      run("ParameterlessBinds.kt");
+    }
+
+    @Test
     @TestMetadata("PrivateBindsProperty.kt")
     public void testPrivateBindsProperty() {
       run("PrivateBindsProperty.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/BindingContainerCallableChecker.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/fir/checkers/BindingContainerCallableChecker.kt
@@ -30,7 +30,9 @@ import dev.zacsweers.metro.compiler.symbols.Symbols
 import dev.zacsweers.metro.compiler.tracing.trace
 import org.jetbrains.kotlin.KtFakeSourceElementKind
 import org.jetbrains.kotlin.KtSourceElement
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.EffectiveVisibility
+import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.isObject
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
@@ -529,6 +531,19 @@ internal object BindingContainerCallableChecker :
 
       val returnType = returnTypeRef.coneTypeOrNull ?: return
 
+      val isZeroSourceBinds =
+        annotations.isBinds &&
+          declaration.receiverParameter == null &&
+          when (declaration) {
+            is FirFunction -> declaration.valueParameters.isEmpty()
+            is FirProperty -> true
+            else -> false
+          }
+      if (isZeroSourceBinds) {
+        validateParameterlessBindsDeclaration(declaration, source, annotations, bodyExpression)
+        return
+      }
+
       // Report a warning if this is `@IntoSet` and also returns a `Set`, as it's probably not what
       // they mean!
       if (annotations.isIntoSet && (returnType.isSet || returnType.isList)) {
@@ -623,6 +638,119 @@ internal object BindingContainerCallableChecker :
     }
 
     session.trace({ "Validate binding declaration" }) { validateBindingDeclaration() }
+  }
+
+  context(context: CheckerContext, reporter: DiagnosticReporter)
+  private fun validateParameterlessBindsDeclaration(
+    declaration: FirCallableDeclaration,
+    source: KtSourceElement,
+    annotations: MetroAnnotations<MetroFirAnnotation>,
+    bodyExpression: FirExpression?,
+  ) {
+    val session = context.session
+    val returnTypeRef = declaration.propertyIfAccessor.returnTypeRef
+    val returnType = returnTypeRef.coneTypeOrNull ?: return
+
+    fun report(message: String, reportSource: KtSourceElement? = source) {
+      reporter.reportOn(reportSource, MetroDiagnostics.BINDS_ERROR, message)
+    }
+
+    val isNamedFunction =
+      declaration is FirFunction && with(session.compatContext) { declaration.isNamedFunction() }
+    if (!isNamedFunction) {
+      report("Parameterless @Binds declarations must be functions.")
+      return
+    }
+
+    if (bodyExpression != null) {
+      if (declaration.visibility == Visibilities.Private) {
+        report("Parameterless @Binds declarations must be abstract and not have a body.")
+      }
+      return
+    }
+
+    if (annotations.qualifier != null) {
+      report(
+        "Parameterless @Binds declarations may not have qualifiers.",
+        annotations.qualifier.fir.source,
+      )
+      return
+    }
+
+    if (annotations.isGraphPrivate) {
+      report("Parameterless @Binds declarations may not be @GraphPrivate.")
+      return
+    }
+
+    if (annotations.isIntoMultibinding) {
+      report("Parameterless @Binds declarations may not use multibinding or map key annotations.")
+      return
+    }
+
+    if (returnType.typeArguments.isNotEmpty()) {
+      report(
+        "Parameterless @Binds declarations must return a non-generic class type.",
+        returnTypeRef.source,
+      )
+      return
+    }
+
+    val returnClass = returnType.toClassSymbolCompat(session)
+    if (returnClass == null) {
+      report(
+        "Parameterless @Binds declarations must return a concrete class type.",
+        returnTypeRef.source,
+      )
+      return
+    }
+
+    val returnClassKind = returnClass.classKind
+    val returnClassModality = returnClass.rawStatus.modality
+    val hasConcreteModality =
+      returnClassModality == null ||
+        returnClassModality == Modality.FINAL ||
+        returnClassModality == Modality.OPEN
+    val returnsConcreteClass =
+      returnClassKind == ClassKind.CLASS && hasConcreteModality
+    if (!returnsConcreteClass) {
+      report(
+        "Parameterless @Binds declarations must return a concrete class type.",
+        returnTypeRef.source,
+      )
+      return
+    }
+
+    if (returnClass.typeParameterSymbols.isNotEmpty()) {
+      report(
+        "Parameterless @Binds declarations must return a non-generic class type.",
+        returnTypeRef.source,
+      )
+      return
+    }
+
+    val injectConstructors = returnClass.findInjectConstructors(session)
+    if (injectConstructors.size != 1) {
+      report(
+        "Parameterless @Binds declarations must return a class with exactly one @Inject constructor.",
+        returnTypeRef.source,
+      )
+      return
+    }
+
+    val classScope =
+      returnClass.resolvedCompilerAnnotationsWithClassIds.scopeAnnotations(session).firstOrNull()
+    val injectConstructor = injectConstructors.single()
+    val constructorScope =
+      injectConstructor.constructor
+        ?.resolvedCompilerAnnotationsWithClassIds
+        ?.scopeAnnotations(session)
+        ?.firstOrNull()
+    if (classScope != null || constructorScope != null) {
+      report(
+        "Parameterless @Binds declarations may not return scoped injected classes.",
+        returnTypeRef.source,
+      )
+    }
   }
 
   private fun FirExpression.returnsThis(): Boolean {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindsLikeCallable.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrBindsLikeCallable.kt
@@ -124,6 +124,43 @@ internal class BindsCallable(
 }
 
 @Poko
+internal class InjectConstructorBindsCallable(
+  override val callableMetadata: IrCallableMetadata,
+  override val typeKey: IrTypeKey,
+) : BindsLikeCallable {
+  fun remapTypes(remapper: TypeRemapper): InjectConstructorBindsCallable {
+    return InjectConstructorBindsCallable(
+      callableMetadata = callableMetadata,
+      typeKey = typeKey.remapTypes(remapper),
+    )
+  }
+
+  /** Renders a [LocationDiagnostic] for this callable. */
+  fun renderLocationDiagnostic(
+    short: Boolean,
+    shortLocation: Boolean,
+    parameters: Parameters,
+  ): LocationDiagnostic {
+    val location =
+      function.renderSourceLocation(short = shortLocation)
+        ?: "<unknown location, likely a separate compilation>"
+
+    val description = buildString {
+      renderForDiagnostic(
+        declaration = function,
+        short = short,
+        typeKey = typeKey,
+        annotations = callableMetadata.annotations,
+        parameters = parameters,
+        isProperty = callableMetadata.isPropertyAccessor,
+        underlineTypeKey = true,
+      )
+    }
+    return LocationDiagnostic(location, description, null)
+  }
+}
+
+@Poko
 internal class MultibindsCallable(
   override val callableMetadata: IrCallableMetadata,
   override val typeKey: IrTypeKey,
@@ -159,6 +196,16 @@ internal fun MetroSimpleFunction.toBindsCallable(isInterop: Boolean): BindsCalla
     source = IrContextualTypeKey.from(ir.nonDispatchParameters.single()).typeKey,
     typeKey = typeKey,
     rawTarget = rawTarget,
+  )
+}
+
+context(context: IrMetroContext)
+internal fun MetroSimpleFunction.toInjectConstructorBindsCallable(
+  isInterop: Boolean
+): InjectConstructorBindsCallable {
+  return InjectConstructorBindsCallable(
+    callableMetadata = ir.irCallableMetadata(annotations, isInterop),
+    typeKey = IrContextualTypeKey.from(ir).typeKey,
   )
 }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/BindingGraphGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/BindingGraphGenerator.kt
@@ -7,6 +7,7 @@ import dev.zacsweers.metro.compiler.Origins
 import dev.zacsweers.metro.compiler.ir.BindsCallable
 import dev.zacsweers.metro.compiler.ir.BindsLikeCallable
 import dev.zacsweers.metro.compiler.ir.BindsOptionalOfCallable
+import dev.zacsweers.metro.compiler.ir.InjectConstructorBindsCallable
 import dev.zacsweers.metro.compiler.ir.IrAnnotation
 import dev.zacsweers.metro.compiler.ir.IrBoundTypeResolver
 import dev.zacsweers.metro.compiler.ir.IrContextualTypeKey
@@ -184,6 +185,7 @@ internal class BindingGraphGenerator(
     val inheritedProviderFactoryKeys = inheritedData.providerFactoryKeys
     val inheritedProviderFactories = inheritedData.providerFactories
     val inheritedBindsCallableKeys = inheritedData.bindsCallableKeys
+    val inheritedInjectConstructorBindsCallableKeys = inheritedData.injectConstructorBindsCallableKeys
 
     val ownProviderFactoryCount = node.providerFactories.values.sumOf { it.size }
     val inheritedProviderFactoryCount = inheritedProviderFactories.size
@@ -340,6 +342,67 @@ internal class BindingGraphGenerator(
             }
 
         // Add the binding to the lookup (duplicates tracked as lists)
+        putBinding(binding.typeKey, isLocallyDeclared = !isInherited, binding)
+      }
+    }
+
+    val ownInjectConstructorBindsCount = node.injectConstructorBindsCallables.values.sumOf { it.size }
+    val inheritedInjectConstructorBindsCount = inheritedData.injectConstructorBindsCallables.size
+    trace(
+      "Collect inject constructor binds callables (own=$ownInjectConstructorBindsCount, inh=$inheritedInjectConstructorBindsCount)"
+    ) {
+      val injectConstructorBindsCallablesToAdd = buildList {
+        node.injectConstructorBindsCallables.values.flatten().forEach { callable ->
+          add(callable.typeKey to callable)
+        }
+        addAll(inheritedData.injectConstructorBindsCallables)
+      }
+
+      trace("Track IC for inject constructor binds") {
+        batchTrackForCallingDeclaration(node.sourceGraph) {
+          for ((_, callable) in injectConstructorBindsCallablesToAdd) {
+            trackFunctionCall(callable.function)
+            trackFunctionCall(callable.callableMetadata.mirrorFunction)
+            trackClassLookup(callable.function.parentAsClass)
+            trackClassLookup(callable.callableMetadata.mirrorFunction.parentAsClass)
+          }
+        }
+      }
+
+      for ((typeKey, callable) in injectConstructorBindsCallablesToAdd) {
+        val isInherited = typeKey in inheritedInjectConstructorBindsCallableKeys
+        if (typeKey in bindingLookup && isInherited) {
+          continue
+        }
+
+        if (!callable.isDynamic && typeKey in node.dynamicTypeKeys) {
+          continue
+        }
+
+        val targetTypeKey = callable.typeKey
+        val isDynamic = callable.isDynamic
+        val existingBinding = bindingLookup[targetTypeKey]
+
+        if (isDynamic && existingBinding != null) {
+          val existingAreDynamic =
+            when (existingBinding) {
+              is Provided -> existingBinding.providerFactory.isDynamic
+              is Alias -> existingBinding.bindsCallable?.isDynamic == true
+              is IrBinding.ConstructorInjected ->
+                existingBinding.injectConstructorBindsCallable?.isDynamic == true
+              else -> false
+            }
+          if (!existingAreDynamic) {
+            bindingLookup.clearBindings(targetTypeKey)
+          }
+        }
+
+        val binding =
+          bindingLookup.createInjectConstructorBindsBinding(
+            callable,
+            graph.bindingsSnapshot(),
+            bindingStack,
+          )
         putBinding(binding.typeKey, isLocallyDeclared = !isInherited, binding)
       }
     }
@@ -734,6 +797,8 @@ internal class BindingGraphGenerator(
     val providerFactoryKeys = mutableSetOf<IrTypeKey>()
     val bindsCallableKeys = mutableSetOf<IrTypeKey>()
     val bindsCallables = mutableListOf<RawBindsCallableEntry>()
+    val injectConstructorBindsCallableKeys = mutableSetOf<IrTypeKey>()
+    val injectConstructorBindsCallables = mutableListOf<RawInjectConstructorBindsCallableEntry>()
     val bindingContainers = mutableSetOf<IrClass>()
     val multibindsCallables = mutableSetOf<MultibindsCallable>()
     val optionalKeys = mutableMapOf<IrTypeKey, MutableSet<BindsOptionalOfCallable>>()
@@ -744,7 +809,8 @@ internal class BindingGraphGenerator(
       val isDynamicParent =
         extendedNode is GraphNode.Local && extendedNode.dynamicTypeKeys.isNotEmpty()
 
-      val alreadyCollectedKeys = providerFactoryKeys + bindsCallableKeys
+      val alreadyCollectedKeys =
+        providerFactoryKeys + bindsCallableKeys + injectConstructorBindsCallableKeys
 
       // Collect provider factories (non-scoped, not already collected from a closer parent).
       // Skip @GraphPrivate factories — private contributions should not leak to child graphs.
@@ -790,6 +856,23 @@ internal class BindingGraphGenerator(
         }
       }
 
+      // Collect parameterless binds callables.
+      for ((key, callables) in extendedNode.injectConstructorBindsCallables) {
+        if (
+          key in alreadyCollectedKeys && !(isDynamicParent && key in extendedNode.dynamicTypeKeys)
+        ) {
+          continue
+        }
+        for (callable in callables) {
+          if (key in extendedNode.graphPrivateKeys) continue
+          val isDynamicInParent = isDynamicParent && key in extendedNode.dynamicTypeKeys
+          injectConstructorBindsCallableKeys.add(key)
+          injectConstructorBindsCallables.add(
+            RawInjectConstructorBindsCallableEntry(key, callable, isDynamicInParent)
+          )
+        }
+      }
+
       // Collect binding containers (only from Local nodes).
       if (extendedNode is GraphNode.Local) {
         bindingContainers.addAll(extendedNode.bindingContainers)
@@ -826,6 +909,7 @@ internal class BindingGraphGenerator(
     return RawInheritedGraphData(
       providerFactories = providerFactories,
       bindsCallables = bindsCallables,
+      injectConstructorBindsCallables = injectConstructorBindsCallables,
       bindingContainers = bindingContainers,
       multibindsCallables = multibindsCallables,
       optionalKeys = optionalKeys,
@@ -842,6 +926,7 @@ internal class BindingGraphGenerator(
 private class RawInheritedGraphData(
   val providerFactories: List<RawProviderFactoryEntry>,
   val bindsCallables: List<RawBindsCallableEntry>,
+  val injectConstructorBindsCallables: List<RawInjectConstructorBindsCallableEntry>,
   val bindingContainers: Set<IrClass>,
   val multibindsCallables: Set<MultibindsCallable>,
   val optionalKeys: Map<IrTypeKey, Set<BindsOptionalOfCallable>>,
@@ -853,6 +938,9 @@ private class RawInheritedGraphData(
     val outProviderFactoryKeys = mutableSetOf<IrTypeKey>()
     val outBindsCallableKeys = mutableSetOf<IrTypeKey>()
     val outBindsCallables = mutableListOf<Pair<IrTypeKey, BindsCallable>>()
+    val outInjectConstructorBindsCallableKeys = mutableSetOf<IrTypeKey>()
+    val outInjectConstructorBindsCallables =
+      mutableListOf<Pair<IrTypeKey, InjectConstructorBindsCallable>>()
     for ((key, factory, isDynamicInParent) in providerFactories) {
       if (isDynamicInParent || key !in directlyProvidedKeys) {
         outProviderFactories.add(key to factory)
@@ -865,11 +953,19 @@ private class RawInheritedGraphData(
         outBindsCallables.add(key to callable)
       }
     }
+    for ((key, callable, isDynamicInParent) in injectConstructorBindsCallables) {
+      if (isDynamicInParent || key !in directlyProvidedKeys) {
+        outInjectConstructorBindsCallableKeys.add(key)
+        outInjectConstructorBindsCallables.add(key to callable)
+      }
+    }
     return InheritedGraphData(
       providerFactories = outProviderFactories,
       providerFactoryKeys = outProviderFactoryKeys,
       bindsCallableKeys = outBindsCallableKeys,
       bindsCallables = outBindsCallables,
+      injectConstructorBindsCallableKeys = outInjectConstructorBindsCallableKeys,
+      injectConstructorBindsCallables = outInjectConstructorBindsCallables,
       bindingContainers = bindingContainers,
       multibindsCallables = multibindsCallables,
       optionalKeys = optionalKeys,
@@ -891,6 +987,12 @@ private data class RawBindsCallableEntry(
   val isDynamicInParent: Boolean,
 )
 
+private data class RawInjectConstructorBindsCallableEntry(
+  val key: IrTypeKey,
+  val callable: InjectConstructorBindsCallable,
+  val isDynamicInParent: Boolean,
+)
+
 /**
  * Data collected from parent nodes in a single pass. Avoids multiple iterations over
  * allParentGraphs.
@@ -900,6 +1002,8 @@ private data class InheritedGraphData(
   val providerFactoryKeys: Set<IrTypeKey>,
   val bindsCallableKeys: Set<IrTypeKey>,
   val bindsCallables: List<Pair<IrTypeKey, BindsCallable>>,
+  val injectConstructorBindsCallableKeys: Set<IrTypeKey>,
+  val injectConstructorBindsCallables: List<Pair<IrTypeKey, InjectConstructorBindsCallable>>,
   val bindingContainers: Set<IrClass>,
   val multibindsCallables: Set<MultibindsCallable>,
   val optionalKeys: Map<IrTypeKey, Set<BindsOptionalOfCallable>>,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/BindingLookup.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/BindingLookup.kt
@@ -15,6 +15,7 @@ import dev.zacsweers.metro.compiler.graph.toText
 import dev.zacsweers.metro.compiler.graph.toTraceSection
 import dev.zacsweers.metro.compiler.ir.BindsOptionalOfCallable
 import dev.zacsweers.metro.compiler.ir.ClassFactory
+import dev.zacsweers.metro.compiler.ir.InjectConstructorBindsCallable
 import dev.zacsweers.metro.compiler.ir.IrAnnotation
 import dev.zacsweers.metro.compiler.ir.IrContextualTypeKey
 import dev.zacsweers.metro.compiler.ir.IrMetroContext
@@ -255,6 +256,24 @@ internal class BindingLookup(
   /** Tracks a key as locally declared without adding a binding to the cache. */
   fun trackDeclaredKey(typeKey: IrTypeKey) {
     locallyDeclaredKeys += typeKey
+  }
+
+  context(context: IrMetroContext)
+  fun createInjectConstructorBindsBinding(
+    callable: InjectConstructorBindsCallable,
+    currentBindings: ScatterMap<IrTypeKey, IrBinding>,
+    stack: IrBindingStack,
+  ): IrBinding.ConstructorInjected {
+    val contextKey = IrContextualTypeKey.create(callable.typeKey)
+    val classBindings = lookupClassBinding(contextKey, currentBindings, stack)
+    val constructorBindings = classBindings.filterIsInstance<IrBinding.ConstructorInjected>()
+    val constructorBinding =
+      constructorBindings.singleOrNull()
+        ?: reportCompilerBug(
+          "Expected exactly one constructor-injected binding for parameterless @Binds " +
+            "${callable.function}, found ${constructorBindings.size}"
+        )
+    return constructorBinding.withInjectConstructorBindsCallable(callable)
   }
 
   /**

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/GraphMetadataReporter.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/GraphMetadataReporter.kt
@@ -169,6 +169,10 @@ internal class GraphMetadataReporter(
     return buildJsonObject {
       put("providerFactories", JsonPrimitive(node.providerFactories.values.sumOf { it.size }))
       put("bindsCallables", JsonPrimitive(node.bindsCallables.values.sumOf { it.size }))
+      put(
+        "injectConstructorBindsCallables",
+        JsonPrimitive(node.injectConstructorBindsCallables.values.sumOf { it.size }),
+      )
       put("multibindsCallables", JsonPrimitive(node.multibindsCallables.size))
       put("optionalBindings", JsonPrimitive(node.optionalKeys.values.sumOf { it.size }))
       put("accessors", JsonPrimitive(node.accessors.size))

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/GraphNode.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/GraphNode.kt
@@ -6,6 +6,7 @@ import dev.zacsweers.metro.compiler.BitField
 import dev.zacsweers.metro.compiler.Origins
 import dev.zacsweers.metro.compiler.ir.BindsCallable
 import dev.zacsweers.metro.compiler.ir.BindsOptionalOfCallable
+import dev.zacsweers.metro.compiler.ir.InjectConstructorBindsCallable
 import dev.zacsweers.metro.compiler.ir.IrAnnotation
 import dev.zacsweers.metro.compiler.ir.IrBindingContainerCallable
 import dev.zacsweers.metro.compiler.ir.IrContextualTypeKey
@@ -49,6 +50,8 @@ internal sealed class GraphNode {
    */
   abstract val accessors: List<GraphAccessor>
   abstract val bindsCallables: Map<IrTypeKey, List<BindsCallable>>
+  abstract val injectConstructorBindsCallables:
+    Map<IrTypeKey, List<InjectConstructorBindsCallable>>
   abstract val multibindsCallables: Set<MultibindsCallable>
   abstract val optionalKeys: Map<IrTypeKey, Set<BindsOptionalOfCallable>>
   abstract val parentGraph: GraphNode?
@@ -72,6 +75,7 @@ internal sealed class GraphNode {
     buildSet {
       addAll(providerFactories.keys)
       addAll(bindsCallables.keys)
+      addAll(injectConstructorBindsCallables.keys)
     }
   }
 
@@ -160,6 +164,8 @@ internal sealed class GraphNode {
     override val providerFactories: Map<IrTypeKey, List<ProviderFactory>>,
     override val accessors: List<GraphAccessor>,
     override val bindsCallables: Map<IrTypeKey, List<BindsCallable>>,
+    override val injectConstructorBindsCallables:
+      Map<IrTypeKey, List<InjectConstructorBindsCallable>>,
     override val multibindsCallables: Set<MultibindsCallable>,
     override val optionalKeys: Map<IrTypeKey, Set<BindsOptionalOfCallable>>,
     override val parentGraph: GraphNode?,
@@ -179,6 +185,8 @@ internal sealed class GraphNode {
     override val providerFactories: Map<IrTypeKey, List<ProviderFactory>>,
     override val accessors: List<GraphAccessor>,
     override val bindsCallables: Map<IrTypeKey, List<BindsCallable>>,
+    override val injectConstructorBindsCallables:
+      Map<IrTypeKey, List<InjectConstructorBindsCallable>>,
     override val multibindsCallables: Set<MultibindsCallable>,
     override val optionalKeys: Map<IrTypeKey, Set<BindsOptionalOfCallable>>,
     /** Binding containers that need a managed instance. */
@@ -210,6 +218,7 @@ internal sealed class GraphNode {
       buildSet {
         addAll(providerFactories.keys)
         addAll(bindsCallables.keys)
+        addAll(injectConstructorBindsCallables.keys)
         creator?.parameters?.regularParameters?.forEach { param ->
           if (param.isBindsInstance) {
             add(param.typeKey)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/GraphNodes.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/GraphNodes.kt
@@ -24,6 +24,7 @@ import dev.zacsweers.metro.compiler.getOrInit
 import dev.zacsweers.metro.compiler.graph.toTraceSection
 import dev.zacsweers.metro.compiler.ir.BindsCallable
 import dev.zacsweers.metro.compiler.ir.BindsOptionalOfCallable
+import dev.zacsweers.metro.compiler.ir.InjectConstructorBindsCallable
 import dev.zacsweers.metro.compiler.ir.IrAnnotation
 import dev.zacsweers.metro.compiler.ir.IrBindingContainerCallable
 import dev.zacsweers.metro.compiler.ir.IrBindingContainerResolver
@@ -209,6 +210,8 @@ internal class GraphNodes(
     private val accessors = mutableListOf<GraphAccessor>()
     private val bindsFunctions = mutableListOf<Pair<MetroSimpleFunction, IrContextualTypeKey>>()
     private val bindsCallables = mutableMapOf<IrTypeKey, MutableList<BindsCallable>>()
+    private val injectConstructorBindsCallables =
+      mutableMapOf<IrTypeKey, MutableList<InjectConstructorBindsCallable>>()
     private val multibindsCallables = mutableSetOf<MultibindsCallable>()
     private val optionalKeys = mutableMapOf<IrTypeKey, MutableSet<BindsOptionalOfCallable>>()
     private val scopes = mutableSetOf<IrAnnotation>()
@@ -1283,6 +1286,26 @@ internal class GraphNodes(
                 bindsCallables.getAndAdd(typeKey, callable)
               }
             }
+            for (callable in bindsMirror.injectConstructorBindsCallables) {
+              if (callable.callableMetadata.annotations.isGraphPrivate) {
+                graphPrivateKeys += callable.typeKey
+              }
+              val typeKey = callable.typeKey
+              val existingIsDynamic = typeKey in dynamicTypeKeys
+              when {
+                isDynamicContainer && !existingIsDynamic -> {
+                  injectConstructorBindsCallables[typeKey] = mutableListOf(callable)
+                  dynamicTypeKeys.getAndAdd(typeKey, callable)
+                }
+                isDynamicContainer -> {
+                  injectConstructorBindsCallables.getAndAdd(typeKey, callable)
+                  dynamicTypeKeys.getAndAdd(typeKey, callable)
+                }
+                !existingIsDynamic -> {
+                  injectConstructorBindsCallables.getAndAdd(typeKey, callable)
+                }
+              }
+            }
             for (callable in bindsMirror.multibindsCallables) {
               if (callable.callableMetadata.annotations.isGraphPrivate) {
                 graphPrivateKeys += callable.typeKey
@@ -1322,6 +1345,7 @@ internal class GraphNodes(
             scopes = scopes,
             aggregationScopes = aggregationScopes,
             bindsCallables = bindsCallables,
+            injectConstructorBindsCallables = injectConstructorBindsCallables,
             bindsFunctions = bindsFunctions.map { it.first },
             multibindsCallables = multibindsCallables,
             optionalKeys = optionalKeys,
@@ -1445,6 +1469,9 @@ internal class GraphNodes(
               for (callable in bindsMirror.bindsCallables) {
                 bindsCallables.getAndAdd(callable.typeKey, callable)
               }
+              for (callable in bindsMirror.injectConstructorBindsCallables) {
+                injectConstructorBindsCallables.getAndAdd(callable.typeKey, callable)
+              }
               multibindsCallables += bindsMirror.multibindsCallables
               for (callable in bindsMirror.optionalKeys) {
                 optionalKeys.getAndAdd(callable.typeKey, callable)
@@ -1475,6 +1502,13 @@ internal class GraphNodes(
           }
         }
       }
+      for ((_, callables) in injectConstructorBindsCallables) {
+        for (callable in callables) {
+          if (callable.callableMetadata.annotations.isGraphPrivate) {
+            externalGraphPrivateKeys += callable.typeKey
+          }
+        }
+      }
       for (callable in multibindsCallables) {
         if (callable.callableMetadata.annotations.isGraphPrivate) {
           externalGraphPrivateKeys += callable.typeKey
@@ -1491,6 +1525,7 @@ internal class GraphNodes(
           providerFactories = providerFactories,
           accessors = accessors,
           bindsCallables = bindsCallables,
+          injectConstructorBindsCallables = injectConstructorBindsCallables,
           multibindsCallables = multibindsCallables,
           optionalKeys = optionalKeys,
           parentGraph = parentGraph,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/IrBinding.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/IrBinding.kt
@@ -13,6 +13,7 @@ import dev.zacsweers.metro.compiler.graph.LocationDiagnostic
 import dev.zacsweers.metro.compiler.ir.BindsCallable
 import dev.zacsweers.metro.compiler.ir.ClassFactory
 import dev.zacsweers.metro.compiler.ir.Format
+import dev.zacsweers.metro.compiler.ir.InjectConstructorBindsCallable
 import dev.zacsweers.metro.compiler.ir.IrAnnotation
 import dev.zacsweers.metro.compiler.ir.IrContextualTypeKey
 import dev.zacsweers.metro.compiler.ir.IrMetroContext
@@ -134,6 +135,7 @@ internal sealed interface IrBinding : BaseBinding<IrType, IrTypeKey, IrContextua
     override val annotations: MetroAnnotations<IrAnnotation>,
     override val typeKey: IrTypeKey,
     val injectedMembers: Set<IrContextualTypeKey>,
+    @Poko.Skip val injectConstructorBindsCallable: InjectConstructorBindsCallable? = null,
   ) : IrBinding, BindingWithAnnotations, InjectedClassBinding<ConstructorInjected> {
     override val parameters: Parameters = classFactory.targetFunctionParameters
 
@@ -180,7 +182,33 @@ internal sealed interface IrBinding : BaseBinding<IrType, IrTypeKey, IrContextua
         )
       }
 
+    override fun renderLocationDiagnostic(
+      short: Boolean,
+      shortLocation: Boolean,
+      underlineTypeKey: Boolean,
+    ): LocationDiagnostic {
+      val callable = injectConstructorBindsCallable
+      return if (callable != null) {
+        callable.renderLocationDiagnostic(short, shortLocation, parameters)
+      } else {
+        super<IrBinding>.renderLocationDiagnostic(short, shortLocation, underlineTypeKey)
+      }
+    }
+
     override fun toString() = renderDescriptionDiagnostic(short = true, underlineTypeKey = false)
+
+    fun withInjectConstructorBindsCallable(
+      callable: InjectConstructorBindsCallable
+    ): ConstructorInjected {
+      return ConstructorInjected(
+        type = type,
+        classFactory = classFactory,
+        annotations = annotations,
+        typeKey = typeKey,
+        injectedMembers = injectedMembers,
+        injectConstructorBindsCallable = callable,
+      )
+    }
 
     override fun withMapKey(mapKey: IrAnnotation?): ConstructorInjected {
       if (mapKey == null) return this
@@ -190,6 +218,7 @@ internal sealed interface IrBinding : BaseBinding<IrType, IrTypeKey, IrContextua
         annotations = annotations.copy(mapKey = mapKey),
         typeKey = typeKey,
         injectedMembers = injectedMembers,
+        injectConstructorBindsCallable = injectConstructorBindsCallable,
       )
     }
   }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/IrGraphGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/IrGraphGenerator.kt
@@ -54,6 +54,7 @@ import dev.zacsweers.metro.compiler.ir.requireSimpleType
 import dev.zacsweers.metro.compiler.ir.setDispatchReceiver
 import dev.zacsweers.metro.compiler.ir.sourceGraphIfMetroGraph
 import dev.zacsweers.metro.compiler.ir.stripOuterProviderOrLazy
+import dev.zacsweers.metro.compiler.ir.stubExpressionBody
 import dev.zacsweers.metro.compiler.ir.thisReceiverOrFail
 import dev.zacsweers.metro.compiler.ir.toProto
 import dev.zacsweers.metro.compiler.ir.trackFunctionCall
@@ -1996,15 +1997,18 @@ internal class IrGraphGenerator(
             declarationToFinalize.finalizeFakeOverride(graphClass.thisReceiverOrFail)
           }
           // This override is the graph impl's concrete implementation of the inherited @Binds
-          // member. @Binds is an identity conversion from the source parameter to the declared
-          // return type, so emit that body directly rather than a placeholder stub. KLIB backends
-          // deserialize and validate these inherited members before later Metro mirror code can
-          // cover for them.
+          // member. Classic @Binds is an identity conversion from the source parameter to the
+          // declared return type, so emit that body directly. Parameterless @Binds is metadata for
+          // an injected-constructor binding claim and has no source parameter to return, so a stub
+          // body is sufficient and should never be called.
           val sourceParameter =
-            extensionReceiverParameterCompat
-              ?: regularParameters.singleOrNull()
-              ?: reportCompilerBug("No source parameter found for @Binds function $kotlinFqName")
-          body = createIrBuilder(symbol).run { irExprBodySafe(irGet(sourceParameter)) }
+            extensionReceiverParameterCompat ?: regularParameters.singleOrNull()
+          body =
+            if (sourceParameter != null) {
+              createIrBuilder(symbol).run { irExprBodySafe(irGet(sourceParameter)) }
+            } else {
+              stubExpressionBody()
+            }
         }
       }
     }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindingContainerTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindingContainerTransformer.kt
@@ -1330,6 +1330,8 @@ internal class BindingContainer(
       BindsMirror(
         ir = mirror.ir,
         bindsCallables = mirror.bindsCallables.mapTo(mutableSetOf()) { it.remapTypes(remapper) },
+        injectConstructorBindsCallables =
+          mirror.injectConstructorBindsCallables.mapTo(mutableSetOf()) { it.remapTypes(remapper) },
         multibindsCallables =
           mirror.multibindsCallables.mapTo(mutableSetOf()) { it.remapTypes(remapper) },
         optionalKeys = mirror.optionalKeys.mapTo(mutableSetOf()) { it.remapTypes(remapper) },

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindsMirrorClassTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindsMirrorClassTransformer.kt
@@ -12,6 +12,7 @@ import dev.zacsweers.metro.compiler.expectAs
 import dev.zacsweers.metro.compiler.expectAsOrNull
 import dev.zacsweers.metro.compiler.ir.BindsCallable
 import dev.zacsweers.metro.compiler.ir.BindsOptionalOfCallable
+import dev.zacsweers.metro.compiler.ir.InjectConstructorBindsCallable
 import dev.zacsweers.metro.compiler.ir.IrMetroContext
 import dev.zacsweers.metro.compiler.ir.IrScope
 import dev.zacsweers.metro.compiler.ir.MetroSimpleFunction
@@ -125,6 +126,8 @@ internal data class BindsMirror(
   val ir: IrClass,
   /** Set of binds callables by their [CallableId]. */
   val bindsCallables: Set<BindsCallable>,
+  /** Parameterless `@Binds` callables that explicitly claim constructor-injected bindings. */
+  val injectConstructorBindsCallables: Set<InjectConstructorBindsCallable>,
   /** Set of multibinds callables by their [BindsCallable]. */
   val multibindsCallables: Set<MultibindsCallable>,
   /**
@@ -133,7 +136,10 @@ internal data class BindsMirror(
   val optionalKeys: Set<BindsOptionalOfCallable>,
 ) {
   fun isEmpty() =
-    bindsCallables.isEmpty() && multibindsCallables.isEmpty() && optionalKeys.isEmpty()
+    bindsCallables.isEmpty() &&
+      injectConstructorBindsCallables.isEmpty() &&
+      multibindsCallables.isEmpty() &&
+      optionalKeys.isEmpty()
 }
 
 context(context: IrMetroContext)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindsMirrorCollector.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/BindsMirrorCollector.kt
@@ -4,14 +4,17 @@ package dev.zacsweers.metro.compiler.ir.transformers
 
 import dev.zacsweers.metro.compiler.ir.BindsCallable
 import dev.zacsweers.metro.compiler.ir.BindsOptionalOfCallable
+import dev.zacsweers.metro.compiler.ir.InjectConstructorBindsCallable
 import dev.zacsweers.metro.compiler.ir.IrMetroContext
 import dev.zacsweers.metro.compiler.ir.MetroSimpleFunction
 import dev.zacsweers.metro.compiler.ir.MultibindsCallable
 import dev.zacsweers.metro.compiler.ir.toBindsCallable
 import dev.zacsweers.metro.compiler.ir.toBindsOptionalOfCallable
+import dev.zacsweers.metro.compiler.ir.toInjectConstructorBindsCallable
 import dev.zacsweers.metro.compiler.ir.toMultibindsCallable
 import dev.zacsweers.metro.compiler.reportCompilerBug
 import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.util.nonDispatchParameters
 
 /**
  * Simple helper class to collect binds callables and build a [BindsMirror].
@@ -21,13 +24,18 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
  */
 internal class BindsMirrorCollector(private val isInterop: Boolean) {
   private val bindsCallables = mutableSetOf<BindsCallable>()
+  private val injectConstructorBindsCallables = mutableSetOf<InjectConstructorBindsCallable>()
   private val multibindsCallables = mutableSetOf<MultibindsCallable>()
   private val optionalTypes = mutableSetOf<BindsOptionalOfCallable>()
 
   context(context: IrMetroContext)
   operator fun plusAssign(function: MetroSimpleFunction) {
     if (function.annotations.isBinds) {
-      bindsCallables += function.toBindsCallable(isInterop)
+      if (function.ir.nonDispatchParameters.isEmpty()) {
+        injectConstructorBindsCallables += function.toInjectConstructorBindsCallable(isInterop)
+      } else {
+        bindsCallables += function.toBindsCallable(isInterop)
+      }
     } else if (function.annotations.isMultibinds) {
       multibindsCallables += function.toMultibindsCallable(isInterop)
     } else if (function.annotations.isBindsOptionalOf) {
@@ -38,6 +46,12 @@ internal class BindsMirrorCollector(private val isInterop: Boolean) {
   }
 
   fun buildMirror(clazz: IrClass): BindsMirror {
-    return BindsMirror(clazz, bindsCallables, multibindsCallables, optionalTypes)
+    return BindsMirror(
+      clazz,
+      bindsCallables,
+      injectConstructorBindsCallables,
+      multibindsCallables,
+      optionalTypes,
+    )
   }
 }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
@@ -859,6 +859,11 @@ internal class DependencyGraphTransformer(
             .map { it.metroFunction.ir }
             .plus(node.injectors.map { it.metroFunction.ir })
             .plus(node.bindsCallables.values.flatten().map { it.callableMetadata.function })
+            .plus(
+              node.injectConstructorBindsCallables.values.flatten().map {
+                it.callableMetadata.function
+              }
+            )
             .plus(node.graphExtensions.flatMap { it.value }.map { it.accessor.ir })
             .filterNot { it.isExternalParent }
             .forEach { function ->

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -30,10 +30,11 @@ Like Dagger, Metro supports this with `@Binds`.
 !!! tip "For multi-module projects"
     If you're working across multiple modules and want bindings to be automatically discovered, see [`@ContributesBinding`](aggregation.md#contributesbinding) for a more powerful approach that supports aggregation.
 
-For these cases, an abstract provider can be specified with the following conditions.
+For these cases, an abstract alias binding can be specified with the following conditions.
 
 * It must be abstract
-* It must define one extension receiver that is a subtype of its provided type
+* It must define one source type, either as an extension receiver or as a single value parameter
+* The source type must be a subtype of its provided type
 
 ```kotlin
 @DependencyGraph
@@ -51,9 +52,36 @@ interface AppGraph {
 class MessageImpl(val text: String) : Message
 ```
 
-If you want to limit access to these from your API, you can make these declarations `private` and just return `this`. Note it’s still important to annotate them with `@Binds` so that the Metro compiler understands its intent! Otherwise, it’s an error to *implement* these declarations.
+The alias source can also be a single value parameter, for example
+`@Binds fun bindMessage(impl: MessageImpl): Message`.
 
-`@Binds` declarations can also declare multibinding annotations.
+Metro also supports parameterless `@Binds` functions for constructor-injected concrete classes.
+These declarations explicitly claim the returned class's own `@Inject` constructor binding in the
+graph, which makes duplicate and override behavior explicit. They are not provider functions and
+are never called to construct the object.
+
+```kotlin
+@DependencyGraph(bindingContainers = [Bindings::class])
+interface AppGraph {
+  val message: MessageImpl
+}
+
+@BindingContainer
+interface Bindings {
+  @Binds fun bindMessageImpl(): MessageImpl
+}
+
+@Inject
+class MessageImpl
+```
+
+Parameterless `@Binds` functions may not declare qualifiers, scopes, graph-private visibility,
+multibinding annotations, or map keys. Their return type must be a non-generic concrete class with
+exactly one unscoped `@Inject` constructor.
+
+If you want to limit access to alias binds from your API, you can make these declarations `private` and just return `this`. Note it’s still important to annotate them with `@Binds` so that the Metro compiler understands its intent! Otherwise, it’s an error to *implement* these declarations.
+
+Alias `@Binds` declarations can also declare multibinding annotations.
 
 ```kotlin
 @DependencyGraph

--- a/runtime/src/commonMain/kotlin/dev/zacsweers/metro/Binds.kt
+++ b/runtime/src/commonMain/kotlin/dev/zacsweers/metro/Binds.kt
@@ -3,19 +3,27 @@
 package dev.zacsweers.metro
 
 /**
- * Binds a given type as a type-assignable return type. This is commonly used to bind implementation
- * types to supertypes or to bind them into multibindings.
+ * Binds a type to the declared return type. This is commonly used to bind implementation types to
+ * supertypes or to bind them into multibindings.
+ *
  * - [Binds]-annotated callable declarations must be abstract. They will never be called at runtime
  *   and are solely signal for the compiler plugin.
- * - [Binds]-annotated callable declarations may declare the source binding as their extension
- *   receiver type.
+ * - Alias [Binds] declarations declare the source binding as their extension receiver type or their
+ *   only value parameter type.
+ * - Parameterless [Binds] function declarations explicitly claim the returned concrete class's own
+ *   `@Inject` constructor binding in the current graph. These are not provider functions and may
+ *   not be qualified, scoped, or used as multibindings.
  *
  * ```
  * interface Base
- * class Impl : Base
+ * @Inject class Impl : Base
  *
  * // In a graph
  * @Binds val Impl.bind: Base
+ * // Equivalent function form: @Binds fun bind(base: Impl): Base
+ *
+ * // Or explicitly claim Impl's @Inject constructor binding
+ * @Binds fun bindImpl(): Impl
  *
  * // Or bind into a multibinding
  * @Binds @IntoSet val Impl.bind: Base


### PR DESCRIPTION
Closes #2493.

## Summary

This adds support for Dagger 2.60-style parameterless `@Binds` declarations.

The important semantic distinction is that parameterless `@Binds` is not modeled as a `Foo -> Foo` alias and is not treated as a provider function. Instead, it explicitly claims the returned concrete class's existing `@Inject` constructor binding in the graph so duplicate and override behavior sees it as a declared binding.

## Changes

- Validate parameterless `@Binds` declarations in FIR with Dagger-compatible constraints.
- Add a separate `InjectConstructorBindsCallable` IR model, keeping classic `BindsCallable` source-backed.
- Thread parameterless binds through binding mirrors, graph nodes, inherited graph data, and dynamic container handling.
- Materialize the normal `ConstructorInjected` binding during graph generation and tag it with the `@Binds` declaration for diagnostics.
- Avoid source-parameter body generation for KLIB fake overrides when the declaration is parameterless.
- Update docs/KDoc and add focused compiler tests.
