### PR TITLE
Fix: Add entry decorators to NavDisplay in compose-viewmodel sample

### DIFF
--- a/samples/compose-viewmodels/app/src/commonMain/kotlin/dev/zacsweers/metro/sample/composeviewmodels/app/ComposeApp.kt
+++ b/samples/compose-viewmodels/app/src/commonMain/kotlin/dev/zacsweers/metro/sample/composeviewmodels/app/ComposeApp.kt
@@ -10,7 +10,9 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import dev.zacsweers.metro.sample.composeviewmodels.details.DetailsScreen
 import dev.zacsweers.metro.sample.composeviewmodels.home.HomeScreen
@@ -46,6 +48,10 @@ fun ComposeApp(metroVmf: MetroViewModelFactory, modifier: Modifier = Modifier) {
               }
           }
         },
+        entryDecorators = listOf(
+          rememberSaveableStateHolderNavEntryDecorator(),
+          rememberViewModelStoreNavEntryDecorator()
+        )
       )
     }
   }


### PR DESCRIPTION

## Change
- Integrates [nav3 entry decorator](https://developer.android.com/guide/navigation/navigation-3/save-state#scoping-viewmodels) in compose-viewmodels sample app to scope viewmodels to nav entry. This allows viewmodel to be scoped to respective navigation entries.

## Verification
### Current Behavior:
- Navigate to details from home screen by clicking on `Details A` button. Verify Details A data and then go back
- Now click on `Details B` and In details screen you have Details A data

### Changed Behavior:
- Now viewmodels are scoped to nav3 nav entries.
- Navigate to details from home screen by clicking on `Details A` button. Verify Details A data and then go back
- Now click on `Details B` and In details screen you have Details B data

 