### PR TITLE
Run JS tests for future versions of Kotlin

### DIFF
--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroTestConfigurator.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroTestConfigurator.kt
@@ -25,10 +25,11 @@ class MetroTestConfigurator(testServices: TestServices) : MetaTestConfigurator(t
     if (MetroDirectives.METRO_IGNORE in directives) return true
 
     if (
-      testServices.isJsBackend() && TEST_COMPILER_TOOLING_VERSION != BUILD_COMPILER_TOOLING_VERSION
+      testServices.isJsBackend() && TEST_COMPILER_TOOLING_VERSION < BUILD_COMPILER_TOOLING_VERSION
     ) {
       // JS box tests compile against Metro's runtime KLIB. KLIB compatibility depends on the
-      // producing compiler, so only run these tests against the compiler version that built it.
+      // producing compiler, so only run these tests against the compiler version that built it or
+      // higher
       return true
     }
 


### PR DESCRIPTION
IIUC, klibs produced by version `2.x` [can be read](https://kotlinlang.org/docs/kotlin-evolution-principles.html#evolving-the-binary-format) by `2.x+3` compiler.
Thus, JS tests can run for versions of Kotlin higher than the build version.
Couldn't figure out the version matrix magic to get CI working on js box tests for these new versions. Running locally with `./ metrow check --all`, everything works just fine!