### PR TITLE
Improve actions caching

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Whether to set up konan cache'
     required: false
     default: 'false'
+  konan-cache-read-only:
+    description: 'Whether konan caches are read-only'
+    required: false
+    default: 'true'
   kotlin-compiler-version:
     description: |
       Kotlin compiler version this run targets (e.g. matrix.kotlin-compiler from
@@ -35,14 +39,22 @@ runs:
       uses: gradle/actions/setup-gradle@v6
       with:
         cache-read-only: ${{ inputs.cache-read-only }}
-        gradle-home-cache-strict-match: true
         cache-encryption-key: ${{ inputs.encryption-key }}
         gradle-home-cache-excludes: |
           caches/jars-9
-          caches/transforms-3
+          caches/transforms-*
+          caches/*/transforms
           wrapper/dists
 
+    - name: Restore Gradle wrapper
+      if: inputs.cache-read-only == 'true'
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.gradle/wrapper/dists
+        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+
     - name: Cache Gradle wrapper
+      if: inputs.cache-read-only != 'true'
       uses: actions/cache@v6
       with:
         path: ~/.gradle/wrapper/dists
@@ -56,21 +68,57 @@ runs:
     #     suffix if K/N ever restructures this directory in a backward-incompatible way.
     #
     #  2. `kotlin-native-prebuilt-<os>-<arch>-<version>/` — the per-Kotlin-version compiler
-    #     distribution + bundled klibs. Cached with the explicit `kotlin-compiler-version` input as
-    #     the discriminator, so each matrix entry owns its own prebuilt.
+    #     distribution + bundled klibs. Cached with the resolved Kotlin compiler version as the
+    #     discriminator, so each matrix entry owns its own prebuilt.
     #
     # `~/.konan/cache/` (K/N's incremental compile cache) is also kept on the per-version key —
     # its contents depend on the Kotlin version's compiler output. It may not exist on cold runs;
     # actions/cache silently ignores missing paths.
-    - name: Cache konan toolchain (shared)
+    - name: Resolve Kotlin compiler version
       if: inputs.konan == 'true'
+      id: kotlin-compiler-version
+      shell: bash
+      env:
+        INPUT_KOTLIN_COMPILER_VERSION: ${{ inputs.kotlin-compiler-version }}
+      run: |
+        kotlin_compiler_version="$INPUT_KOTLIN_COMPILER_VERSION"
+        if [[ -z "$kotlin_compiler_version" ]]; then
+          kotlin_compiler_version=$(sed -n 's/^kotlin = "\(.*\)"/\1/p' gradle/libs.versions.toml)
+        fi
+        if [[ -z "$kotlin_compiler_version" ]]; then
+          echo "::error::Could not resolve the Kotlin compiler version"
+          exit 1
+        fi
+        echo "version=$kotlin_compiler_version" >> "$GITHUB_OUTPUT"
+
+    - name: Restore konan toolchain (shared)
+      if: inputs.konan == 'true' && inputs.konan-cache-read-only == 'true'
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.konan/dependencies
+        key: ${{ runner.os }}-konan-deps-v1
+
+    - name: Cache konan toolchain (shared)
+      if: inputs.konan == 'true' && inputs.konan-cache-read-only != 'true'
       uses: actions/cache@v6
       with:
         path: ~/.konan/dependencies
         key: ${{ runner.os }}-konan-deps-v1
 
+    - name: Restore konan klibs (per Kotlin version)
+      if: inputs.konan == 'true' && inputs.konan-cache-read-only == 'true'
+      uses: actions/cache/restore@v6
+      with:
+        path: |
+          ~/.konan/cache
+          ~/.konan/kotlin-native-prebuilt-linux*
+          ~/.konan/kotlin-native-prebuilt-macos*
+          ~/.konan/kotlin-native-prebuilt-mingw*
+          ~/.konan/kotlin-native-prebuilt-windows*
+        key: ${{ runner.os }}-konan-klibs-${{ steps.kotlin-compiler-version.outputs.version }}
+
     - name: Cache konan klibs (per Kotlin version)
-      if: inputs.konan == 'true'
+      if: inputs.konan == 'true' && inputs.konan-cache-read-only != 'true'
       uses: actions/cache@v6
       with:
         path: |
@@ -79,4 +127,4 @@ runs:
           ~/.konan/kotlin-native-prebuilt-macos*
           ~/.konan/kotlin-native-prebuilt-mingw*
           ~/.konan/kotlin-native-prebuilt-windows*
-        key: ${{ runner.os }}-konan-klibs-${{ inputs.kotlin-compiler-version || 'default' }}
+        key: ${{ runner.os }}-konan-klibs-${{ steps.kotlin-compiler-version.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,25 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
+      default_kotlin_version: ${{ steps.generate.outputs.default_kotlin_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Generate matrix
         id: generate
-        run: ./scripts/generate-ci-matrix.sh
+        run: |
+          ./scripts/generate-ci-matrix.sh
+          default_kotlin_version=$(sed -n 's/^kotlin = "\(.*\)"/\1/p' gradle/libs.versions.toml)
+          if [[ -z "$default_kotlin_version" ]]; then
+            echo "::error::Could not read the default Kotlin version"
+            exit 1
+          fi
+          if ! grep -Fxq "$default_kotlin_version" compiler-compat/version-aliases.txt; then
+            echo "::error::Default Kotlin version $default_kotlin_version is not in the compiler matrix"
+            exit 1
+          fi
+          echo "default_kotlin_version=$default_kotlin_version" >> "$GITHUB_OUTPUT"
 
   core:
     name: "core artifacts / ${{ matrix.kotlin-compiler }}"
@@ -78,8 +90,10 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          # Keep one Linux Gradle cache writer, using the repository's default Kotlin version.
+          cache-read-only: ${{ github.ref != 'refs/heads/main' || matrix.kotlin-compiler != needs.generate-matrix.outputs.default_kotlin_version }}
           konan: true
+          konan-cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           kotlin-compiler-version: ${{ matrix.kotlin-compiler }}
 
       - name: Check root project
@@ -122,7 +136,7 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: true
 
       - name: Generate tests
         run: ./gradlew :compiler-tests:generateTests --quiet ${{ github.ref != 'refs/heads/main' && '-Dorg.gradle.configuration-cache.read-only=true' || '' }}
@@ -186,12 +200,9 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: true
+          # These jobs restore the versioned Konan cache written by the default Kotlin core lane.
           konan: true
-          # All 3 matrix targets here run against the default Kotlin version (from libs.versions.toml)
-          # so they share the same `<os>-konan-klibs-default` cache key. Only the linuxX64 target
-          # actually populates `~/.konan/kotlin-native-prebuilt-linux-*/`; the js and wasmJs entries
-          # don't touch ~/.konan/ but cleanly read whatever the linuxX64 entry saved.
 
       - name: ':gradle-plugin:functionalTest'
         if: github.ref == 'refs/heads/main'
@@ -226,7 +237,7 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: true
           konan: true
 
       - name: Check samples
@@ -264,7 +275,7 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: true
 
       - name: Test idea-plugin
         run: ./gradlew -p idea-plugin test --quiet ${{ github.ref != 'refs/heads/main' && '-Dorg.gradle.configuration-cache.read-only=true' || '' }}
@@ -318,8 +329,10 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          # The core job writes Linux caches; these lanes only write their host-specific caches.
+          cache-read-only: ${{ github.ref != 'refs/heads/main' || matrix.os == 'ubuntu-latest' }}
           konan: true
+          konan-cache-read-only: ${{ github.ref != 'refs/heads/main' || matrix.os == 'ubuntu-latest' }}
 
       - name: Check runtime and IC tests
         if: github.ref == 'refs/heads/main'
@@ -359,7 +372,7 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: true
           konan: true
 
       - name: Build Metro benchmark
@@ -411,7 +424,7 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: true
           konan: true
 
       - name: Upload snapshot

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: true
 
       - name: Generate API docs
         # NOTE: The `dokkaPublications.html` task is pre-configured to generate HTML in `/docs/api`.

--- a/.github/workflows/ide-integration.yml
+++ b/.github/workflows/ide-integration.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/setup-gradle
         with:
           encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: true
           konan: true
 
       - name: Publish Metro to functionalTestRepo
@@ -108,7 +108,7 @@ jobs:
             uses: ./.github/actions/setup-gradle
             with:
               encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-              cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+              cache-read-only: true
 
           - name: Install aria2 and xvfb
             run: |


### PR DESCRIPTION
- Reduced large Gradle/wrapper cache writers from 35 to 3 per normal main push: one each for Linux, macOS, and Windows.
- Made IDE, docs, publish, samples, benchmarks, and satellite CI jobs restore-only. 
- Excluded all current Gradle transform-cache layouts and removed strict cache matching. 
- Made explicit wrapper/Konan reader paths use the restore-only cache action, avoiding post-job saves.
- Replaced the shared default Konan key with the resolved Kotlin version. Main compiler-version lanes can still populate their stable, version-specific Konan caches.