### PR TITLE
Move IDEA unused declaration support

### DIFF
--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/unused/MetroImplicitUsageProvider.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/unused/MetroImplicitUsageProvider.kt
@@ -1,6 +1,6 @@
 // Copyright (C) 2026 Zac Sweers
 // SPDX-License-Identifier: Apache-2.0
-package dev.zacsweers.metro.idea
+package dev.zacsweers.metro.idea.unused
 
 import com.intellij.codeInsight.daemon.ImplicitUsageProvider
 import com.intellij.openapi.application.ApplicationManager
@@ -10,6 +10,9 @@ import com.intellij.psi.PsiMember
 import com.intellij.psi.PsiNameIdentifierOwner
 import com.intellij.psi.util.PsiTreeUtil
 import dev.zacsweers.metro.compiler.MetroOptions
+import dev.zacsweers.metro.idea.MetroIdeAnnotationClassIds
+import dev.zacsweers.metro.idea.MetroSettings
+import dev.zacsweers.metro.idea.metroIdeState
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.permissions.allowAnalysisOnEdt
 import org.jetbrains.kotlin.analysis.api.types.KaClassType

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/unused/MetroUnusedDeclarationInspectionSuppressor.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/unused/MetroUnusedDeclarationInspectionSuppressor.kt
@@ -1,6 +1,6 @@
 // Copyright (C) 2026 Zac Sweers
 // SPDX-License-Identifier: Apache-2.0
-package dev.zacsweers.metro.idea
+package dev.zacsweers.metro.idea.unused
 
 import com.intellij.codeInspection.InspectionSuppressor
 import com.intellij.codeInspection.SuppressQuickFix

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -24,7 +24,7 @@ Metro IDE support for Kotlin dependency injection projects.
         id="dev.zacsweers.metro.idea.settings"
         displayName="Metro"
         instance="dev.zacsweers.metro.idea.MetroSettingsConfigurable"/>
-    <implicitUsageProvider implementation="dev.zacsweers.metro.idea.MetroImplicitUsageProvider"/>
+    <implicitUsageProvider implementation="dev.zacsweers.metro.idea.unused.MetroImplicitUsageProvider"/>
     <errorHandler implementation="dev.zacsweers.metro.idea.MetroErrorHandler"/>
     <codeInsight.lineMarkerProvider
         language="kotlin"
@@ -44,11 +44,11 @@ Metro IDE support for Kotlin dependency injection projects.
         descriptionKey="metro.inlay.injected.implementation.description"/>
     <lang.inspectionSuppressor
         language="kotlin"
-        implementationClass="dev.zacsweers.metro.idea.MetroUnusedDeclarationInspectionSuppressor"
+        implementationClass="dev.zacsweers.metro.idea.unused.MetroUnusedDeclarationInspectionSuppressor"
         order="first"/>
     <lang.inspectionSuppressor
         language="JAVA"
-        implementationClass="dev.zacsweers.metro.idea.MetroUnusedDeclarationInspectionSuppressor"
+        implementationClass="dev.zacsweers.metro.idea.unused.MetroUnusedDeclarationInspectionSuppressor"
         order="first"/>
     <lang.inspectionSuppressor
         language="kotlin"

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroImplicitUsageProviderTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroImplicitUsageProviderTest.kt
@@ -6,6 +6,8 @@ import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import dev.zacsweers.metro.idea.unused.MetroUnusedDeclarationInspectionSuppressor
+import dev.zacsweers.metro.idea.unused.isMetroImplicitUsage
 import java.io.File
 import java.nio.file.Path
 import kotlin.test.assertFalse

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroImplicitUsageProviderTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroImplicitUsageProviderTest.kt
@@ -3,13 +3,9 @@
 package dev.zacsweers.metro.idea
 
 import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.roots.ModuleRootModificationUtil
-import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import dev.zacsweers.metro.idea.unused.MetroUnusedDeclarationInspectionSuppressor
 import dev.zacsweers.metro.idea.unused.isMetroImplicitUsage
-import java.io.File
-import java.nio.file.Path
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.jetbrains.kotlin.idea.k2.codeinsight.inspections.UnusedSymbolInspection
@@ -21,7 +17,7 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
   override fun setUp() {
     super.setUp()
     setMetroEnabled(null)
-    addMetroRuntimeLibrary()
+    module.addMetroRuntimeLibrary()
   }
 
   fun testMarksMetroDeclarationsAsImplicitlyUsed() {
@@ -58,7 +54,7 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
   }
 
   fun testMarksCustomMetroDeclarationsAsImplicitlyUsedWhenConfigured() {
-    setMetroOptions(
+    project.setMetroOptions(
       "custom-binds" to "test/CustomBinds",
       "custom-contributes-binding" to "test/CustomContributesBinding",
       "custom-contributes-into-set" to "test/CustomContributesIntoCollection",
@@ -109,7 +105,7 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
   }
 
   fun testMarksContributionProviderDeclarationsAsImplicitlyUsedWhenConfigured() {
-    setMetroOptions(
+    project.setMetroOptions(
       "contributes-as-inject" to "false",
       "generate-contribution-providers" to "true",
     )
@@ -123,7 +119,7 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
   }
 
   fun testMarksDaggerInteropDeclarationsAsImplicitlyUsedWhenConfigured() {
-    setMetroOptions("interop-include-dagger-annotations" to "true")
+    project.setMetroOptions("interop-include-dagger-annotations" to "true")
     myFixture.addFileToProject(
       "dagger/Annotations.kt",
       """
@@ -187,7 +183,7 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
   }
 
   fun testMarksCircuitInjectDeclarationsAsImplicitlyUsedWhenEnabled() {
-    setMetroOptions("enable-circuit-codegen" to "true")
+    project.setMetroOptions("enable-circuit-codegen" to "true")
 
     val declarations = circuitFileDeclarations()
 
@@ -347,7 +343,7 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
   }
 
   fun testUnusedDeclarationHighlightingRespectsCircuitInjectWhenEnabled() {
-    setMetroOptions("enable-circuit-codegen" to "true")
+    project.setMetroOptions("enable-circuit-codegen" to "true")
     myFixture.enableInspections(UnusedSymbolInspection())
     val declarations = circuitFileDeclarations()
     myFixture.configureFromExistingVirtualFile(declarations.first().containingFile.virtualFile)
@@ -463,35 +459,11 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
     ) as KtFile
   }
 
-  private fun addMetroRuntimeLibrary() {
-    val runtimeJar = metroRuntimeJar()
-    ModuleRootModificationUtil.addModuleLibrary(
-      module,
-      "metro-runtime",
-      listOf(VfsUtil.getUrlForLibraryRoot(runtimeJar.toFile())),
-      emptyList(),
-    )
-  }
-
-  private fun metroRuntimeJar(): Path {
-    return System.getProperty("metroRuntime.classpath")
-      ?.split(File.pathSeparator)
-      ?.map { Path.of(it) }
-      ?.single {
-        val fileName = it.fileName.toString()
-        fileName.startsWith("runtime-jvm-") && fileName.endsWith(".jar")
-      } ?: error("Unable to get a valid classpath from 'metroRuntime.classpath' property")
-  }
-
   private fun setMetroEnabled(enabled: Boolean?) {
     if (enabled == null) {
-      setMetroOptions()
+      project.setMetroOptions()
     } else {
-      setMetroOptions("enabled" to enabled.toString())
+      project.setMetroOptions("enabled" to enabled.toString())
     }
-  }
-
-  private fun setMetroOptions(vararg options: Pair<String, String>) {
-    project.setMetroOptions(*options)
   }
 }


### PR DESCRIPTION
Move unused-declaration support into its own package and reuse shared test helpers.