### PR TITLE
Fix accessing graph factories across modules with IR class gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Changelog
 **Unreleased**
 --------------
 
+### Fixes
+
+- **[IR]** Fix `createGraphFactory()` calls for graph factory interfaces compiled in upstream modules with IR-only class generation.
+
+### [Consider sponsoring Metro's development](https://www.zacsweers.dev/sponsoring-metro/)
+
 1.3.0
 -----
 

--- a/compiler-tests/src/test/data/box/dependencygraph/CreateGraphFactoryExternalInterfaceFactory.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/CreateGraphFactoryExternalInterfaceFactory.kt
@@ -1,0 +1,23 @@
+// https://github.com/ZacSweers/metro/issues/2506
+// Regression test for graph factory access across modules with IR-only class
+// generation. The upstream module publishes AppGraph.Factory.Impl in metadata; downstream
+// createGraphFactory<AppGraph.Factory>() should still use the companion-backed interface factory
+// path instead of looking for a companion factory() accessor.
+// This specifically is just for IR factory gen in 2.4.20+
+// MODULE: lib
+@DependencyGraph
+interface AppGraph {
+  val value: String
+
+  @DependencyGraph.Factory
+  interface Factory {
+    fun create(@Provides value: String): AppGraph
+  }
+}
+
+// MODULE: main(lib)
+fun box(): String {
+  val graph = createGraphFactory<AppGraph.Factory>().create("hello")
+  assertEquals("hello", graph.value)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -1077,6 +1077,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("CreateGraphFactoryExternalInterfaceFactory.kt")
+    public void testCreateGraphFactoryExternalInterfaceFactory() {
+      run("CreateGraphFactoryExternalInterfaceFactory.kt");
+    }
+
+    @Test
     @TestMetadata("DefaultAccessorBodiesWorkAcrossModules.kt")
     public void testDefaultAccessorBodiesWorkAcrossModules() {
       run("DefaultAccessorBodiesWorkAcrossModules.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -1077,6 +1077,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     }
 
     @Test
+    @TestMetadata("CreateGraphFactoryExternalInterfaceFactory.kt")
+    public void testCreateGraphFactoryExternalInterfaceFactory() {
+      run("CreateGraphFactoryExternalInterfaceFactory.kt");
+    }
+
+    @Test
     @TestMetadata("DefaultAccessorBodiesWorkAcrossModules.kt")
     public void testDefaultAccessorBodiesWorkAcrossModules() {
       run("DefaultAccessorBodiesWorkAcrossModules.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -1077,6 +1077,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("CreateGraphFactoryExternalInterfaceFactory.kt")
+    public void testCreateGraphFactoryExternalInterfaceFactory() {
+      run("CreateGraphFactoryExternalInterfaceFactory.kt");
+    }
+
+    @Test
     @TestMetadata("DefaultAccessorBodiesWorkAcrossModules.kt")
     public void testDefaultAccessorBodiesWorkAcrossModules() {
       run("DefaultAccessorBodiesWorkAcrossModules.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
@@ -1077,6 +1077,12 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
     }
 
     @Test
+    @TestMetadata("CreateGraphFactoryExternalInterfaceFactory.kt")
+    public void testCreateGraphFactoryExternalInterfaceFactory() {
+      run("CreateGraphFactoryExternalInterfaceFactory.kt");
+    }
+
+    @Test
     @TestMetadata("DefaultAccessorBodiesWorkAcrossModules.kt")
     public void testDefaultAccessorBodiesWorkAcrossModules() {
       run("DefaultAccessorBodiesWorkAcrossModules.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
@@ -815,6 +815,12 @@ public class JsBoxTestGenerated extends AbstractJsBoxTest {
     }
 
     @Test
+    @TestMetadata("CreateGraphFactoryExternalInterfaceFactory.kt")
+    public void testCreateGraphFactoryExternalInterfaceFactory() {
+      run("CreateGraphFactoryExternalInterfaceFactory.kt");
+    }
+
+    @Test
     @TestMetadata("DefaultAccessorBodiesWorkAcrossModules.kt")
     public void testDefaultAccessorBodiesWorkAcrossModules() {
       run("DefaultAccessorBodiesWorkAcrossModules.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
@@ -815,6 +815,12 @@ public class JsContributionProvidersBoxTestGenerated extends AbstractJsContribut
     }
 
     @Test
+    @TestMetadata("CreateGraphFactoryExternalInterfaceFactory.kt")
+    public void testCreateGraphFactoryExternalInterfaceFactory() {
+      run("CreateGraphFactoryExternalInterfaceFactory.kt");
+    }
+
+    @Test
     @TestMetadata("DefaultAccessorBodiesWorkAcrossModules.kt")
     public void testDefaultAccessorBodiesWorkAcrossModules() {
       run("DefaultAccessorBodiesWorkAcrossModules.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
@@ -815,6 +815,12 @@ public class JsFastInitBoxTestGenerated extends AbstractJsFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("CreateGraphFactoryExternalInterfaceFactory.kt")
+    public void testCreateGraphFactoryExternalInterfaceFactory() {
+      run("CreateGraphFactoryExternalInterfaceFactory.kt");
+    }
+
+    @Test
     @TestMetadata("DefaultAccessorBodiesWorkAcrossModules.kt")
     public void testDefaultAccessorBodiesWorkAcrossModules() {
       run("DefaultAccessorBodiesWorkAcrossModules.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/GeneratedClassIr.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/GeneratedClassIr.kt
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.typeWith
 import org.jetbrains.kotlin.ir.util.addChild
-import org.jetbrains.kotlin.ir.util.addFakeOverrides
 import org.jetbrains.kotlin.ir.util.addSimpleDelegatingConstructor
 import org.jetbrains.kotlin.ir.util.copyTypeParametersFrom
 import org.jetbrains.kotlin.ir.util.createThisReceiverParameter
@@ -130,26 +129,6 @@ internal fun IrClass.getOrCreateGraphImplClassShell(): IrClass {
             context.metadataDeclarationRegistrarCompat.registerConstructorAsMetadataVisible(this)
           }
       }
-    }
-}
-
-context(context: IrMetroContext)
-internal fun IrClass.getOrCreateGraphFactoryImplShell(): IrClass {
-  return getOrCreateMetadataVisibleHiddenNestedClass(
-      name = Symbols.Names.Impl,
-      origin = Origins.GraphFactoryImplClassDeclaration,
-      superTypesProvider = {
-        listOf(
-          this@getOrCreateGraphFactoryImplShell.symbol.typeWith(
-            typeParameters.map { it.defaultType }
-          )
-        )
-      },
-    )
-    .apply {
-      addMetroImplMarkerAnnotation()
-      addMetadataVisibleDefaultConstructor()
-      addFakeOverrides(context.irTypeSystemContext)
     }
 }
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/DependencyGraphTransformer.kt
@@ -32,12 +32,14 @@ import dev.zacsweers.metro.compiler.ir.ParentContext
 import dev.zacsweers.metro.compiler.ir.ParentContextReader
 import dev.zacsweers.metro.compiler.ir.RuntimeTracingAvailability
 import dev.zacsweers.metro.compiler.ir.UsedKeyCollector
+import dev.zacsweers.metro.compiler.ir.addMetadataVisibleDefaultConstructor
+import dev.zacsweers.metro.compiler.ir.addMetroImplMarkerAnnotation
 import dev.zacsweers.metro.compiler.ir.annotationsIn
 import dev.zacsweers.metro.compiler.ir.chunkSupertypesIfNeeded
 import dev.zacsweers.metro.compiler.ir.computePromotedParents
 import dev.zacsweers.metro.compiler.ir.createIrBuilder
 import dev.zacsweers.metro.compiler.ir.finalizeFakeOverride
-import dev.zacsweers.metro.compiler.ir.getOrCreateGraphFactoryImplShell
+import dev.zacsweers.metro.compiler.ir.getOrCreateMetadataVisibleHiddenNestedClass
 import dev.zacsweers.metro.compiler.ir.graph.BindingGraphGenerator
 import dev.zacsweers.metro.compiler.ir.graph.BindingLookupCache
 import dev.zacsweers.metro.compiler.ir.graph.BindingPropertyContext
@@ -80,6 +82,7 @@ import dev.zacsweers.metro.compiler.tracing.TraceScope
 import dev.zacsweers.metro.compiler.tracing.diagnosticTag
 import dev.zacsweers.metro.compiler.tracing.trace
 import java.util.concurrent.ForkJoinPool
+import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.builders.irBlockBody
@@ -95,6 +98,7 @@ import org.jetbrains.kotlin.ir.overrides.FakeOverrideBuilderStrategy
 import org.jetbrains.kotlin.ir.overrides.IrFakeOverrideBuilder
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.types.defaultType
+import org.jetbrains.kotlin.ir.util.addFakeOverrides
 import org.jetbrains.kotlin.ir.util.classIdOrFail
 import org.jetbrains.kotlin.ir.util.companionObject
 import org.jetbrains.kotlin.ir.util.copyTo
@@ -1011,6 +1015,24 @@ internal class DependencyGraphTransformer(
     } else {
       requireNestedClass(Symbols.Names.Impl)
     }
+  }
+
+  context(context: IrMetroContext)
+  private fun IrClass.getOrCreateGraphFactoryImplShell(): IrClass {
+    return getOrCreateMetadataVisibleHiddenNestedClass(
+        name = Symbols.Names.Impl,
+        origin = Origins.GraphFactoryImplClassDeclaration,
+        kind = ClassKind.OBJECT,
+        superTypesProvider = {
+          listOf(this@getOrCreateGraphFactoryImplShell.symbol.defaultType)
+        },
+        copyTypeParameters = false,
+      )
+      .apply {
+        addMetroImplMarkerAnnotation()
+        addMetadataVisibleDefaultConstructor()
+        addFakeOverrides(context.irTypeSystemContext)
+      }
   }
 }
 


### PR DESCRIPTION
Resolves #2506