### PR TITLE
Share provider type sets

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ClassIds.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ClassIds.kt
@@ -119,35 +119,18 @@ public class ClassIds(private val options: MetroOptions = MetroOptions()) {
    * Suspend-provider shapes that type parsing recognizes. This is intentionally independent of the
    * suspend-provider opt-in so a consuming module can validate signatures compiled elsewhere.
    */
-  internal val suspendProviderModelingTypes = buildSet {
-    add(Symbols.ClassIds.metroSuspendProvider)
-    if (options.enableFunctionProviders) {
-      add(Symbols.ClassIds.suspendFunction0)
-    }
-  }
+  internal val suspendProviderModelingTypes = options.suspendProviderModelingTypes
 
   /**
    * Suspend-provider types used after validation. The explicit Metro type stays addressable so its
    * disabled use can be diagnosed; the function spelling joins only when the opt-in is enabled.
    */
-  internal val suspendProviderTypes = buildSet {
-    add(Symbols.ClassIds.metroSuspendProvider)
-    if (options.enableFunctionProviders && options.enableSuspendProviders) {
-      add(Symbols.ClassIds.suspendFunction0)
-    }
-  }
+  internal val suspendProviderTypes = options.suspendProviderTypes
 
-  internal val suspendLazyTypes = setOf(Symbols.ClassIds.metroSuspendLazy)
+  internal val suspendLazyTypes = options.suspendLazyTypes
 
   /** The zero-arg function types enabled as provider spellings. */
-  internal val function0Types: Set<ClassId> = buildSet {
-    if (options.enableFunctionProviders) {
-      add(Symbols.ClassIds.function0)
-      if (options.enableSuspendProviders) {
-        add(Symbols.ClassIds.suspendFunction0)
-      }
-    }
-  }
+  internal val function0Types: Set<ClassId> = options.function0Types
 
   internal val ClassId?.isFunction0Like: Boolean
     get() = this != null && this in function0Types

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/ClassIdsTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/ClassIdsTest.kt
@@ -33,4 +33,53 @@ class ClassIdsTest {
     assertThat(bothEnabled.function0Types).contains(Symbols.ClassIds.suspendFunction0)
     assertThat(bothEnabled.suspendProviderTypes).contains(Symbols.ClassIds.suspendFunction0)
   }
+
+  @Test
+  fun `provider type sets reuse shared options for every provider configuration`() {
+    for (enableFunctionProviders in listOf(false, true)) {
+      for (enableSuspendProviders in listOf(false, true)) {
+        val options =
+          MetroOptions()
+            .toBuilder()
+            .enableFunctionProviders(enableFunctionProviders)
+            .enableSuspendProviders(enableSuspendProviders)
+            .build()
+        val classIds = ClassIds(options)
+
+        assertThat(classIds.suspendProviderModelingTypes)
+          .isSameInstanceAs(options.suspendProviderModelingTypes)
+        assertThat(classIds.suspendProviderTypes).isSameInstanceAs(options.suspendProviderTypes)
+        assertThat(classIds.suspendLazyTypes).isSameInstanceAs(options.suspendLazyTypes)
+        assertThat(classIds.function0Types).isSameInstanceAs(options.function0Types)
+
+        val expectedModelingTypes = buildSet {
+          add(MetroClassIds.suspendProvider)
+          if (enableFunctionProviders) {
+            add(MetroClassIds.suspendFunction0)
+          }
+        }
+        val expectedSuspendProviderTypes = buildSet {
+          add(MetroClassIds.suspendProvider)
+          if (enableFunctionProviders && enableSuspendProviders) {
+            add(MetroClassIds.suspendFunction0)
+          }
+        }
+        val expectedFunctionTypes = buildSet {
+          if (enableFunctionProviders) {
+            add(MetroClassIds.function0)
+            if (enableSuspendProviders) {
+              add(MetroClassIds.suspendFunction0)
+            }
+          }
+        }
+
+        assertThat(classIds.suspendProviderModelingTypes)
+          .containsExactlyElementsIn(expectedModelingTypes)
+        assertThat(classIds.suspendProviderTypes)
+          .containsExactlyElementsIn(expectedSuspendProviderTypes)
+        assertThat(classIds.suspendLazyTypes).containsExactly(MetroClassIds.suspendLazy)
+        assertThat(classIds.function0Types).containsExactlyElementsIn(expectedFunctionTypes)
+      }
+    }
+  }
 }

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
@@ -159,11 +159,15 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val service = project.service<MetroResolutionService>()
     service.index(file)
     var notifications = 0
-    service.addIndexListener(testRootDisposable) { notifications++ }
+    val notified = CompletableFuture<Unit>()
+    service.addIndexListener(testRootDisposable) {
+      notifications++
+      notified.complete(Unit)
+    }
     val initialRoots = ProjectRootModificationTracker.getInstance(project).modificationCount
 
     project.setMetroOptions("generate-contribution-providers" to "true")
-    UIUtil.dispatchAllInvocationEvents()
+    PlatformTestUtil.waitForFuture(notified, 30_000)
 
     assertEquals(
       initialRoots,
@@ -176,11 +180,15 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     project.clearMetroOptions()
     val service = project.service<MetroResolutionService>()
     var notifications = 0
-    service.addIndexListener(testRootDisposable) { notifications++ }
+    val notified = CompletableFuture<Unit>()
+    service.addIndexListener(testRootDisposable) {
+      notifications++
+      notified.complete(Unit)
+    }
     val initialRoots = ProjectRootModificationTracker.getInstance(project).modificationCount
 
     project.setMetroOptions()
-    UIUtil.dispatchAllInvocationEvents()
+    PlatformTestUtil.waitForFuture(notified, 30_000)
 
     assertEquals(
       initialRoots,

--- a/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
+++ b/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/MetroOptions.kt
@@ -1312,7 +1312,30 @@ public class MetroOptions(
     }
   }
 
+  /**
+   * Suspend-provider shapes used after option validation. The explicit Metro type remains
+   * addressable while disabled so consumers can report its use.
+   */
+  @Transient
+  public val suspendProviderTypes: Set<ClassId> = buildSet {
+    add(MetroClassIds.suspendProvider)
+    if (enableFunctionProviders && enableSuspendProviders) {
+      add(MetroClassIds.suspendFunction0)
+    }
+  }
+
   @Transient public val suspendLazyTypes: Set<ClassId> = setOf(MetroClassIds.suspendLazy)
+
+  /** Zero-argument function types enabled as provider spellings. */
+  @Transient
+  public val function0Types: Set<ClassId> = buildSet {
+    if (enableFunctionProviders) {
+      add(MetroClassIds.function0)
+      if (enableSuspendProviders) {
+        add(MetroClassIds.suspendFunction0)
+      }
+    }
+  }
 
   @Transient
   public val dependencyGraphAnnotations: Set<ClassId> =


### PR DESCRIPTION
Share provider type sets between compiler options and compiler class IDs.