### PR TITLE
Fix JS box test flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Run JS box tests
         if: github.ref == 'refs/heads/main'
         run: |
-          ./gradlew :compiler-tests:test --continue --quiet -Pmetro.jsBoxTestRetries=3 \
+          ./gradlew :compiler-tests:test --continue --quiet \
             --tests 'dev.zacsweers.metro.compiler.JsBoxTestGenerated*' \
             --tests 'dev.zacsweers.metro.compiler.JsFastInitBoxTestGenerated*' \
             --tests 'dev.zacsweers.metro.compiler.JsContributionProvidersBoxTestGenerated*'

--- a/compiler-tests/build.gradle.kts
+++ b/compiler-tests/build.gradle.kts
@@ -19,7 +19,6 @@ import org.jetbrains.kotlin.tooling.core.toKotlinVersion
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.buildConfig)
-  alias(libs.plugins.gradleTestRetry)
   java
 }
 
@@ -304,8 +303,6 @@ val generateTests =
 
 val largeTestMode = providers.gradleProperty("metro.enableLargeTests").isPresent
 val excludeJsBoxTests = providers.gradleProperty("metro.excludeJsBoxTests").isPresent
-val jsBoxTestRetries =
-  providers.gradleProperty("metro.jsBoxTestRetries").map(String::toInt).orElse(0)
 
 tasks.withType<Test> {
   outputs.upToDateWhen { false }
@@ -369,12 +366,6 @@ tasks.withType<Test> {
   }
 
   useJUnitPlatform()
-
-  retry {
-    maxRetries.set(jsBoxTestRetries)
-    failOnPassedAfterRetry.set(false)
-    failOnSkippedAfterRetry.set(true)
-  }
 
   if (largeTestMode) {
     filter { includeTestsMatching("*StressTest*") }

--- a/compiler-tests/src/generator230/kotlin/dev/zacsweers/metro/compiler/AbstractJsBoxTest.kt
+++ b/compiler-tests/src/generator230/kotlin/dev/zacsweers/metro/compiler/AbstractJsBoxTest.kt
@@ -4,10 +4,22 @@ package dev.zacsweers.metro.compiler
 
 import org.jetbrains.kotlin.js.test.fir.AbstractFirJsTest
 import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives
 
 open class KotlinJsBoxTestBase :
   AbstractFirJsTest(
     pathToTestDir = "compiler-tests/src/test/data/box",
     testGroupOutputDirPrefix = "box/js/",
     parser = FirParser.LightTree,
-  )
+  ) {
+  override fun configure(builder: TestConfigurationBuilder) =
+    with(builder) {
+      // give each JS box test its own output directory, so no race conditions happen
+      defaultDirectives {
+        JsEnvironmentConfigurationDirectives.TEST_GROUP_OUTPUT_DIR_PREFIX with
+          "box/js/${testInfo.className}"
+      }
+      super.configure(builder)
+    }
+}

--- a/compiler-tests/src/generator2320/kotlin/dev/zacsweers/metro/compiler/AbstractJsBoxTest.kt
+++ b/compiler-tests/src/generator2320/kotlin/dev/zacsweers/metro/compiler/AbstractJsBoxTest.kt
@@ -4,10 +4,22 @@ package dev.zacsweers.metro.compiler
 
 import org.jetbrains.kotlin.js.test.runners.AbstractJsTest
 import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives
 
 open class KotlinJsBoxTestBase :
   AbstractJsTest(
     pathToTestDir = "compiler-tests/src/test/data/box",
     testGroupOutputDirPrefix = "box/js/",
     parser = FirParser.LightTree,
-  )
+  ) {
+  override fun configure(builder: TestConfigurationBuilder) =
+    with(builder) {
+      // give each JS box test its own output directory, so no race conditions happen
+      defaultDirectives {
+        JsEnvironmentConfigurationDirectives.TEST_GROUP_OUTPUT_DIR_PREFIX with
+          "box/js/${testInfo.className}"
+      }
+      super.configure(builder)
+    }
+}

--- a/compiler-tests/src/generator240/kotlin/dev/zacsweers/metro/compiler/AbstractJsBoxTest.kt
+++ b/compiler-tests/src/generator240/kotlin/dev/zacsweers/metro/compiler/AbstractJsBoxTest.kt
@@ -4,10 +4,22 @@ package dev.zacsweers.metro.compiler
 
 import org.jetbrains.kotlin.js.test.runners.AbstractJsTest
 import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives
 
 open class KotlinJsBoxTestBase :
   AbstractJsTest(
     pathToTestDir = "compiler-tests/src/test/data/box",
     testGroupOutputDirPrefix = "box/js/",
     parser = FirParser.LightTree,
-  )
+  ) {
+  override fun configure(builder: TestConfigurationBuilder) =
+    with(builder) {
+      // give each JS box test its own output directory, so no race conditions happen
+      defaultDirectives {
+        JsEnvironmentConfigurationDirectives.TEST_GROUP_OUTPUT_DIR_PREFIX with
+          "box/js/${testInfo.className}"
+      }
+      super.configure(builder)
+    }
+}

--- a/compiler-tests/src/generator2420/kotlin/dev/zacsweers/metro/compiler/AbstractJsBoxTest.kt
+++ b/compiler-tests/src/generator2420/kotlin/dev/zacsweers/metro/compiler/AbstractJsBoxTest.kt
@@ -4,10 +4,22 @@ package dev.zacsweers.metro.compiler
 
 import org.jetbrains.kotlin.js.test.runners.AbstractJsTest
 import org.jetbrains.kotlin.test.FirParser
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives
 
 open class KotlinJsBoxTestBase :
   AbstractJsTest(
     pathToTestDir = "compiler-tests/src/test/data/box",
     testGroupOutputDirPrefix = "box/js/",
     parser = FirParser.LightTree,
-  )
+  ) {
+  override fun configure(builder: TestConfigurationBuilder) =
+    with(builder) {
+      // give each JS box test its own output directory, so no race conditions happen
+      defaultDirectives {
+        JsEnvironmentConfigurationDirectives.TEST_GROUP_OUTPUT_DIR_PREFIX with
+          "box/js/${testInfo.className}"
+      }
+      super.configure(builder)
+    }
+}


### PR DESCRIPTION
The solution is to give each test class its own output directory, so that no races happen while trying to copy files in parallel.

In case you approve workflows to run,`testContributedAccessorsCanBeLazy` keeps failing because the `main` I'm basing this on has it failing, too. Once you fix `main`, update this branch, then workflows will pass.