### PR TITLE
Fix AssistedInject runtime crash on Kotlin 2.4.20-RC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 **Unreleased**
 --------------
 
+### Fixes
+
+- **[IR]** Fix a runtime crash when an assisted-injected class with no assisted parameters is used across modules with IR class generation.
+
 1.4.2
 -----
 

--- a/compiler-tests/src/test/data/box/inject/assisted/NoAssistedArgsInAssistedInjectAcrossModules.kt
+++ b/compiler-tests/src/test/data/box/inject/assisted/NoAssistedArgsInAssistedInjectAcrossModules.kt
@@ -1,3 +1,4 @@
+// MIN_COMPILER_VERSION: 2.4.20-dev-6138
 // GENERATE_CLASSES_IN_IR: true
 // MODULE: lib
 @AssistedInject

--- a/compiler-tests/src/test/data/box/inject/assisted/NoAssistedArgsInAssistedInjectAcrossModules.kt
+++ b/compiler-tests/src/test/data/box/inject/assisted/NoAssistedArgsInAssistedInjectAcrossModules.kt
@@ -1,0 +1,21 @@
+// GENERATE_CLASSES_IN_IR: true
+// MODULE: lib
+@AssistedInject
+class Example {
+  @AssistedFactory
+  interface Factory {
+    fun create(): Example
+  }
+}
+
+// MODULE: main(lib)
+@DependencyGraph
+interface AppGraph {
+  val factory: Example.Factory
+}
+
+fun box(): String {
+  val instance = createGraph<AppGraph>().factory.create()
+  assertNotNull(instance)
+  return "OK"
+}

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -2394,6 +2394,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
       }
 
       @Test
+      @TestMetadata("NoAssistedArgsInAssistedInjectAcrossModules.kt")
+      public void testNoAssistedArgsInAssistedInjectAcrossModules() {
+        run("NoAssistedArgsInAssistedInjectAcrossModules.kt");
+      }
+
+      @Test
       @TestMetadata("PreserveNullabilityForGenericsLayering.kt")
       public void testPreserveNullabilityForGenericsLayering() {
         run("PreserveNullabilityForGenericsLayering.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -2394,6 +2394,12 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
       }
 
       @Test
+      @TestMetadata("NoAssistedArgsInAssistedInjectAcrossModules.kt")
+      public void testNoAssistedArgsInAssistedInjectAcrossModules() {
+        run("NoAssistedArgsInAssistedInjectAcrossModules.kt");
+      }
+
+      @Test
       @TestMetadata("PreserveNullabilityForGenericsLayering.kt")
       public void testPreserveNullabilityForGenericsLayering() {
         run("PreserveNullabilityForGenericsLayering.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -2394,6 +2394,12 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("NoAssistedArgsInAssistedInjectAcrossModules.kt")
+      public void testNoAssistedArgsInAssistedInjectAcrossModules() {
+        run("NoAssistedArgsInAssistedInjectAcrossModules.kt");
+      }
+
+      @Test
       @TestMetadata("PreserveNullabilityForGenericsLayering.kt")
       public void testPreserveNullabilityForGenericsLayering() {
         run("PreserveNullabilityForGenericsLayering.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
@@ -2394,6 +2394,12 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
       }
 
       @Test
+      @TestMetadata("NoAssistedArgsInAssistedInjectAcrossModules.kt")
+      public void testNoAssistedArgsInAssistedInjectAcrossModules() {
+        run("NoAssistedArgsInAssistedInjectAcrossModules.kt");
+      }
+
+      @Test
       @TestMetadata("PreserveNullabilityForGenericsLayering.kt")
       public void testPreserveNullabilityForGenericsLayering() {
         run("PreserveNullabilityForGenericsLayering.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
@@ -2084,6 +2084,12 @@ public class JsBoxTestGenerated extends AbstractJsBoxTest {
       }
 
       @Test
+      @TestMetadata("NoAssistedArgsInAssistedInjectAcrossModules.kt")
+      public void testNoAssistedArgsInAssistedInjectAcrossModules() {
+        run("NoAssistedArgsInAssistedInjectAcrossModules.kt");
+      }
+
+      @Test
       @TestMetadata("PreserveNullabilityForGenericsLayering.kt")
       public void testPreserveNullabilityForGenericsLayering() {
         run("PreserveNullabilityForGenericsLayering.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
@@ -2084,6 +2084,12 @@ public class JsContributionProvidersBoxTestGenerated extends AbstractJsContribut
       }
 
       @Test
+      @TestMetadata("NoAssistedArgsInAssistedInjectAcrossModules.kt")
+      public void testNoAssistedArgsInAssistedInjectAcrossModules() {
+        run("NoAssistedArgsInAssistedInjectAcrossModules.kt");
+      }
+
+      @Test
       @TestMetadata("PreserveNullabilityForGenericsLayering.kt")
       public void testPreserveNullabilityForGenericsLayering() {
         run("PreserveNullabilityForGenericsLayering.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
@@ -2084,6 +2084,12 @@ public class JsFastInitBoxTestGenerated extends AbstractJsFastInitBoxTest {
       }
 
       @Test
+      @TestMetadata("NoAssistedArgsInAssistedInjectAcrossModules.kt")
+      public void testNoAssistedArgsInAssistedInjectAcrossModules() {
+        run("NoAssistedArgsInAssistedInjectAcrossModules.kt");
+      }
+
+      @Test
       @TestMetadata("PreserveNullabilityForGenericsLayering.kt")
       public void testPreserveNullabilityForGenericsLayering() {
         run("PreserveNullabilityForGenericsLayering.kt");

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/OmitRedundantMirrorsIrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/OmitRedundantMirrorsIrOnlyClassesBoxTestGenerated.java
@@ -2394,6 +2394,12 @@ public class OmitRedundantMirrorsIrOnlyClassesBoxTestGenerated extends AbstractO
       }
 
       @Test
+      @TestMetadata("NoAssistedArgsInAssistedInjectAcrossModules.kt")
+      public void testNoAssistedArgsInAssistedInjectAcrossModules() {
+        run("NoAssistedArgsInAssistedInjectAcrossModules.kt");
+      }
+
+      @Test
       @TestMetadata("PreserveNullabilityForGenericsLayering.kt")
       public void testPreserveNullabilityForGenericsLayering() {
         run("PreserveNullabilityForGenericsLayering.kt");

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectedClassTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectedClassTransformer.kt
@@ -512,7 +512,12 @@ internal class InjectedClassTransformer(
       )
       .apply {
         if (isAssistedInject) {
-          addAnnotationCompat(buildAnnotation(symbol, metroSymbols.assistedMarkerConstructor))
+          val assistedMarker = buildAnnotation(symbol, metroSymbols.assistedMarkerConstructor)
+          addAnnotationCompat(assistedMarker)
+          metadataDeclarationRegistrarCompat.addMetadataVisibleAnnotationsToElement(
+            this,
+            assistedMarker,
+          )
         }
         addMetadataVisibleHiddenCompanionObject()
       }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectedClassTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/InjectedClassTransformer.kt
@@ -512,11 +512,9 @@ internal class InjectedClassTransformer(
       )
       .apply {
         if (isAssistedInject) {
-          val assistedMarker = buildAnnotation(symbol, metroSymbols.assistedMarkerConstructor)
-          addAnnotationCompat(assistedMarker)
           metadataDeclarationRegistrarCompat.addMetadataVisibleAnnotationsToElement(
             this,
-            assistedMarker,
+            buildAnnotation(symbol, metroSymbols.assistedMarkerConstructor),
           )
         }
         addMetadataVisibleHiddenCompanionObject()


### PR DESCRIPTION
We recently updated to Kotlin 2.4.20-RC and started seeing Metro runtime crashes on a class that had an `@AssistedInject` constructor, but no assisted arguments. 

This bug seems to only reproduce when:
- using the latest Kotlin, e.g. `-Pmetro.testCompilerVersion=2.4.20-RC`. 
- the assisted inject class is in another module

Added a failing case to demonstrate.

Feel free to close this if it's too soon for 2.4.20-RC bugs!

```
BoxTestGenerated > Inject > Assisted > testNoAssistedArgsInAssistedInjectAcrossModules() FAILED

java.lang.ClassCastException: class Example cannot be cast to class Example$MetroFactory (Example and Example$MetroFactory are in unnamed module of loader org.jetbrains.kotlin.codegen.GeneratedClassLoader @706e8586)
      at AppGraph$Impl.getFactory(module_main_NoAssistedArgsInAssistedInjectAcrossModules.kt)
      at Module_main_NoAssistedArgsInAssistedInjectAcrossModulesKt.box(module_main_NoAssistedArgsInAssistedInjectAcrossModules.kt:21)
      at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
      at java.base/java.lang.reflect.Method.invoke(Method.java:565)
      at org.jetbrains.kotlin.test.backend.handlers.JvmBoxRunner.runBoxInCurrentProcess(JvmBoxRunner.kt:179)
```