### PR TITLE
Do not minimize mordant with R8

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -163,6 +163,8 @@ val shadowJar =
     minimize {
       exclude(dependency("dev.zacsweers.metro:compiler-compat.*:.*"))
       exclude(dependency("dev.zacsweers.metro:metro-common:.*"))
+      // Mordant selects its terminal interface via runtime probing and native (JNA) loading
+      exclude(dependency("com.github.ajalt.mordant:.*:.*"))
       r8 {
         // Compat implementations receive callbacks from Kotlin compiler classes on the library
         // classpath, so R8 cannot discover these usages itself.
@@ -173,6 +175,9 @@ val shadowJar =
           -dontwarn com.intellij.**
           -dontwarn org.intellij.**
           -dontwarn org.jetbrains.**
+          # Mordant's native-image/FFM terminal interfaces reference GraalVM SDK and SVM classes
+          -dontwarn org.graalvm.**
+          -dontwarn com.oracle.svm.**
           """
             .trimIndent()
         )


### PR DESCRIPTION
After enabling R8 on the metro compiler (https://github.com/ZacSweers/metro/pull/2571), we observed an issue in our metro-station repo that is using `compileOnly(metro.compiler)`:
https://github.com/bandlab/metro-station/actions/runs/29969341318

It's because the classes from Mordant were removed by R8, excluding Mordant from being minimized fixed the issue.

The stacktrace:
```
org.jetbrains.kotlin.fir.pipeline.IrGenerationExtensionException
	at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.applyIrGenerationExtensions(convertToIr.kt:583)
	at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.runActualizationPipeline(convertToIr.kt:281)
	at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.convertToIrAndActualize(convertToIr.kt:154)
	at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize-MT2kVtw(convertToIr.kt:119)
	at org.jetbrains.kotlin.fir.pipeline.ConvertToIrKt.convertToIrAndActualize-MT2kVtw$default(convertToIr.kt:92)
	at org.jetbrains.kotlin.cli.jvm.compiler.legacy.pipeline.JvmCompilerPipelineKt.convertToIrAndActualizeForJvm-_I1IR-w(jvmCompilerPipeline.kt:95)
	at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:31)
	at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:26)
	at org.jetbrains.kotlin.cli.pipeline.jvm.JvmFir2IrPipelinePhase.executePhase(JvmFir2IrPipelinePhase.kt:20)
	at org.jetbrains.kotlin.test.frontend.fir.Fir2IrCliFacade.transform(Fir2IrCliFacade.kt:48)
	at org.jetbrains.kotlin.test.frontend.fir.Fir2IrCliFacade.transform(Fir2IrCliFacade.kt:25)
	at org.jetbrains.kotlin.test.TestStep$NonGroupingStep$FacadeStep.processModule(TestStep.kt:59)
	at org.jetbrains.kotlin.test.NonGroupingTestRunner.processModule(TestRunner.kt:264)
	at org.jetbrains.kotlin.test.NonGroupingTestRunner.hackyProcessModule(TestRunner.kt:255)
	at org.jetbrains.kotlin.test.NonGroupingTestRunner.processModule$lambda$2(TestRunner.kt:236)
	at org.jetbrains.kotlin.test.TestRunner.runPipelineOnSingleUnit(TestRunner.kt:85)
	at org.jetbrains.kotlin.test.NonGroupingTestRunner.processModule(TestRunner.kt:232)
	at org.jetbrains.kotlin.test.NonGroupingTestRunner.runSteps(TestRunner.kt:198)
	at org.jetbrains.kotlin.test.NonGroupingTestRunner.runTestPipeline(TestRunner.kt:183)
	at org.jetbrains.kotlin.test.NonGroupingTestRunner.runTest(TestRunner.kt:146)
	at org.jetbrains.kotlin.test.NonGroupingTestRunner.runTest$default(TestRunner.kt:143)
	at org.jetbrains.kotlin.test.runners.AbstractKotlinCompilerTest.runTest(AbstractKotlinCompilerTest.kt:119)
	at com.bandlab.metro.station.runners.BoxTestGenerated$Configselector.run(BoxTestGenerated.java:33)
	at com.bandlab.metro.station.runners.BoxTestGenerated$Configselector.testBasic(BoxTestGenerated.java:44)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1394)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1970)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: java.lang.ExceptionInInitializerError
	at dev.zacsweers.metro.compiler.shaded.com.github.ajalt.mordant.terminal.Terminal.<init>(SourceFile:59)
	at dev.zacsweers.metro.compiler.diagnostics.render.MordantStyler.<init>(SourceFile:146)
	at dev.zacsweers.metro.compiler.diagnostics.render.Styler$Companion.<clinit>(SourceFile:139)
	at dev.zacsweers.metro.compiler.diagnostics.render.Styler.<clinit>(SourceFile)
	at dev.zacsweers.metro.compiler.diagnostics.render.RenderProfile.<clinit>(SourceFile:57)
	at dev.zacsweers.metro.compiler.diagnostics.render.RenderProfileKt.renderProfileFor(SourceFile:28)
	at dev.zacsweers.metro.compiler.ir.IrDependencyGraph.provideDiagnosticRenderer(SourceFile:82)
	at dev.zacsweers.metro.compiler.ir.IrDependencyGraph$ProvideDiagnosticRendererMetroFactory$Companion.provideDiagnosticRenderer(SourceFile)
	at dev.zacsweers.metro.compiler.ir.IrDependencyGraph$ProvideDiagnosticRendererMetroFactory.invoke(SourceFile)
	at dev.zacsweers.metro.compiler.ir.IrDependencyGraph$ProvideDiagnosticRendererMetroFactory.invoke(SourceFile:44)
	at dev.zacsweers.metro.compiler.shaded.metro.internal.BaseDoubleCheck.getValue(SourceFile:50)
	at dev.zacsweers.metro.compiler.shaded.metro.internal.BaseDoubleCheck.invoke(SourceFile:62)
	at dev.zacsweers.metro.compiler.ir.IrMetroContextImpl$MetroFactory.invoke(SourceFile)
	at dev.zacsweers.metro.compiler.ir.IrMetroContextImpl$MetroFactory.invoke(SourceFile:162)
	at dev.zacsweers.metro.compiler.shaded.metro.internal.BaseDoubleCheck.getValue(SourceFile:50)
	at dev.zacsweers.metro.compiler.shaded.metro.internal.BaseDoubleCheck.invoke(SourceFile:62)
	at dev.zacsweers.metro.compiler.ir.IrDependencyGraph$Impl.getPipeline(SourceFile:44)
	at dev.zacsweers.metro.compiler.ir.MetroIrGenerationExtension.generate(SourceFile:44)
	at org.jetbrains.kotlin.fir.pipeline.Fir2IrPipeline.applyIrGenerationExtensions(convertToIr.kt:577)
	... 29 more
Caused by: java.lang.NullPointerException: Cannot throw exception because "null" is null
	at dev.zacsweers.metro.compiler.shaded.com.github.ajalt.mordant.terminal.terminalinterface.jna.TerminalInterfaceJnaMacos.<init>(SourceFile:76)
	at dev.zacsweers.metro.compiler.shaded.com.github.ajalt.mordant.terminal.terminalinterface.jna.TerminalInterfaceProviderJna.load(SourceFile:20)
	at dev.zacsweers.metro.compiler.shaded.com.github.ajalt.mordant.internal.MppInternal_jvmKt.getStandardTerminalInterface(SourceFile:139)
	at dev.zacsweers.metro.compiler.shaded.com.github.ajalt.mordant.internal.MppInternalKt.<clinit>(SourceFile:61)
	... 48 more
```