### PR TITLE
Fix: GraphPrivate bindings can leak to chained Graph Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Changelog
 - **[IR]** Fix dispatch receivers for generated graph factory functions and companion/object factory accessors.
 - **[IR]** Manage transitive simple class binding containers included by contributed binding containers when they have instance providers.
 - **[IR]** Patch declaration parents for generated `@Binds` mirror declarations so copied declarations remain attached to the correct generated class.
+- **[IR]** Preserve `@GraphPrivate` on cross-module mirror functions so private multibinding contributions do not leak through chained graph extensions.
 - **[IR/Dagger interop]** Fix an IR gen crash when an unscoped parent `@Provides` binding is injected as `dagger.Lazy<T>` from a child graph.
 - **[IR/JS]** Fix `Map<K, () -> V>` multibindings accessed through provider-style map factories on Kotlin/JS. Generated maps now store callable function values instead of Metro `Provider` objects.
 - **[IR/KLIB]** Fix generated `@Binds` implementations on KLIB backends. Metro now emits concrete identity bodies for inherited `@Binds` members where JS, Native, and Wasm validate abstract members during deserialization.
@@ -100,6 +101,7 @@ Special thanks to the following contributors for contributing to this release!
 
 - [@BraisGabin](https://github.com/BraisGabin)
 - [@FletchMcKee](https://github.com/FletchMcKee)
+- [@jonamireh](https://github.com/jonamireh)
 - [@tikurahul](https://github.com/tikurahul)
 - [@ychescale9](https://github.com/ychescale9)
 

--- a/compiler-tests/src/test/data/box/dependencygraph/extensions/GraphPrivateMultibindingMapNotExposedToGrandChild.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/extensions/GraphPrivateMultibindingMapNotExposedToGrandChild.kt
@@ -1,3 +1,4 @@
+// https://github.com/ZacSweers/metro/issues/2496
 // MODULE: lib
 @GraphExtension
 interface ChildGraph {

--- a/compiler-tests/src/test/data/box/dependencygraph/extensions/GraphPrivateMultibindingMapNotExposedToGrandChild.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/extensions/GraphPrivateMultibindingMapNotExposedToGrandChild.kt
@@ -1,0 +1,40 @@
+// MODULE: lib
+@GraphExtension
+interface ChildGraph {
+  @GraphPrivate @Provides @IntoMap @StringKey("b") fun provideB(): Int = 2
+
+  val childMap: Map<String, Int>
+
+  fun grandChildGraph(): GrandChildGraph
+
+}
+
+@GraphExtension
+interface GrandChildGraph {
+  @GraphPrivate @Provides @IntoMap @StringKey("c") fun provideC(): Int = 3
+
+  val grandChildMap: Map<String, Int>
+}
+
+// MODULE: main(lib)
+@SingleIn(AppScope::class)
+@DependencyGraph
+interface ParentGraph {
+  @Multibinds(allowEmpty = true) val parentMap: Map<String, Int>
+
+  @GraphPrivate @Provides @IntoMap @StringKey("a") fun provideA(): Int = 1
+
+  fun childGraph(): ChildGraph
+}
+
+fun box(): String {
+  val parent = createGraph<ParentGraph>()
+  assertEquals(mapOf("a" to 1), parent.parentMap)
+
+  val child = parent.childGraph()
+  assertEquals(mapOf("b" to 2), child.childMap)
+
+  val grandChild = child.grandChildGraph()
+  assertEquals(mapOf("c" to 3), grandChild.grandChildMap)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -1628,6 +1628,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("GraphPrivateMultibindingMapNotExposedToGrandChild.kt")
+      public void testGraphPrivateMultibindingMapNotExposedToGrandChild() {
+        run("GraphPrivateMultibindingMapNotExposedToGrandChild.kt");
+      }
+
+      @Test
       @TestMetadata("GraphPrivateMultibindingSetNotExposedToChild.kt")
       public void testGraphPrivateMultibindingSetNotExposedToChild() {
         run("GraphPrivateMultibindingSetNotExposedToChild.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -1628,6 +1628,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
       }
 
       @Test
+      @TestMetadata("GraphPrivateMultibindingMapNotExposedToGrandChild.kt")
+      public void testGraphPrivateMultibindingMapNotExposedToGrandChild() {
+        run("GraphPrivateMultibindingMapNotExposedToGrandChild.kt");
+      }
+
+      @Test
       @TestMetadata("GraphPrivateMultibindingSetNotExposedToChild.kt")
       public void testGraphPrivateMultibindingSetNotExposedToChild() {
         run("GraphPrivateMultibindingSetNotExposedToChild.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -1628,6 +1628,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("GraphPrivateMultibindingMapNotExposedToGrandChild.kt")
+      public void testGraphPrivateMultibindingMapNotExposedToGrandChild() {
+        run("GraphPrivateMultibindingMapNotExposedToGrandChild.kt");
+      }
+
+      @Test
       @TestMetadata("GraphPrivateMultibindingSetNotExposedToChild.kt")
       public void testGraphPrivateMultibindingSetNotExposedToChild() {
         run("GraphPrivateMultibindingSetNotExposedToChild.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
@@ -1628,6 +1628,12 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
       }
 
       @Test
+      @TestMetadata("GraphPrivateMultibindingMapNotExposedToGrandChild.kt")
+      public void testGraphPrivateMultibindingMapNotExposedToGrandChild() {
+        run("GraphPrivateMultibindingMapNotExposedToGrandChild.kt");
+      }
+
+      @Test
       @TestMetadata("GraphPrivateMultibindingSetNotExposedToChild.kt")
       public void testGraphPrivateMultibindingSetNotExposedToChild() {
         run("GraphPrivateMultibindingSetNotExposedToChild.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
@@ -1366,6 +1366,12 @@ public class JsBoxTestGenerated extends AbstractJsBoxTest {
       }
 
       @Test
+      @TestMetadata("GraphPrivateMultibindingMapNotExposedToGrandChild.kt")
+      public void testGraphPrivateMultibindingMapNotExposedToGrandChild() {
+        run("GraphPrivateMultibindingMapNotExposedToGrandChild.kt");
+      }
+
+      @Test
       @TestMetadata("GraphPrivateMultibindingSetNotExposedToChild.kt")
       public void testGraphPrivateMultibindingSetNotExposedToChild() {
         run("GraphPrivateMultibindingSetNotExposedToChild.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
@@ -1366,6 +1366,12 @@ public class JsContributionProvidersBoxTestGenerated extends AbstractJsContribut
       }
 
       @Test
+      @TestMetadata("GraphPrivateMultibindingMapNotExposedToGrandChild.kt")
+      public void testGraphPrivateMultibindingMapNotExposedToGrandChild() {
+        run("GraphPrivateMultibindingMapNotExposedToGrandChild.kt");
+      }
+
+      @Test
       @TestMetadata("GraphPrivateMultibindingSetNotExposedToChild.kt")
       public void testGraphPrivateMultibindingSetNotExposedToChild() {
         run("GraphPrivateMultibindingSetNotExposedToChild.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
@@ -1366,6 +1366,12 @@ public class JsFastInitBoxTestGenerated extends AbstractJsFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("GraphPrivateMultibindingMapNotExposedToGrandChild.kt")
+      public void testGraphPrivateMultibindingMapNotExposedToGrandChild() {
+        run("GraphPrivateMultibindingMapNotExposedToGrandChild.kt");
+      }
+
+      @Test
       @TestMetadata("GraphPrivateMultibindingSetNotExposedToChild.kt")
       public void testGraphPrivateMultibindingSetNotExposedToChild() {
         run("GraphPrivateMultibindingSetNotExposedToChild.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroAnnotations.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroAnnotations.kt
@@ -782,6 +782,9 @@ internal fun MetroAnnotations<IrAnnotation>.mirrorIrConstructorCalls(
     } else if (isBinds) {
       add(buildAnnotation(symbol, context.metroSymbols.bindsConstructor))
     }
+    if (isGraphPrivate) {
+      add(buildAnnotation(symbol, context.metroSymbols.graphPrivateConstructor))
+    }
     if (isIntoSet) {
       add(buildAnnotation(symbol, context.metroSymbols.intoSetConstructor))
     } else if (isElementsIntoSet) {

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/BindingGraphGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/BindingGraphGenerator.kt
@@ -796,7 +796,10 @@ internal class BindingGraphGenerator(
       }
 
       // Collect multibinds callables.
-      multibindsCallables.addAll(extendedNode.multibindsCallables)
+      for (callable in extendedNode.multibindsCallables) {
+        if (callable.typeKey in extendedNode.graphPrivateKeys) continue
+        multibindsCallables.add(callable)
+      }
 
       // Collect optional keys.
       for ((optKey, callables) in extendedNode.optionalKeys) {
@@ -817,6 +820,7 @@ internal class BindingGraphGenerator(
 
       // Collect multibinding accessors.
       for (accessor in extendedNode.accessors) {
+        if (accessor.contextKey.typeKey in extendedNode.graphPrivateKeys) continue
         if (accessor.metroFunction.annotations.isMultibinds) {
           multibindingAccessors.add(accessor)
         }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
@@ -589,6 +589,12 @@ internal class DependencyGraphTransformer(
       // Batch by declaration to avoid kotlinc diagnostic deduplication
       val privateBindingErrors = mutableMapOf<IrDeclaration, MutableList<String>>()
       for (accessor in node.accessors) {
+        val annotations = accessor.metroFunction.annotations
+        val accessorDeclaresGraphPrivateMultibinds =
+          annotations.isGraphPrivate && annotations.isMultibinds
+        if (accessorDeclaresGraphPrivateMultibinds) {
+          continue
+        }
         if (accessor.contextKey.typeKey in node.graphPrivateKeys) {
           // Resolve to the source declaration (the user-authored property/function in the
           // interface, not the fake override in the generated impl class)

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/symbols/Symbols.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/symbols/Symbols.kt
@@ -722,6 +722,10 @@ internal class Symbols(
       .single()
   }
 
+  val graphPrivateConstructor by lazy {
+    builtinsFinder.findClass(classIds.graphPrivateAnnotation)!!.constructors.single()
+  }
+
   val assistedConstructor by lazy {
     builtinsFinder
       .findClass(ClassId(metroRuntime.packageFqName, StringNames.ASSISTED.asName()))!!


### PR DESCRIPTION
Fixes #2496 
