### PR TITLE
Rename Metro IDE project service

### DIFF
--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/MetroIdeProjectService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/MetroIdeProjectService.kt
@@ -149,7 +149,3 @@ private fun parseMetroOptions(optionStrings: List<String>): MetroOptions {
       }
     }
 }
-
-private fun <T> Set<T>.emptyUnless(condition: Boolean): Set<T> {
-  return if (condition) this else emptySet()
-}


### PR DESCRIPTION
Move the project service into its dedicated source file and remove an unused helper.