### PR TITLE
Route switching providers directly to their chunked invokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This release introduces experimental support for suspend providers. This is disa
 ### Enhancements
 
 - **[IR]** Avoid generating unused provider fields for included graph accessors that can be read directly.
+- **[IR]** Avoid linear helper traversal in large switching providers by routing directly to the matching chunk.
 - **[runtime]** If the input function to `provider()` is already a `Provider` instance, return it directly rather than needlessly wrap it.
 - **[runtime]** Support nullable values in ordinary map multibinding factories, including provider and lazy map value forms.
 

--- a/compiler-tests/src/test/data/box/bytecode/SwitchingProvidersGenerateTableSwitch.kt
+++ b/compiler-tests/src/test/data/box/bytecode/SwitchingProvidersGenerateTableSwitch.kt
@@ -1,4 +1,5 @@
 // ENABLE_SWITCHING_PROVIDERS: true
+// STATEMENTS_PER_INIT_FUN: 2
 
 @SingleIn(AppScope::class)
 @Inject
@@ -12,11 +13,26 @@ class Thing2
 @Inject
 class Thing3
 
+@SingleIn(AppScope::class)
+@Inject
+class Thing4
+
+@SingleIn(AppScope::class)
+@Inject
+class Thing5
+
+@SingleIn(AppScope::class)
+@Inject
+class Thing6
+
 @DependencyGraph(AppScope::class)
 interface AppGraph {
   val thing1: Thing1
   val thing2: Thing2
   val thing3: Thing3
+  val thing4: Thing4
+  val thing5: Thing5
+  val thing6: Thing6
 }
 
 fun box(): String {
@@ -24,14 +40,17 @@ fun box(): String {
   assertNotNull(graph.thing1)
   assertNotNull(graph.thing2)
   assertNotNull(graph.thing3)
+  assertNotNull(graph.thing4)
+  assertNotNull(graph.thing5)
+  assertNotNull(graph.thing6)
   return "OK"
 }
 
 // <count> <instruction>
-// Asserts that we use tableswitch and not fall-through equals checks
+// Asserts that invoke() routes directly to one helper and all switches lower to tableswitch.
 // CHECK_BYTECODE_TEXT
+// @AppGraph$Impl$SwitchingProvider.class:
 // 0 Intrinsics.areEqual
 // 0 IF_ICMPNE
-// 1 TABLESWITCH
-// 1 ISTORE 1
-// 1 GETFIELD AppGraph\$Impl\$SwitchingProvider\.id : I
+// 1 IDIV
+// 4 TABLESWITCH

--- a/compiler-tests/src/test/data/box/dependencygraph/sharding/MinimalGraphSharding.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/sharding/MinimalGraphSharding.kt
@@ -1,5 +1,6 @@
 // KEYS_PER_GRAPH_SHARD: 2
 // ENABLE_GRAPH_SHARDING: true
+// STATEMENTS_PER_INIT_FUN: 1
 
 /*
  * This test verifies basic graph sharding with a linear dependency chain.
@@ -8,6 +9,8 @@
  * Expected shards: 2 shards
  * - Shard1: Service1, Service2
  * - Shard2: Service3
+ *
+ * The FastInit variant also forces direct multi-chunk routing inside the two-binding shard.
  *
  * Validation: Dependency chain works correctly across shard boundaries
  */

--- a/compiler-tests/src/test/data/dump/ir/dependencygraph/switchingproviders/ChunkedSwitchingProvider.kt
+++ b/compiler-tests/src/test/data/dump/ir/dependencygraph/switchingproviders/ChunkedSwitchingProvider.kt
@@ -2,13 +2,11 @@
 // STATEMENTS_PER_INIT_FUN: 2
 
 /**
- * Tests that SwitchingProvider correctly chunks its when branches across multiple private helper
- * functions when the number of bindings exceeds STATEMENTS_PER_INIT_FUN.
+ * Tests that SwitchingProvider routes directly to chunked when branches when the number of
+ * bindings exceeds STATEMENTS_PER_INIT_FUN.
  *
- * With STATEMENTS_PER_INIT_FUN=2, the 5 provider bindings should be split as:
- * - invoke(): handles IDs 0-1, else -> invoke_1()
- * - invoke_1(): handles IDs 2-3, else -> invoke_2()
- * - invoke_2(): handles ID 4, else -> error
+ * With STATEMENTS_PER_INIT_FUN=2, invoke() selects a helper using id / 2. The helpers handle IDs
+ * 0-1, 2-3, and 4 respectively, and each helper throws for an unexpected ID.
  */
 @DependencyGraph(AppScope::class)
 interface AppGraph {

--- a/compiler-tests/src/test/data/dump/ir/dependencygraph/switchingproviders/ChunkedSwitchingProvider.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/dependencygraph/switchingproviders/ChunkedSwitchingProvider.kt.txt
@@ -262,10 +262,12 @@ interface AppGraph {
       override fun invoke(): T {
         return { // BLOCK
           val tmp0_id: Int = <this>.#id
+          val tmp1_selector: Int = tmp0_id.div(other = 2)
           when {
-            EQEQ(arg0 = tmp0_id, arg1 = 4) -> ClassA() /*as T */
-            EQEQ(arg0 = tmp0_id, arg1 = 3) -> ClassB() /*as T */
-            else -> <this>.invoke3()
+            EQEQ(arg0 = tmp1_selector, arg1 = 0) -> <this>.invoke2()
+            EQEQ(arg0 = tmp1_selector, arg1 = 1) -> <this>.invoke3()
+            EQEQ(arg0 = tmp1_selector, arg1 = 2) -> <this>.invoke4()
+            else -> throw error(message = "Unexpected SwitchingProvider id: " + tmp0_id)
           }
         }
       }
@@ -274,6 +276,7 @@ interface AppGraph {
         return { // BLOCK
           val tmp0_id: Int = <this>.#id
           when {
+            EQEQ(arg0 = tmp0_id, arg1 = 1) -> ClassD() /*as T */
             EQEQ(arg0 = tmp0_id, arg1 = 0) -> ClassE() /*as T */
             else -> throw error(message = "Unexpected SwitchingProvider id: " + tmp0_id)
           }
@@ -284,9 +287,19 @@ interface AppGraph {
         return { // BLOCK
           val tmp0_id: Int = <this>.#id
           when {
+            EQEQ(arg0 = tmp0_id, arg1 = 3) -> ClassB() /*as T */
             EQEQ(arg0 = tmp0_id, arg1 = 2) -> ClassC() /*as T */
-            EQEQ(arg0 = tmp0_id, arg1 = 1) -> ClassD() /*as T */
-            else -> <this>.invoke2()
+            else -> throw error(message = "Unexpected SwitchingProvider id: " + tmp0_id)
+          }
+        }
+      }
+
+      private fun invoke4(): T {
+        return { // BLOCK
+          val tmp0_id: Int = <this>.#id
+          when {
+            EQEQ(arg0 = tmp0_id, arg1 = 4) -> ClassA() /*as T */
+            else -> throw error(message = "Unexpected SwitchingProvider id: " + tmp0_id)
           }
         }
       }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/SwitchingProviderGenerator.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/SwitchingProviderGenerator.kt
@@ -103,6 +103,17 @@ internal class SwitchingProviderGenerator(
     val contextKey: IrContextualTypeKey,
   )
 
+  /**
+   * Groups switching bindings that route through the same helper function.
+   *
+   * @param selector The quotient produced by dividing each binding ID by the chunk size
+   * @param bindings The bindings dispatched by the helper selected by [selector]
+   */
+  private data class SwitchingBindingGroup(
+    val selector: Int,
+    val bindings: List<SwitchingBinding>,
+  )
+
   data class SwitchingProvider(val irClass: IrClass, val constructor: IrConstructor)
 
   /**
@@ -199,8 +210,9 @@ internal class SwitchingProviderGenerator(
   /**
    * Adds the `invoke(): T` function that implements Provider<T>.
    *
-   * If there are more bindings than [MetroOptions.statementsPerInitFun], the switch branches are
-   * chunked across multiple private helper functions to avoid JVM method size limits.
+   * If there are more bindings than [MetroOptions.statementsPerInitFun], bindings are grouped by
+   * their ID divided by that limit. The main function selects one private helper directly to avoid
+   * both JVM method size limits and a linear chain of helper calls.
    */
   private fun IrClass.addInvokeFunction(
     typeParam: IrTypeParameter,
@@ -208,53 +220,56 @@ internal class SwitchingProviderGenerator(
     idProperty: IrProperty,
   ) {
     val chunkSize = options.statementsPerInitFun
-    val bindingChunks = switchingBindings.chunked(chunkSize)
 
-    // Create helper functions for overflow chunks (in reverse order to wire up else -> calls)
-    val chunkFunctions = ArrayList<IrSimpleFunction>(bindingChunks.size)
+    if (switchingBindings.size <= chunkSize) {
+      addMainInvokeFunction(
+        bindings = switchingBindings,
+        typeParam = typeParam,
+        graphProperty = graphProperty,
+        idProperty = idProperty,
+      )
+      return
+    }
+
+    val bindingGroups =
+      switchingBindings
+        .groupBy { it.id / chunkSize }
+        .map { (selector, bindings) -> SwitchingBindingGroup(selector, bindings) }
+        .sortedBy { it.selector }
+
     val invokeNameAllocator =
       NameAllocator(mode = NameAllocator.Mode.COUNT).apply {
         // reserve the initial invoke() function name that we'll override
         reserveName(Symbols.StringNames.INVOKE)
       }
+    val groupFunctions = ArrayList<Pair<Int, IrSimpleFunction>>(bindingGroups.size)
 
-    for (chunkIndex in (1 until bindingChunks.size).reversed()) {
-      val chunk = bindingChunks[chunkIndex]
-      val isLast = chunkIndex == bindingChunks.lastIndex
-      val nextFunction = chunkFunctions.firstOrNull()
-
-      val chunkFunction =
+    for ((selector, bindings) in bindingGroups) {
+      val groupFunction =
         addInvokeChunkFunction(
-          chunk = chunk,
+          bindings = bindings,
           typeParam = typeParam,
           graphProperty = graphProperty,
           idProperty = idProperty,
-          isLast = isLast,
-          nextFunction = nextFunction,
           nameAllocator = invokeNameAllocator,
         )
-      chunkFunctions.add(0, chunkFunction)
+      groupFunctions += selector to groupFunction
     }
 
-    // Create main invoke function with first chunk
-    addMainInvokeFunction(
-      firstChunk = bindingChunks.first(),
+    addRoutingInvokeFunction(
+      groupFunctions = groupFunctions,
+      chunkSize = chunkSize,
       typeParam = typeParam,
-      graphProperty = graphProperty,
       idProperty = idProperty,
-      nextFunction = chunkFunctions.firstOrNull(),
-      isOnly = bindingChunks.size == 1,
     )
   }
 
-  /** Adds the main `invoke(): T` function with the first chunk of bindings. */
+  /** Adds the main `invoke(): T` function when all bindings fit in one switch. */
   private fun IrClass.addMainInvokeFunction(
-    firstChunk: List<SwitchingBinding>,
+    bindings: List<SwitchingBinding>,
     typeParam: IrTypeParameter,
     graphProperty: IrProperty,
     idProperty: IrProperty,
-    nextFunction: IrSimpleFunction?,
-    isOnly: Boolean,
   ) {
     addFunction {
       name = Symbols.Names.invoke
@@ -273,28 +288,59 @@ internal class SwitchingProviderGenerator(
         body =
           withIrBuilder(symbol) {
             irExprBodySafe(
-              generateChunkedWhenExpression(
-                bindings = firstChunk,
+              generateBindingWhenExpression(
+                bindings = bindings,
                 switchingProviderThisReceiver = localDispatchReceiver,
                 graphProperty = graphProperty,
                 idProperty = idProperty,
                 typeParam = typeParam,
-                isLast = isOnly,
-                nextFunction = nextFunction,
               )
             )
           }
       }
   }
 
-  /** Adds a private helper function for a chunk of bindings beyond the first. */
+  /** Adds the main `invoke(): T` function that routes directly to one binding group. */
+  private fun IrClass.addRoutingInvokeFunction(
+    groupFunctions: List<Pair<Int, IrSimpleFunction>>,
+    chunkSize: Int,
+    typeParam: IrTypeParameter,
+    idProperty: IrProperty,
+  ) {
+    addFunction {
+      name = Symbols.Names.invoke
+      returnType = typeParam.defaultType
+    }
+      .apply {
+        val localDispatchReceiver =
+          this@addRoutingInvokeFunction.thisReceiverOrFail.copyTo(
+            this,
+            type = this@addRoutingInvokeFunction.defaultType,
+          )
+        setDispatchReceiver(localDispatchReceiver)
+        overriddenSymbols = listOf(metroSymbols.providerInvoke)
+
+        body =
+          withIrBuilder(symbol) {
+            irExprBodySafe(
+              generateRoutingWhenExpression(
+                groupFunctions = groupFunctions,
+                chunkSize = chunkSize,
+                switchingProviderThisReceiver = localDispatchReceiver,
+                idProperty = idProperty,
+                typeParam = typeParam,
+              )
+            )
+          }
+      }
+  }
+
+  /** Adds a private helper function for one binding group. */
   private fun IrClass.addInvokeChunkFunction(
-    chunk: List<SwitchingBinding>,
+    bindings: List<SwitchingBinding>,
     typeParam: IrTypeParameter,
     graphProperty: IrProperty,
     idProperty: IrProperty,
-    isLast: Boolean,
-    nextFunction: IrSimpleFunction?,
     nameAllocator: NameAllocator,
   ): IrSimpleFunction {
     return addFunction {
@@ -313,36 +359,74 @@ internal class SwitchingProviderGenerator(
         body =
           withIrBuilder(symbol) {
             irExprBodySafe(
-              generateChunkedWhenExpression(
-                bindings = chunk,
+              generateBindingWhenExpression(
+                bindings = bindings,
                 switchingProviderThisReceiver = localDispatchReceiver,
                 graphProperty = graphProperty,
                 idProperty = idProperty,
                 typeParam = typeParam,
-                isLast = isLast,
-                nextFunction = nextFunction,
               )
             )
           }
       }
   }
 
-  /**
-   * Generates a `when` expression for a chunk of bindings.
-   *
-   * @param bindings The bindings to include in this chunk
-   * @param isLast If true, the else branch throws an error; otherwise it calls [nextFunction]
-   * @param nextFunction The function to call in the else branch (only used if [isLast] is false)
-   */
+  /** Generates a `when` expression that routes directly to one binding group. */
   context(scope: IrBuilderWithScope)
-  private fun generateChunkedWhenExpression(
+  private fun generateRoutingWhenExpression(
+    groupFunctions: List<Pair<Int, IrSimpleFunction>>,
+    chunkSize: Int,
+    switchingProviderThisReceiver: IrValueParameter,
+    idProperty: IrProperty,
+    typeParam: IrTypeParameter,
+  ): IrExpression =
+    with(scope) {
+      return irBlock(resultType = typeParam.defaultType) {
+        val idLocal =
+          irTemporaryVariable(
+            value = irGetProperty(irGet(switchingProviderThisReceiver), idProperty),
+            nameHint = "id",
+          )
+        +idLocal
+
+        val selectorLocal =
+          irTemporaryVariable(
+            value =
+              irInvoke(
+                dispatchReceiver = irGet(idLocal),
+                callee = metroSymbols.intDiv,
+                args = listOf(irInt(chunkSize)),
+                typeHint = irBuiltIns.intType,
+              ),
+            nameHint = "selector",
+          )
+        +selectorLocal
+
+        val branches = ArrayList<IrBranch>(groupFunctions.size + 1)
+        branches += groupFunctions.map { (selector, function) ->
+          irBranch(
+            condition = irEquals(irGet(selectorLocal), irInt(selector)),
+            result =
+              irInvoke(
+                dispatchReceiver = irGet(switchingProviderThisReceiver),
+                callee = function.symbol,
+              ),
+          )
+        }
+        branches += irElseBranch(generateUnexpectedIdExpression(irGet(idLocal)))
+
+        +irWhen(typeParam.defaultType, branches)
+      }
+    }
+
+  /** Generates a `when` expression for the supplied bindings. */
+  context(scope: IrBuilderWithScope)
+  private fun generateBindingWhenExpression(
     bindings: List<SwitchingBinding>,
     switchingProviderThisReceiver: IrValueParameter,
     graphProperty: IrProperty,
     idProperty: IrProperty,
     typeParam: IrTypeParameter,
-    isLast: Boolean,
-    nextFunction: IrSimpleFunction?,
   ): IrExpression =
     with(scope) {
       // Create a ShardExpressionContext for SwitchingProvider that ensures all property access
@@ -388,23 +472,18 @@ internal class SwitchingProviderGenerator(
           irBranch(condition, result)
         }
 
-        val elseBranchExpr =
-          if (isLast) {
-            val errorString = irConcat()
-            errorString.addArgument(irString("Unexpected SwitchingProvider id: "))
-            errorString.addArgument(irGet(idLocal))
-            irThrow(irInvoke(callee = metroSymbols.stdlibErrorFunction, args = listOf(errorString)))
-          } else {
-            irInvoke(
-              dispatchReceiver = irGet(switchingProviderThisReceiver),
-              callee = nextFunction!!.symbol,
-            )
-          }
-        branches += irElseBranch(elseBranchExpr)
+        branches += irElseBranch(generateUnexpectedIdExpression(irGet(idLocal)))
 
         +irWhen(typeParam.defaultType, branches)
       }
     }
+
+  private fun IrBuilderWithScope.generateUnexpectedIdExpression(id: IrExpression): IrExpression {
+    val errorString = irConcat()
+    errorString.addArgument(irString("Unexpected SwitchingProvider id: "))
+    errorString.addArgument(id)
+    return irThrow(irInvoke(callee = metroSymbols.stdlibErrorFunction, args = listOf(errorString)))
+  }
 
   /** Generates the expression to create the binding instance. */
   private fun IrBuilderWithScope.generateBindingExpression(

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/symbols/Symbols.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/symbols/Symbols.kt
@@ -803,6 +803,20 @@ internal class Symbols(
       .symbol
   }
 
+  val intDiv by lazy {
+    pluginContext.irBuiltIns.intClass.owner.functions
+      .single {
+        it.name.asString() == "div" &&
+          it.hasShape(
+            dispatchReceiver = true,
+            regularParameters = 1,
+            parameterTypes =
+              listOf(pluginContext.irBuiltIns.intType, pluginContext.irBuiltIns.intType),
+          )
+      }
+      .symbol
+  }
+
   val buildMapWithCapacity by lazy {
     builtinsFinder
       .findFunctions(CallableId(stdlibCollections.packageFqName, "buildMap".asName()))


### PR DESCRIPTION
This avoids the sequential fallthrough and uses direct routing to the relevant `invoke()` chunk instead