### PR TITLE
Show IDEA graph validation progress

### DIFF
--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/GraphValidationProgress.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/GraphValidationProgress.kt
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea.graph
+
+import dev.zacsweers.metro.idea.model.GraphPath
+
+internal data class GraphValidationProgress(
+  val requestPath: GraphPath,
+  val graphName: String? = null,
+  val completed: Int? = null,
+  val total: Int? = null,
+) {
+  init {
+    require((completed == null) == (total == null))
+    require(completed == null || completed >= 0)
+    require(total == null || total > 0)
+    require(completed == null || total == null || completed < total)
+  }
+
+  val message: String
+    get() {
+      val graphName = graphName ?: return "Preparing Metro graph validation"
+      val completed = completed ?: return "Validating Metro graph $graphName"
+      val total = total ?: return "Validating Metro graph $graphName"
+      val graphLabel = if (total == 1) "graph" else "graphs"
+      return "Validating Metro graph $graphName (${completed + 1} of $total $graphLabel)"
+    }
+
+  val fraction: Double?
+    get() {
+      val completed = completed ?: return null
+      val total = total ?: return null
+      return completed.toDouble() / total
+    }
+
+  fun covers(path: GraphPath): Boolean {
+    if (requestPath.segments.size > path.segments.size) return false
+    return path.segments.takeLast(requestPath.segments.size) == requestPath.segments
+  }
+}

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/MetroGraphValidationService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/MetroGraphValidationService.kt
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea.graph
 
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.smartReadAction
 import com.intellij.openapi.components.Service
@@ -10,7 +12,9 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.platform.ide.progress.withBackgroundProgress
+import com.intellij.platform.util.progress.reportRawProgress
 import com.intellij.psi.PsiElement
 import dev.zacsweers.metro.compiler.MetroOptions
 import dev.zacsweers.metro.idea.MetroIdeProjectService
@@ -23,6 +27,7 @@ import dev.zacsweers.metro.idea.model.GraphQueryContext
 import dev.zacsweers.metro.idea.model.KaGraphDeclaration
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
 import kotlinx.coroutines.CancellationException
@@ -59,6 +64,11 @@ internal class MetroGraphValidationService(
     val context: GraphContext,
   )
 
+  private class ValidationTraversal(
+    val requestPath: GraphPath,
+    val inputs: List<ValidationInput>,
+  )
+
   private fun cacheKey(context: GraphContext): GraphPath? {
     val hasLocalGraph = context.path.segments.any { it.classId == null }
     return context.path.takeUnless { hasLocalGraph }
@@ -86,6 +96,9 @@ internal class MetroGraphValidationService(
 
   /** In-flight validations by stable graph path, so repeat requests coalesce into one run. */
   private val inFlight = ConcurrentHashMap<GraphPath, Job>()
+  private val validationProgress = ConcurrentHashMap<GraphPath, GraphValidationProgress>()
+  private val validationProgressListeners =
+    CopyOnWriteArrayList<(List<GraphValidationProgress>) -> Unit>()
 
   /** Drops all retained results. */
   fun clearResults() {
@@ -93,6 +106,19 @@ internal class MetroGraphValidationService(
     if (activeTraversals.get() == 0) {
       retainFloor.set(0)
     }
+  }
+
+  internal fun addValidationProgressListener(
+    parentDisposable: Disposable,
+    listener: (List<GraphValidationProgress>) -> Unit,
+  ) {
+    validationProgressListeners += listener
+    Disposer.register(parentDisposable) { validationProgressListeners -= listener }
+    notifyValidationProgressListener(listener)
+  }
+
+  internal fun isValidationRunning(path: GraphPath): Boolean {
+    return validationProgress.values.any { it.covers(path) }
   }
 
   /**
@@ -217,43 +243,71 @@ internal class MetroGraphValidationService(
   fun validateWithExtensions(
     element: PsiElement,
     graph: KaGraphDeclaration,
+    onProgress: (GraphValidationProgress) -> Unit = {},
   ): List<KaGraphValidationResult> {
     val declarationElement = graph.pointer.element ?: element
     val index = project.service<MetroResolutionService>().index(declarationElement)
     val currentGraph =
       index.graphFor(graph)
         ?: throw CancellationException("Metro graph declaration is no longer current")
-    return validateWithExtensions(declarationElement, index.contextsFor(currentGraph))
+    val requestPath = GraphPath(listOf(currentGraph.declarationId))
+    val traversal =
+      validationTraversal(declarationElement, requestPath, index.contextsFor(currentGraph))
+    return validateTraversal(traversal, onProgress)
   }
 
   /** Validates one concrete graph path and the extension paths it creates. */
   fun validateWithExtensions(
     element: PsiElement,
     context: GraphContext,
+    onProgress: (GraphValidationProgress) -> Unit = {},
   ): List<KaGraphValidationResult> {
-    return validateWithExtensions(element, listOf(context))
+    val traversal = validationTraversal(element, context.path, listOf(context))
+    return validateTraversal(traversal, onProgress)
   }
 
-  private fun validateWithExtensions(
+  private fun validationTraversal(
     declarationFallback: PsiElement,
+    requestPath: GraphPath,
     rootContexts: List<GraphContext>,
+  ): ValidationTraversal {
+    val inputs = mutableListOf<ValidationInput>()
+    val visited = mutableSetOf<GraphPath>()
+
+    fun visit(context: GraphContext) {
+      val input = validationInput(declarationFallback, context)
+      if (!visited.add(input.context.path)) return
+      for (extension in input.index.extensionContextsOf(input.context)) {
+        visit(extension)
+      }
+      inputs += input
+    }
+
+    rootContexts.forEach(::visit)
+    return ValidationTraversal(requestPath, inputs)
+  }
+
+  private fun validateTraversal(
+    traversal: ValidationTraversal,
+    onProgress: (GraphValidationProgress) -> Unit,
   ): List<KaGraphValidationResult> {
     activeTraversals.incrementAndGet()
     try {
-      val traversalResults = mutableListOf<KaGraphValidationResult>()
-      val visited = mutableSetOf<GraphPath>()
-
-      fun visit(context: GraphContext) {
-        val input = validationInput(declarationFallback, context)
-        if (!visited.add(input.context.path)) return
-        for (extension in input.index.extensionContextsOf(input.context)) {
-          visit(extension)
-        }
+      val traversalResults = ArrayList<KaGraphValidationResult>(traversal.inputs.size)
+      for ((index, input) in traversal.inputs.withIndex()) {
+        val graphName =
+          input.context.graph.name ?: input.context.graph.classId?.asFqNameString() ?: "<unknown>"
+        onProgress(
+          GraphValidationProgress(
+            requestPath = traversal.requestPath,
+            graphName = graphName,
+            completed = index,
+            total = traversal.inputs.size,
+          )
+        )
         traversalResults += validate(input)
         retainFloor.updateAndGet { floor -> maxOf(floor, traversalResults.size + 1) }
       }
-
-      rootContexts.forEach(::visit)
       return traversalResults
     } finally {
       if (activeTraversals.decrementAndGet() == 0) {
@@ -313,10 +367,26 @@ internal class MetroGraphValidationService(
     context: GraphContext,
     onDone: Consumer<KaGraphValidationResult>,
   ) {
-    launchCoalesced(context.path) {
+    launchCoalesced(context.path, context.graph) { publish ->
       val result =
         withBackgroundProgress(project, progressTitle(context.graph)) {
-          retryCancelledIndexBuild { smartReadAction(project) { validate(element, context) } }
+          reportRawProgress { reporter ->
+            retryCancelledIndexBuild {
+              smartReadAction(project) {
+                publish(
+                  GraphValidationProgress(
+                    requestPath = context.path,
+                    graphName = graphDisplayName(context.graph),
+                    completed = 0,
+                    total = 1,
+                  )
+                )
+                reporter.details("Validating ${graphDisplayName(context.graph)}")
+                reporter.fraction(0.0)
+                validate(element, context)
+              }
+            }
+          }
         }
       withContext(Dispatchers.EDT) { onDone.accept(result) }
     }
@@ -330,11 +400,20 @@ internal class MetroGraphValidationService(
   ) {
     // Keyed by the root path so this coalesces with validateAsync for the same graph and stays
     // stable across index rebuilds, unlike the declaration instance.
-    launchCoalesced(GraphPath(listOf(graph.declarationId))) {
+    val requestPath = GraphPath(listOf(graph.declarationId))
+    launchCoalesced(requestPath, graph) { publish ->
       val results =
         withBackgroundProgress(project, progressTitle(graph)) {
-          retryCancelledIndexBuild {
-            smartReadAction(project) { validateWithExtensions(element, graph) }
+          reportRawProgress { reporter ->
+            retryCancelledIndexBuild {
+              smartReadAction(project) {
+                validateWithExtensions(element, graph) { progress ->
+                  publish(progress)
+                  reporter.details(progress.message)
+                  reporter.fraction(progress.fraction)
+                }
+              }
+            }
           }
         }
       withContext(Dispatchers.EDT) { onDone.accept(results) }
@@ -347,11 +426,19 @@ internal class MetroGraphValidationService(
     context: GraphContext,
     onDone: Consumer<List<KaGraphValidationResult>>,
   ) {
-    launchCoalesced(context.path) {
+    launchCoalesced(context.path, context.graph) { publish ->
       val results =
         withBackgroundProgress(project, progressTitle(context.graph)) {
-          retryCancelledIndexBuild {
-            smartReadAction(project) { validateWithExtensions(element, context) }
+          reportRawProgress { reporter ->
+            retryCancelledIndexBuild {
+              smartReadAction(project) {
+                validateWithExtensions(element, context) { progress ->
+                  publish(progress)
+                  reporter.details(progress.message)
+                  reporter.fraction(progress.fraction)
+                }
+              }
+            }
           }
         }
       withContext(Dispatchers.EDT) { onDone.accept(results) }
@@ -359,14 +446,22 @@ internal class MetroGraphValidationService(
   }
 
   private fun progressTitle(graph: KaGraphDeclaration): String =
-    "Validating Metro graph ${graph.name ?: ""}".trimEnd()
+    "Validating Metro graph ${graphDisplayName(graph)}"
+
+  private fun graphDisplayName(graph: KaGraphDeclaration): String {
+    return graph.name ?: graph.classId?.asFqNameString() ?: "<unknown>"
+  }
 
   /** Launches [block], cancelling any in-flight run for the same graph request. */
-  private fun launchCoalesced(key: GraphPath, block: suspend CoroutineScope.() -> Unit) {
+  private fun launchCoalesced(
+    key: GraphPath,
+    graph: KaGraphDeclaration,
+    block: suspend CoroutineScope.((GraphValidationProgress) -> Unit) -> Unit,
+  ) {
     val job =
       scope.launch(start = CoroutineStart.LAZY) {
         try {
-          block()
+          block { progress -> publishValidationProgress(key, progress) }
         } catch (e: ProcessCanceledException) {
           throw e
         } catch (e: CancellationException) {
@@ -376,8 +471,54 @@ internal class MetroGraphValidationService(
         }
       }
     inFlight.put(key, job)?.cancel()
-    job.invokeOnCompletion { inFlight.remove(key, job) }
+    publishValidationProgress(
+      key,
+      GraphValidationProgress(requestPath = key, graphName = graphDisplayName(graph)),
+    )
+    job.invokeOnCompletion {
+      if (inFlight.remove(key, job)) {
+        publishValidationProgress(key, null)
+      }
+    }
     job.start()
+  }
+
+  private fun publishValidationProgress(key: GraphPath, progress: GraphValidationProgress?) {
+    if (progress == null) {
+      validationProgress.remove(key)
+    } else {
+      validationProgress[key] = progress
+    }
+    notifyValidationProgressListeners()
+  }
+
+  private fun notifyValidationProgressListeners() {
+    val application = ApplicationManager.getApplication()
+    if (!application.isDispatchThread) {
+      application.invokeLater {
+        if (!project.isDisposed) notifyValidationProgressListeners()
+      }
+      return
+    }
+    val snapshot = validationProgress.values.sortedBy { it.requestPath.toString() }
+    for (listener in validationProgressListeners.toList()) {
+      listener(snapshot)
+    }
+  }
+
+  private fun notifyValidationProgressListener(listener: (List<GraphValidationProgress>) -> Unit) {
+    val application = ApplicationManager.getApplication()
+    if (!application.isDispatchThread) {
+      application.invokeLater {
+        if (!project.isDisposed && listener in validationProgressListeners) {
+          notifyValidationProgressListener(listener)
+        }
+      }
+      return
+    }
+    if (listener in validationProgressListeners) {
+      listener(validationProgress.values.sortedBy { it.requestPath.toString() })
+    }
   }
 
   private fun moduleOptions(declarationElement: PsiElement): MetroOptions {

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
@@ -7,6 +7,7 @@ import com.intellij.icons.AllIcons
 import com.intellij.ide.util.treeView.NodeDescriptor
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -30,6 +31,7 @@ import com.intellij.ui.tree.TreeVisitor
 import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.tree.TreeUtil
 import dev.zacsweers.metro.idea.MetroIcons
+import dev.zacsweers.metro.idea.graph.GraphValidationProgress
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
 import dev.zacsweers.metro.idea.index.IndexBuildProgress
 import dev.zacsweers.metro.idea.index.MetroResolutionService
@@ -37,6 +39,7 @@ import dev.zacsweers.metro.idea.model.GraphContext
 import dev.zacsweers.metro.idea.model.KaGraphDeclaration
 import java.awt.BorderLayout
 import java.awt.event.MouseEvent
+import javax.swing.BoxLayout
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import javax.swing.event.DocumentEvent
@@ -55,8 +58,12 @@ internal class MetroToolWindowPanel(private val project: Project) :
   // search text instead of touching the Swing component off the EDT.
   @Volatile private var searchText: String = ""
   private val resolutionService = project.service<MetroResolutionService>()
+  private val validationService = project.service<MetroGraphValidationService>()
   private val indexBuildStatus = IndexBuildStatusPanel()
+  private val validationStatus = ValidationStatusPanel()
   private var indexBuildProgress: IndexBuildProgress? = null
+  private var validationProgress: List<GraphValidationProgress> = emptyList()
+  private lateinit var actionToolbar: ActionToolbar
   private val treeStructure =
     MetroTreeStructure(project, resolutionService::indexForToolWindow) { searchText }
 
@@ -110,6 +117,10 @@ internal class MetroToolWindowPanel(private val project: Project) :
       indexBuildProgress = progress
       updateIndexBuildStatus()
     }
+    validationService.addValidationProgressListener(this) { progress ->
+      validationProgress = progress
+      updateValidationStatus()
+    }
 
     object : DoubleClickListener() {
         override fun onDoubleClick(event: MouseEvent): Boolean = navigateSelected()
@@ -124,6 +135,7 @@ internal class MetroToolWindowPanel(private val project: Project) :
         }
       }
     )
+    tree.addTreeSelectionListener { updateValidationStatus() }
 
     val overflowGroup =
       DefaultActionGroup("More", true).apply {
@@ -134,31 +146,30 @@ internal class MetroToolWindowPanel(private val project: Project) :
       DefaultActionGroup(
         // Not DumbAware: the refreshed tree needs stub indexes, so wait for smart mode
         loadOrRefreshAction,
-        object :
-          AnAction("Validate", "Validate the selected graph", MetroIcons.GRAPH_VALIDATED),
-          DumbAware {
-          override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
-
-          override fun update(e: AnActionEvent) {
-            e.presentation.isEnabled = selectedGraphNode() != null
-          }
-
-          override fun actionPerformed(e: AnActionEvent) {
-            selectedGraphNode()?.context?.let(::validateContext)
-          }
-        },
+        ValidateSelectedGraphAction(
+          selectedContext = { selectedGraphNode()?.context },
+          isValidationRunning = { validationService.isValidationRunning(it.path) },
+          validate = ::validateContext,
+        ),
         overflowGroup,
       )
-    val toolbar =
+    actionToolbar =
       ActionManager.getInstance().createActionToolbar("MetroToolWindow", actionGroup, true)
-    toolbar.targetComponent = tree
+    actionToolbar.targetComponent = tree
 
     val header = JPanel(BorderLayout())
-    header.add(toolbar.component, BorderLayout.WEST)
+    header.add(actionToolbar.component, BorderLayout.WEST)
     header.add(searchField, BorderLayout.CENTER)
     setToolbar(header)
     val content = JPanel(BorderLayout())
-    content.add(indexBuildStatus, BorderLayout.NORTH)
+    val statusContainer =
+      JPanel().apply {
+        isOpaque = false
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+        add(indexBuildStatus)
+        add(validationStatus)
+      }
+    content.add(statusContainer, BorderLayout.NORTH)
     content.add(JBScrollPane(tree), BorderLayout.CENTER)
     setContent(content)
   }
@@ -174,6 +185,23 @@ internal class MetroToolWindowPanel(private val project: Project) :
         !resolutionService.isGraphBrowserActivated -> indexBuildStatus.showNotLoaded()
         else -> indexBuildStatus.clear()
       }
+    }
+  }
+
+  private fun updateValidationStatus() {
+    if (disposed || project.isDisposed) return
+    val selectedPath = selectedGraphNode()?.context?.path
+    val selectedProgress = selectedPath?.let { path ->
+      validationProgress.firstOrNull { it.covers(path) }
+    }
+    val progress = selectedProgress ?: validationProgress.firstOrNull()
+    if (progress == null) {
+      validationStatus.clear()
+    } else {
+      validationStatus.show(progress)
+    }
+    if (::actionToolbar.isInitialized) {
+      actionToolbar.updateActionsImmediately()
     }
   }
 
@@ -243,14 +271,14 @@ internal class MetroToolWindowPanel(private val project: Project) :
 
   private fun validateGraph(graph: KaGraphDeclaration) {
     val element = graph.pointer.element ?: return
-    project.service<MetroGraphValidationService>().validateWithExtensionsAsync(element, graph) {
+    validationService.validateWithExtensionsAsync(element, graph) {
       validationFinished(validationVisitor(graph))
     }
   }
 
   private fun validateContext(context: GraphContext) {
     val element = context.graph.pointer.element ?: return
-    project.service<MetroGraphValidationService>().validateWithExtensionsAsync(element, context) {
+    validationService.validateWithExtensionsAsync(element, context) {
       validationFinished(validationVisitor(context))
     }
   }
@@ -313,6 +341,24 @@ internal class MetroToolWindowPanel(private val project: Project) :
     disposed = true
     pendingValidation = null
     indexBuildStatus.clear()
+    validationStatus.clear()
+  }
+}
+
+internal class ValidateSelectedGraphAction(
+  private val selectedContext: () -> GraphContext?,
+  private val isValidationRunning: (GraphContext) -> Boolean,
+  private val validate: (GraphContext) -> Unit,
+) : AnAction("Validate", "Validate the selected graph", MetroIcons.GRAPH_VALIDATED), DumbAware {
+  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
+
+  override fun update(e: AnActionEvent) {
+    val context = selectedContext()
+    e.presentation.isEnabled = context != null && !isValidationRunning(context)
+  }
+
+  override fun actionPerformed(e: AnActionEvent) {
+    selectedContext()?.takeUnless(isValidationRunning)?.let(validate)
   }
 }
 

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/ValidationStatusPanel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/ValidationStatusPanel.kt
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea.toolwindow
+
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
+import dev.zacsweers.metro.idea.graph.GraphValidationProgress
+import java.awt.BorderLayout
+import javax.swing.JPanel
+import javax.swing.JProgressBar
+
+internal class ValidationStatusPanel : JPanel(BorderLayout(0, JBUI.scale(4))) {
+  internal val messageLabel = JBLabel()
+  internal val progressBar = JProgressBar()
+
+  init {
+    isOpaque = false
+    isVisible = false
+    border = JBUI.Borders.empty(6, 8)
+    progressBar.isStringPainted = false
+    add(messageLabel, BorderLayout.NORTH)
+    add(progressBar, BorderLayout.SOUTH)
+  }
+
+  fun show(progress: GraphValidationProgress) {
+    messageLabel.text = progress.message
+    progressBar.isVisible = true
+    val completed = progress.completed
+    val total = progress.total
+    if (completed != null && total != null) {
+      progressBar.isIndeterminate = false
+      progressBar.minimum = 0
+      progressBar.maximum = total
+      progressBar.value = completed
+    } else {
+      progressBar.isIndeterminate = true
+    }
+    isVisible = true
+  }
+
+  fun clear() {
+    isVisible = false
+    progressBar.isIndeterminate = false
+  }
+}

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import dev.zacsweers.metro.compiler.MetroClassIds
 import dev.zacsweers.metro.compiler.diagnostics.MetroDiagnosticId
+import dev.zacsweers.metro.idea.graph.GraphValidationProgress
 import dev.zacsweers.metro.idea.graph.IncompleteGraphAnalysis
 import dev.zacsweers.metro.idea.graph.KaBindingGraph
 import dev.zacsweers.metro.idea.graph.KaGraphValidationResult
@@ -2300,8 +2301,21 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
 
     validationService.clearResults()
     val leftParent = index.graphs.single { it.name == "LeftParent" }
-    val traversal = validationService.validateWithExtensions(file, leftParent)
+    val progress = mutableListOf<GraphValidationProgress>()
+    val traversal = validationService.validateWithExtensions(file, leftParent, progress::add)
     assertEquals(listOf("ChildGraph", "LeftParent"), traversal.map { it.graph.name })
+    assertEquals(listOf("ChildGraph", "LeftParent"), progress.map { it.graphName })
+    assertEquals(listOf(0, 1), progress.map { it.completed })
+    assertEquals(listOf(2, 2), progress.map { it.total })
+    assertEquals(
+      listOf(
+        "Validating Metro graph ChildGraph (1 of 2 graphs)",
+        "Validating Metro graph LeftParent (2 of 2 graphs)",
+      ),
+      progress.map { it.message },
+    )
+    assertTrue(progress.first().covers(leftContext.path))
+    assertFalse(progress.first().covers(rightContext.path))
     assertEquals("LeftParent", traversal.first().context.chain[1].name)
     assertNull(validationService.cachedResult(file, rightContext))
   }

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
@@ -21,6 +21,7 @@ import com.intellij.ui.tree.StructureTreeModel
 import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.tree.TreeUtil
 import dev.zacsweers.metro.compiler.diagnostics.MetroDiagnosticId
+import dev.zacsweers.metro.idea.graph.GraphValidationProgress
 import dev.zacsweers.metro.idea.graph.KaGraphValidationResult
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
 import dev.zacsweers.metro.idea.index.IndexBuildPhase
@@ -36,6 +37,8 @@ import dev.zacsweers.metro.idea.toolwindow.MetroToolWindowPanel
 import dev.zacsweers.metro.idea.toolwindow.MetroTreeNode
 import dev.zacsweers.metro.idea.toolwindow.MetroTreeStructure
 import dev.zacsweers.metro.idea.toolwindow.ValidateMetroGraphAction
+import dev.zacsweers.metro.idea.toolwindow.ValidateSelectedGraphAction
+import dev.zacsweers.metro.idea.toolwindow.ValidationStatusPanel
 import dev.zacsweers.metro.idea.toolwindow.writeGraphDebugReport
 import java.nio.file.Files
 import org.jetbrains.kotlin.name.ClassId
@@ -389,6 +392,64 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
 
     panel.clear()
     assertFalse(panel.isVisible)
+  }
+
+  fun testValidationStatusPanelShowsPreparingAndCountedProgress() {
+    val file = configure()
+    val index = project.service<MetroResolutionService>().index(file)
+    val context = index.contextsFor(index.graphs.single()).single()
+    val panel = ValidationStatusPanel()
+
+    panel.show(GraphValidationProgress(context.path, graphName = "AppGraph"))
+    assertTrue(panel.isVisible)
+    assertTrue(panel.progressBar.isIndeterminate)
+    assertEquals("Validating Metro graph AppGraph", panel.messageLabel.text)
+
+    panel.show(GraphValidationProgress(context.path, "ChildGraph", completed = 1, total = 3))
+    assertFalse(panel.progressBar.isIndeterminate)
+    assertEquals(1, panel.progressBar.value)
+    assertEquals(3, panel.progressBar.maximum)
+    assertEquals(
+      "Validating Metro graph ChildGraph (2 of 3 graphs)",
+      panel.messageLabel.text,
+    )
+
+    panel.clear()
+    assertFalse(panel.isVisible)
+  }
+
+  fun testValidateActionIsDisabledWhileTheSelectedGraphIsRunning() {
+    val file = configure()
+    val index = project.service<MetroResolutionService>().index(file)
+    val context = index.contextsFor(index.graphs.single()).single()
+    var selectedContext: GraphContext? = null
+    var validationRunning = false
+    var validatedContext: GraphContext? = null
+    val action =
+      ValidateSelectedGraphAction(
+        selectedContext = { selectedContext },
+        isValidationRunning = { validationRunning },
+        validate = { validatedContext = it },
+      )
+    val event =
+      AnActionEvent.createFromAnAction(action, null, ActionPlaces.UNKNOWN, DataContext { null })
+
+    action.update(event)
+    assertFalse(event.presentation.isEnabled)
+
+    selectedContext = context
+    action.update(event)
+    assertTrue(event.presentation.isEnabled)
+
+    validationRunning = true
+    action.update(event)
+    assertFalse(event.presentation.isEnabled)
+    action.actionPerformed(event)
+    assertNull(validatedContext)
+
+    validationRunning = false
+    action.actionPerformed(event)
+    assertSame(context, validatedContext)
   }
 
   fun testGraphBrowserActionLoadsOnceThenRefreshes() {


### PR DESCRIPTION
Show progress while the IDEA plugin validates graphs and graph extensions. The Metro tool window now displays the current validation step and prevents starting the same validation again while it is running.