### PR TITLE
Fix FIR annotation cache race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 **Unreleased**
 --------------
 
+### Fixes
+
+- **[FIR]** Avoid annotation-cache races during concurrent IDE analysis.
+
 1.4.2
 -----
 

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroAnnotations.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/MetroAnnotations.kt
@@ -536,7 +536,13 @@ internal fun FirBasedSymbol<*>.metroAnnotations(
     return it
   }
   val computed = metroAnnotations(session, null, kinds)
-  fir.metroAnnotationsCache = computed
+  try {
+    fir.metroAnnotationsCache = computed
+  } catch (_: IllegalStateException) {
+    // FirDeclarationAttributes is not thread-safe and the IDE runs checkers concurrently, so this
+    // write can race another attribute write on the same declaration. The cache is an
+    // optimization, so skip it and return the computed value.
+  }
   return computed
 }
 


### PR DESCRIPTION
Prevent concurrent FIR annotation cache writes during IDE analysis.