### PR TITLE
Fix suspend param deduping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ _2026-07-13_
 
 Special thanks to the following contributors for contributing to this release!
 
+- [@kevinguitar](https://github.com/kevinguitar)
 - [@kyay10](https://github.com/kyay10)
 
 ### [Consider sponsoring Metro's development](https://www.zacsweers.dev/sponsoring-metro/)

--- a/compiler-tests/src/test/data/box/contributesgraphextension/DuplicatedDepInBinding.kt
+++ b/compiler-tests/src/test/data/box/contributesgraphextension/DuplicatedDepInBinding.kt
@@ -1,5 +1,3 @@
-// ENABLE_SUSPEND_PROVIDERS
-
 // MODULE: lib
 interface Foo
 

--- a/compiler-tests/src/test/data/box/suspend/DuplicatedDepInBinding.kt
+++ b/compiler-tests/src/test/data/box/suspend/DuplicatedDepInBinding.kt
@@ -1,36 +1,27 @@
 // ENABLE_SUSPEND_PROVIDERS
 
-// MODULE: api
+// MODULE: lib
 interface Foo
-interface Bar
 
-@BindingContainer
-object BarProvider {
-  @Provides
-  fun provideBar(): Bar = object : Bar {}
-}
-
-// MODULE: impl(api)
 @Inject
 @ContributesBinding(Unit::class)
 class FooImpl(
-  private val bar: Bar,
-  duplicatedBar: Bar,
+  private val int: Int,
+  duplicatedInt: Int,
 ) : Foo
 
-// MODULE: main(api, impl)
+// MODULE: main(lib)
 @DependencyGraph(AppScope::class)
-interface AppGraph
+interface AppGraph {
+  val featureGraph: FeatureGraph
+}
 
-@GraphExtension(Unit::class, bindingContainers = [BarProvider::class])
+@GraphExtension(Unit::class)
 interface FeatureGraph {
   val viewModel: ViewModel
 
-  @ContributesTo(AppScope::class)
-  @GraphExtension.Factory
-  interface Factory {
-    fun createFeatureGraph(): FeatureGraph
-  }
+  @Provides
+  fun provideInt(): Int = 3
 }
 
 interface ViewModel
@@ -42,8 +33,7 @@ class ViewModelImpl(foo: Foo): ViewModel
 
 fun box(): String {
   val appGraph = createGraph<AppGraph>()
-  val featureGraph = appGraph.createFeatureGraph()
-  assertNotNull(featureGraph.viewModel)
+  assertNotNull(appGraph.featureGraph.viewModel)
 
   return "OK"
 }

--- a/compiler-tests/src/test/data/box/suspend/DuplicatedDepInBinding.kt
+++ b/compiler-tests/src/test/data/box/suspend/DuplicatedDepInBinding.kt
@@ -24,6 +24,7 @@ interface AppGraph
 
 @GraphExtension(Unit::class, bindingContainers = [BarProvider::class])
 interface FeatureGraph {
+  val viewModel: ViewModel
 
   @ContributesTo(AppScope::class)
   @GraphExtension.Factory
@@ -32,10 +33,17 @@ interface FeatureGraph {
   }
 }
 
+interface ViewModel
+
+@SingleIn(Unit::class)
+@Inject
+@ContributesBinding(Unit::class)
+class ViewModelImpl(foo: Foo): ViewModel
+
 fun box(): String {
   val appGraph = createGraph<AppGraph>()
   val featureGraph = appGraph.createFeatureGraph()
-  assertNotNull(featureGraph)
+  assertNotNull(featureGraph.viewModel)
 
   return "OK"
 }

--- a/compiler-tests/src/test/data/box/suspend/DuplicatedDepInBinding.kt
+++ b/compiler-tests/src/test/data/box/suspend/DuplicatedDepInBinding.kt
@@ -1,0 +1,41 @@
+// ENABLE_SUSPEND_PROVIDERS
+
+// MODULE: api
+interface Foo
+interface Bar
+
+@BindingContainer
+object BarProvider {
+  @Provides
+  fun provideBar(): Bar = object : Bar {}
+}
+
+// MODULE: impl(api)
+@Inject
+@ContributesBinding(Unit::class)
+class FooImpl(
+  private val bar: Bar,
+  duplicatedBar: Bar,
+) : Foo
+
+// MODULE: main(api, impl)
+@DependencyGraph(AppScope::class)
+interface AppGraph
+
+@GraphExtension(Unit::class, bindingContainers = [BarProvider::class])
+interface FeatureGraph {
+
+  @ContributesTo(AppScope::class)
+  @GraphExtension.Factory
+  interface Factory {
+    fun createFeatureGraph(): FeatureGraph
+  }
+}
+
+fun box(): String {
+  val appGraph = createGraph<AppGraph>()
+  val featureGraph = appGraph.createFeatureGraph()
+  assertNotNull(featureGraph)
+
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -3421,6 +3421,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("FullBindingGraphValidationSuspendPropagation.kt")
     public void testFullBindingGraphValidationSuspendPropagation() {
       run("FullBindingGraphValidationSuspendPropagation.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -947,6 +947,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("ParentIncludesArePropgatedToExtensions.kt")
     public void testParentIncludesArePropgatedToExtensions() {
       run("ParentIncludesArePropgatedToExtensions.kt");
@@ -3418,12 +3424,6 @@ public class BoxTestGenerated extends AbstractBoxTest {
     @TestMetadata("DepInConstructorInjectedAccessor.kt")
     public void testDepInConstructorInjectedAccessor() {
       run("DepInConstructorInjectedAccessor.kt");
-    }
-
-    @Test
-    @TestMetadata("DuplicatedDepInBinding.kt")
-    public void testDuplicatedDepInBinding() {
-      run("DuplicatedDepInBinding.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -3421,6 +3421,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("FullBindingGraphValidationSuspendPropagation.kt")
     public void testFullBindingGraphValidationSuspendPropagation() {
       run("FullBindingGraphValidationSuspendPropagation.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -947,6 +947,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("ParentIncludesArePropgatedToExtensions.kt")
     public void testParentIncludesArePropgatedToExtensions() {
       run("ParentIncludesArePropgatedToExtensions.kt");
@@ -3418,12 +3424,6 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     @TestMetadata("DepInConstructorInjectedAccessor.kt")
     public void testDepInConstructorInjectedAccessor() {
       run("DepInConstructorInjectedAccessor.kt");
-    }
-
-    @Test
-    @TestMetadata("DuplicatedDepInBinding.kt")
-    public void testDuplicatedDepInBinding() {
-      run("DuplicatedDepInBinding.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -3421,6 +3421,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("FullBindingGraphValidationSuspendPropagation.kt")
     public void testFullBindingGraphValidationSuspendPropagation() {
       run("FullBindingGraphValidationSuspendPropagation.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -947,6 +947,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("ParentIncludesArePropgatedToExtensions.kt")
     public void testParentIncludesArePropgatedToExtensions() {
       run("ParentIncludesArePropgatedToExtensions.kt");
@@ -3418,12 +3424,6 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     @TestMetadata("DepInConstructorInjectedAccessor.kt")
     public void testDepInConstructorInjectedAccessor() {
       run("DepInConstructorInjectedAccessor.kt");
-    }
-
-    @Test
-    @TestMetadata("DuplicatedDepInBinding.kt")
-    public void testDuplicatedDepInBinding() {
-      run("DuplicatedDepInBinding.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
@@ -947,6 +947,12 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("ParentIncludesArePropgatedToExtensions.kt")
     public void testParentIncludesArePropgatedToExtensions() {
       run("ParentIncludesArePropgatedToExtensions.kt");
@@ -3418,12 +3424,6 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
     @TestMetadata("DepInConstructorInjectedAccessor.kt")
     public void testDepInConstructorInjectedAccessor() {
       run("DepInConstructorInjectedAccessor.kt");
-    }
-
-    @Test
-    @TestMetadata("DuplicatedDepInBinding.kt")
-    public void testDuplicatedDepInBinding() {
-      run("DuplicatedDepInBinding.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
@@ -3421,6 +3421,12 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("FullBindingGraphValidationSuspendPropagation.kt")
     public void testFullBindingGraphValidationSuspendPropagation() {
       run("FullBindingGraphValidationSuspendPropagation.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
@@ -679,6 +679,12 @@ public class JsBoxTestGenerated extends AbstractJsBoxTest {
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("ParentIncludesArePropgatedToExtensions.kt")
     public void testParentIncludesArePropgatedToExtensions() {
       run("ParentIncludesArePropgatedToExtensions.kt");
@@ -2602,12 +2608,6 @@ public class JsBoxTestGenerated extends AbstractJsBoxTest {
     @TestMetadata("DepInConstructorInjectedAccessor.kt")
     public void testDepInConstructorInjectedAccessor() {
       run("DepInConstructorInjectedAccessor.kt");
-    }
-
-    @Test
-    @TestMetadata("DuplicatedDepInBinding.kt")
-    public void testDuplicatedDepInBinding() {
-      run("DuplicatedDepInBinding.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
@@ -2605,6 +2605,12 @@ public class JsBoxTestGenerated extends AbstractJsBoxTest {
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("FullBindingGraphValidationSuspendPropagation.kt")
     public void testFullBindingGraphValidationSuspendPropagation() {
       run("FullBindingGraphValidationSuspendPropagation.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
@@ -2605,6 +2605,12 @@ public class JsContributionProvidersBoxTestGenerated extends AbstractJsContribut
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("FullBindingGraphValidationSuspendPropagation.kt")
     public void testFullBindingGraphValidationSuspendPropagation() {
       run("FullBindingGraphValidationSuspendPropagation.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
@@ -679,6 +679,12 @@ public class JsContributionProvidersBoxTestGenerated extends AbstractJsContribut
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("ParentIncludesArePropgatedToExtensions.kt")
     public void testParentIncludesArePropgatedToExtensions() {
       run("ParentIncludesArePropgatedToExtensions.kt");
@@ -2602,12 +2608,6 @@ public class JsContributionProvidersBoxTestGenerated extends AbstractJsContribut
     @TestMetadata("DepInConstructorInjectedAccessor.kt")
     public void testDepInConstructorInjectedAccessor() {
       run("DepInConstructorInjectedAccessor.kt");
-    }
-
-    @Test
-    @TestMetadata("DuplicatedDepInBinding.kt")
-    public void testDuplicatedDepInBinding() {
-      run("DuplicatedDepInBinding.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
@@ -2605,6 +2605,12 @@ public class JsFastInitBoxTestGenerated extends AbstractJsFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("FullBindingGraphValidationSuspendPropagation.kt")
     public void testFullBindingGraphValidationSuspendPropagation() {
       run("FullBindingGraphValidationSuspendPropagation.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
@@ -679,6 +679,12 @@ public class JsFastInitBoxTestGenerated extends AbstractJsFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("DuplicatedDepInBinding.kt")
+    public void testDuplicatedDepInBinding() {
+      run("DuplicatedDepInBinding.kt");
+    }
+
+    @Test
     @TestMetadata("ParentIncludesArePropgatedToExtensions.kt")
     public void testParentIncludesArePropgatedToExtensions() {
       run("ParentIncludesArePropgatedToExtensions.kt");
@@ -2602,12 +2608,6 @@ public class JsFastInitBoxTestGenerated extends AbstractJsFastInitBoxTest {
     @TestMetadata("DepInConstructorInjectedAccessor.kt")
     public void testDepInConstructorInjectedAccessor() {
       run("DepInConstructorInjectedAccessor.kt");
-    }
-
-    @Test
-    @TestMetadata("DuplicatedDepInBinding.kt")
-    public void testDuplicatedDepInBinding() {
-      run("DuplicatedDepInBinding.kt");
     }
 
     @Test

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/factoryIrUtil.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/factoryIrUtil.kt
@@ -25,6 +25,7 @@ import dev.zacsweers.metro.compiler.ir.irCallConstructorWithSameParameters
 import dev.zacsweers.metro.compiler.ir.irExprBodySafe
 import dev.zacsweers.metro.compiler.ir.parameters.Parameter
 import dev.zacsweers.metro.compiler.ir.parameters.Parameters
+import dev.zacsweers.metro.compiler.ir.parameters.dedupeParameters
 import dev.zacsweers.metro.compiler.ir.parameters.parameters
 import dev.zacsweers.metro.compiler.ir.regularParameters
 import dev.zacsweers.metro.compiler.ir.replaceAnnotationsCompat
@@ -450,13 +451,20 @@ internal fun generateStubCreatorFunctions(
 ) {
   val creatorClass = factoryClass.requireStaticIshDeclarationContainer()
 
-  val params = sourceFunction.parameters().nonDispatchParameters
+  val sourceParameters = sourceFunction.parameters()
+  val createParameters =
+    sourceParameters.copy(
+      regularParameters =
+        sourceParameters.regularParameters.dedupeParameters(
+          defaultUsesSuspendProvider = sourceFunction.isSuspend
+        )
+    )
 
   // create() function, parameters are Provider-wrapped
   creatorClass.addFunction(Symbols.StringNames.CREATE, factoryClass.defaultType).apply {
     setDispatchReceiver(creatorClass.thisReceiverOrFail.copyTo(this))
     addParameters(
-      params,
+      createParameters.nonDispatchParameters,
       wrapInProvider = true,
       copyQualifiers = true,
       wrapInSuspendProvider = sourceFunction.isSuspend,
@@ -469,7 +477,11 @@ internal fun generateStubCreatorFunctions(
   creatorClass.addFunction(callableName, returnType).apply {
     isSuspend = sourceFunction.isSuspend
     setDispatchReceiver(creatorClass.thisReceiverOrFail.copyTo(this))
-    addParameters(params, wrapInProvider = false, copyQualifiers = true)
+    addParameters(
+      sourceParameters.nonDispatchParameters,
+      wrapInProvider = false,
+      copyQualifiers = true,
+    )
     addStaticAnnotations(this)
     body = context.createIrBuilder(symbol).run { irExprBodySafe(stubExpression()) }
   }


### PR DESCRIPTION
It fails only when `generateContributionProviders` is set to true, and `enableSwitchingProviders` is set to false

Stacktrace:
```
'FooImplContributions$ToUnit$ProvideFooImplAsFooMetroFactory FooImplContributions$ToUnit$ProvideFooImplAsFooMetroFactory$Companion.create(dev.zacsweers.metro.Provider, dev.zacsweers.metro.Provider)'
java.lang.NoSuchMethodError: 'FooImplContributions$ToUnit$ProvideFooImplAsFooMetroFactory FooImplContributions$ToUnit$ProvideFooImplAsFooMetroFactory$Companion.create(dev.zacsweers.metro.Provider, dev.zacsweers.metro.Provider)'
	at AppGraph$Impl$FeatureGraphImpl.<init>(module_main_DuplicatedDepInBinding.kt)
	at AppGraph$Impl.getFeatureGraph(module_main_DuplicatedDepInBinding.kt:15)
	at Module_main_DuplicatedDepInBindingKt.box(module_main_DuplicatedDepInBinding.kt:37)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
```