### PR TITLE
Support dynamic graphs in the IDEA plugin

### DIFF
--- a/idea-plugin/README.md
+++ b/idea-plugin/README.md
@@ -93,6 +93,12 @@ project. The status indicator shows loading progress or waits for IDE indexing b
 available. Graph extensions with different parent chains appear as separate rows rather than being
 merged together.
 
+Calls to `createDynamicGraph` and `createDynamicGraphFactory` appear as separate graph contexts at
+their call sites. The browser applies each concrete binding-container type as an override, carries
+those bindings into graph extensions, and keeps multibinding contributions additive. Equivalent
+calls in one file share a context, matching the compiler, while calls from different files remain
+distinct.
+
 Expanding a graph groups its bindings into scoped, unscoped, multibinding, and contributed
 categories. The search field filters by binding key or implementation name, and double-clicking a
 binding navigates to its declaration. After validation, an Unused category lists authored

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/KaBindingLookup.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/KaBindingLookup.kt
@@ -306,7 +306,11 @@ internal class KaBindingLookup(
 
   private fun createParentSuspendAnalysis(): SuspendBindingAnalysis? {
     val chain = queryContext.graphContext.chain
-    val parentPath = GraphPath(chain.drop(1).map { it.declarationId })
+    val parentPath =
+      GraphPath(
+        chain.drop(1).map { it.declarationId },
+        queryContext.graphContext.dynamicGraph?.id,
+      )
     val parentContext = index.findContext(parentPath) ?: return null
     val resolvedParent = resolveParentGraph(parentContext)
     val parent =

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/MetroGraphValidationService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/MetroGraphValidationService.kt
@@ -54,12 +54,9 @@ internal class MetroGraphValidationService(
 
   private class CachedEntry(val result: KaGraphValidationResult, val index: BindingIndex)
 
-  /**
-   * A current graph declaration and context interpreted using the declaration module's Metro
-   * options. [BindingIndex.queryContext] separately uses the root graph module for visibility.
-   */
+  /** A current graph context interpreted using the compilation that owns it. */
   private class ValidationInput(
-    val declarationElement: PsiElement,
+    val contextElement: PsiElement,
     val index: BindingIndex,
     val context: GraphContext,
   )
@@ -129,8 +126,8 @@ internal class MetroGraphValidationService(
   fun cachedResult(element: PsiElement, context: GraphContext): CachedValidation? {
     val key = cacheKey(context) ?: return null
     val entry = results[key] ?: return null
-    val declarationElement = context.graph.pointer.element ?: element
-    val currentIndex = project.service<MetroResolutionService>().index(declarationElement)
+    val contextElement = context.contextPointer.element ?: element
+    val currentIndex = project.service<MetroResolutionService>().index(contextElement)
     return CachedValidation(entry.result, stale = entry.index !== currentIndex)
   }
 
@@ -153,10 +150,10 @@ internal class MetroGraphValidationService(
   ): T? {
     val input = validationInputOrNull(element, context) ?: return null
     val queryContext = input.index.queryContext(input.context) ?: return null
-    val options = moduleOptions(input.declarationElement)
+    val options = moduleOptions(input.contextElement)
     val lookup =
       KaBindingLookup(input.index, queryContext, options) { parentContext ->
-        parentGraphLookup(input.declarationElement, parentContext)
+        parentGraphLookup(input.contextElement, parentContext)
       }
     return try {
       block(input.index, queryContext, options, lookup)
@@ -185,7 +182,7 @@ internal class MetroGraphValidationService(
     var childFailed = false
     var incompleteChild: KaGraphValidationResult.Incomplete? = null
     for (extensionContext in index.extensionContextsOf(context)) {
-      val childInput = validationInputOrNull(input.declarationElement, extensionContext) ?: continue
+      val childInput = validationInputOrNull(input.contextElement, extensionContext) ?: continue
       val childResult = validate(childInput)
       when (childResult) {
         is KaGraphValidationResult.Completed -> {
@@ -215,13 +212,13 @@ internal class MetroGraphValidationService(
         )
       } else {
         runGraphValidation(context, graphName) {
-          val options = moduleOptions(input.declarationElement)
+          val options = moduleOptions(input.contextElement)
           val queryContext =
             checkNotNull(index.queryContext(context)) {
               "Graph declaration disappeared: $graphName"
             }
           KaBindingGraph(index, queryContext, options, reservations) { parentContext ->
-              parentGraphLookup(input.declarationElement, parentContext)
+              parentGraphLookup(input.contextElement, parentContext)
             }
             .seal()
         }
@@ -330,35 +327,33 @@ internal class MetroGraphValidationService(
   ): ParentGraphLookup? {
     val input = validationInputOrNull(declarationFallback, context) ?: return null
     val queryContext = input.index.queryContext(input.context) ?: return null
-    return ParentGraphLookup(input.index, queryContext, moduleOptions(input.declarationElement))
+    return ParentGraphLookup(input.index, queryContext, moduleOptions(input.contextElement))
   }
 
   private fun validationInputOrNull(
     declarationFallback: PsiElement,
     context: GraphContext,
   ): ValidationInput? {
-    val declarationElement = context.graph.pointer.element ?: declarationFallback
-    val index = project.service<MetroResolutionService>().index(declarationElement)
+    val contextElement = context.contextPointer.element ?: declarationFallback
+    val index = project.service<MetroResolutionService>().index(contextElement)
     val currentContext = index.findContext(context.path) ?: return null
-    val currentDeclarationElement = currentContext.graph.pointer.element ?: return null
-    return ValidationInput(currentDeclarationElement, index, currentContext)
+    val currentContextElement = currentContext.contextPointer.element ?: return null
+    return ValidationInput(currentContextElement, index, currentContext)
   }
 
   private fun validationInput(
     declarationFallback: PsiElement,
     context: GraphContext,
   ): ValidationInput {
-    // Options follow the concrete graph declaration's module. Visibility still follows the root
-    // graph's compilation module through BindingIndex.queryContext().
-    val declarationElement = context.graph.pointer.element ?: declarationFallback
-    val index = project.service<MetroResolutionService>().index(declarationElement)
+    val contextElement = context.contextPointer.element ?: declarationFallback
+    val index = project.service<MetroResolutionService>().index(contextElement)
     val currentContext =
       index.findContext(context.path)
         ?: throw CancellationException("Metro graph context is no longer current")
-    val currentDeclarationElement =
-      currentContext.graph.pointer.element
-        ?: throw CancellationException("Metro graph declaration is no longer available")
-    return ValidationInput(currentDeclarationElement, index, currentContext)
+    val currentContextElement =
+      currentContext.contextPointer.element
+        ?: throw CancellationException("Metro graph context is no longer available")
+    return ValidationInput(currentContextElement, index, currentContext)
   }
 
   /** Runs [validate] for one context in a smart-mode read action and delivers it on the EDT. */

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/FileShardBuilder.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/FileShardBuilder.kt
@@ -20,6 +20,8 @@ import dev.zacsweers.metro.idea.model.AssistedSite
 import dev.zacsweers.metro.idea.model.BindingContainerEntry
 import dev.zacsweers.metro.idea.model.ConsumerEntry
 import dev.zacsweers.metro.idea.model.ContributionEntry
+import dev.zacsweers.metro.idea.model.DynamicGraphCall
+import dev.zacsweers.metro.idea.model.DynamicGraphId
 import dev.zacsweers.metro.idea.model.GraphCallableReference
 import dev.zacsweers.metro.idea.model.GraphCallableSignature
 import dev.zacsweers.metro.idea.model.GraphDeclarationId
@@ -39,6 +41,7 @@ import dev.zacsweers.metro.idea.scopeAnnotations
 import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotated
+import org.jetbrains.kotlin.analysis.api.resolution.successfulFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaNamedClassSymbol
@@ -49,10 +52,12 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
 import org.jetbrains.kotlin.analysis.api.symbols.KaValueParameterSymbol
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
@@ -79,6 +84,7 @@ internal class FileShardBuilder(
   private val assistedSites = mutableListOf<AssistedSite>()
   private val bindingContainerEntries = mutableListOf<BindingContainerEntry>()
   private val factoryInputs = mutableListOf<FactoryInputEntry>()
+  private val dynamicGraphs = mutableListOf<DynamicGraphCall>()
   private val graphInterfaces = mutableListOf<GraphInterfaceSurface>()
   private val pointerManager = SmartPointerManager.getInstance(project)
 
@@ -93,6 +99,7 @@ internal class FileShardBuilder(
   private val processedAssistedFactoryTypes = HashSet<AssistedFactoryIdentity>()
   private val processedContainers = HashSet<KtClassOrObject>()
   private val processedFactoryInputs = HashSet<FactoryInputEntry.Id>()
+  private val processedDynamicGraphs = HashSet<DynamicGraphId>()
   private val cacheDependencies = HashSet<PsiFile>()
 
   /**
@@ -137,6 +144,12 @@ internal class FileShardBuilder(
     val assistedFactoryNames = annotationNames(options.assistedFactoryAnnotations)
     val containerNames = annotationNames(options.bindingContainerAnnotations)
     val circuitNames = annotationNames(setOf(CircuitClassIds.CircuitInject))
+    val dynamicGraphNames = buildSet {
+      for (callableId in DYNAMIC_GRAPH_CALLABLES.keys) {
+        add(callableId.callableName.asString())
+        addAll(aliasedImports[callableId.asSingleFqName()].orEmpty())
+      }
+    }
 
     for (entry in PsiTreeUtil.collectElementsOfType(file, KtAnnotationEntry::class.java)) {
       ProgressManager.checkCanceled()
@@ -152,6 +165,11 @@ internal class FileShardBuilder(
         processCircuitInject(declaration)
       }
     }
+    for (call in PsiTreeUtil.collectElementsOfType(file, KtCallExpression::class.java)) {
+      ProgressManager.checkCanceled()
+      val name = call.calleeExpression?.text ?: continue
+      if (name in dynamicGraphNames) processDynamicGraphCall(call)
+    }
     return FileShard(
       bindings,
       consumers,
@@ -160,9 +178,87 @@ internal class FileShardBuilder(
       assistedSites,
       bindingContainerEntries,
       factoryInputs,
+      dynamicGraphs,
       cacheDependencies.mapNotNullTo(mutableSetOf()) { it.virtualFile },
       graphInterfaces,
     )
+  }
+
+  private fun processDynamicGraphCall(call: KtCallExpression) {
+    analyze(call) {
+      val function =
+        call
+          .resolveToCall()
+          ?.successfulFunctionCallOrNull()
+          ?.partiallyAppliedSymbol
+          ?.signature
+          ?.symbol ?: return@analyze
+      val isFactory = DYNAMIC_GRAPH_CALLABLES[function.callableId] ?: return@analyze
+      val requestedType = call.expressionType?.fullyExpandedType as? KaClassType ?: return@analyze
+      val requestedClass = requestedType.symbol as? KaNamedClassSymbol ?: return@analyze
+      val targetGraphType =
+        if (isFactory) {
+          assistedFactoryFunction(requestedType)?.returnType?.fullyExpandedType as? KaClassType
+            ?: return@analyze
+        } else {
+          requestedType
+        }
+      val targetGraphClass = targetGraphType.symbol as? KaNamedClassSymbol ?: return@analyze
+      if (!targetGraphClass.hasAnyAnnotation(options.dependencyGraphAnnotations)) return@analyze
+      val targetGraphFile = targetGraphClass.psi?.containingFile
+      targetGraphFile?.let(cacheDependencies::add)
+      requestedClass.psi?.containingFile?.let(cacheDependencies::add)
+
+      val callerFile = call.containingKtFile.virtualFile ?: return@analyze
+      val containerKeys = linkedSetOf<KaTypeKey>()
+      val inputs = mutableListOf<FactoryInputEntry>()
+      for (argument in call.valueArguments) {
+        val expression = argument.getArgumentExpression() ?: continue
+        val containerType = expression.expressionType?.fullyExpandedType as? KaClassType ?: continue
+        val containerClass = containerType.symbol as? KaNamedClassSymbol ?: continue
+        if (!containerClass.hasAnyAnnotation(options.bindingContainerAnnotations)) continue
+        val containerKey = typeKey(containerType, qualifier = null)
+        if (!containerKeys.add(containerKey)) continue
+        val input =
+          bindingContainerInput(
+            containerType,
+            containerKey,
+            expression,
+            options,
+            pointerManager,
+            cacheDependencies,
+            GraphDeclarationId(targetGraphType.classId, targetGraphFile?.virtualFile),
+          )
+        inputs += input
+      }
+      if (containerKeys.isEmpty()) return@analyze
+      val id = DynamicGraphId(requestedType.classId, containerKeys.toSet(), callerFile)
+      if (!processedDynamicGraphs.add(id)) return@analyze
+      for (input in inputs) {
+        val inputBinding = input.bindings.firstOrNull()
+        if (inputBinding is KaBinding.BoundInstance) {
+          bindings += inputBinding
+        }
+        if (processedFactoryInputs.add(input.id)) {
+          factoryInputs += input
+        }
+      }
+      val bindingKeys =
+        inputs
+          .asSequence()
+          .flatMap { it.bindings.asSequence() }
+          .filterNot { it is KaBinding.BoundInstance || it.multibindingId != null }
+          .mapTo(linkedSetOf()) { it.typeKey }
+      dynamicGraphs +=
+        DynamicGraphCall(
+          pointerManager.createSmartPsiElementPointer(call),
+          id,
+          targetGraphType.graphReference(),
+          bindingKeys,
+          inputs.mapNotNull { it.bindings.firstOrNull() as? KaBinding.BoundInstance },
+          isFactory,
+        )
+    }
   }
 
   private fun ptr(element: KtElement): SmartPsiElementPointer<KtElement> {
@@ -1231,3 +1327,10 @@ internal class FileShardBuilder(
     }
   }
 }
+
+internal val DYNAMIC_GRAPH_CALLABLES =
+  mapOf(
+    CallableId(MetroClassIds.metroRuntimePackage, Name.identifier("createDynamicGraph")) to false,
+    CallableId(MetroClassIds.metroRuntimePackage, Name.identifier("createDynamicGraphFactory")) to
+      true,
+  )

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/GraphFactoryInputs.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/GraphFactoryInputs.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea.index
 
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPointerManager
 import dev.zacsweers.metro.compiler.MetroClassIds
@@ -77,10 +78,10 @@ internal fun KaClassSymbol.graphFactoryInputs(
       if (parameterClass.hasAnyAnnotation(options.bindingContainerAnnotations)) {
         if (bindingContainers.add(parameterKey)) {
           inputs +=
-            includedBindingContainer(
+            bindingContainerInput(
               parameterType,
               parameterKey,
-              parameter,
+              parameter.symbol.psi ?: parameterType.symbol.psi,
               options,
               pointerManager,
               cacheDependencies,
@@ -159,10 +160,10 @@ private fun KaSession.includedGraphDependency(
   )
 }
 
-private fun KaSession.includedBindingContainer(
+internal fun KaSession.bindingContainerInput(
   containerType: KaClassType,
   containerKey: KaTypeKey,
-  parameter: CallableParameterView,
+  inputElement: PsiElement?,
   options: MetroOptions,
   pointerManager: SmartPointerManager,
   cacheDependencies: MutableSet<PsiFile>,
@@ -170,11 +171,10 @@ private fun KaSession.includedBindingContainer(
 ): FactoryInputEntry {
   val bindings = mutableListOf<KaBinding>()
   val consumers = mutableListOf<ConsumerEntry>()
-  val ownerElement = parameter.symbol.psi ?: containerType.symbol.psi
-  if (ownerElement != null) {
+  if (inputElement != null) {
     bindings +=
       KaBinding.BoundInstance(
-        pointerManager.createSmartPsiElementPointer(ownerElement),
+        pointerManager.createSmartPsiElementPointer(inputElement),
         containerKey,
         containerId = null,
         isBindingContainerInput = true,

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/IndexModels.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/IndexModels.kt
@@ -8,6 +8,7 @@ import dev.zacsweers.metro.idea.model.AssistedSite
 import dev.zacsweers.metro.idea.model.BindingContainerEntry
 import dev.zacsweers.metro.idea.model.ConsumerEntry
 import dev.zacsweers.metro.idea.model.ContributionEntry
+import dev.zacsweers.metro.idea.model.DynamicGraphCall
 import dev.zacsweers.metro.idea.model.GraphDefaultImplementation
 import dev.zacsweers.metro.idea.model.GraphExtensionFactoryAccessor
 import dev.zacsweers.metro.idea.model.GraphInterfaceContribution
@@ -160,6 +161,7 @@ internal class FileShard(
   val assistedSites: List<AssistedSite>,
   val bindingContainers: List<BindingContainerEntry>,
   val factoryInputs: List<FactoryInputEntry>,
+  val dynamicGraphs: List<DynamicGraphCall>,
   /** Referenced declaration files whose changes require this shard to be rebuilt. */
   val dependencyFiles: Set<VirtualFile>,
   val graphInterfaces: List<GraphInterfaceSurface> = emptyList(),
@@ -167,6 +169,7 @@ internal class FileShard(
   companion object {
     val EMPTY =
       FileShard(
+        emptyList(),
         emptyList(),
         emptyList(),
         emptyList(),

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroResolutionService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroResolutionService.kt
@@ -52,6 +52,8 @@ import dev.zacsweers.metro.idea.model.BindingContainerEntry
 import dev.zacsweers.metro.idea.model.BindingIndex
 import dev.zacsweers.metro.idea.model.ConsumerEntry
 import dev.zacsweers.metro.idea.model.ContributionEntry
+import dev.zacsweers.metro.idea.model.DynamicGraphCall
+import dev.zacsweers.metro.idea.model.DynamicGraphId
 import dev.zacsweers.metro.idea.model.GraphCallableReference
 import dev.zacsweers.metro.idea.model.GraphCallableSignature
 import dev.zacsweers.metro.idea.model.GraphDeclarationId
@@ -87,6 +89,7 @@ import org.jetbrains.kotlin.idea.stubindex.KotlinAnnotationsIndex
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtElement
@@ -550,6 +553,7 @@ class MetroResolutionService(
           incompleteAssistedFactories =
             if (key.resolveFromLibraries) library.incompleteFactories
             else summary.sourceFactories.incompleteFactories,
+          dynamicGraphs = source.dynamicGraphs,
         )
       // Only cache when nothing invalidated the pass semantically. A plain re-drain of new dirty
       // files under the same generation still describes this exact source snapshot.
@@ -677,6 +681,7 @@ class MetroResolutionService(
     val assistedSites = mutableListOf<AssistedSite>()
     val bindingContainers = mutableListOf<BindingContainerEntry>()
     val graphInterfaces = mutableListOf<GraphInterfaceSurface>()
+    val dynamicGraphs = linkedMapOf<DynamicGraphId, DynamicGraphCall>()
     val factoryInputs = linkedMapOf<FactoryInputEntry.Id, FactoryInputEntry>()
     var factoryInputBindings: CanonicalFactoryInputBindings? = null
     var completed = 0
@@ -713,6 +718,9 @@ class MetroResolutionService(
         assistedSites += shard.assistedSites
         bindingContainers += shard.bindingContainers
         graphInterfaces += shard.graphInterfaces
+        for (dynamicGraph in shard.dynamicGraphs) {
+          dynamicGraphs.putIfAbsent(dynamicGraph.id, dynamicGraph)
+        }
         for (input in shard.factoryInputs) factoryInputs.putIfAbsent(input.id, input)
       } finally {
         completed++
@@ -741,6 +749,7 @@ class MetroResolutionService(
       contributions,
       assistedSites,
       bindingContainers,
+      dynamicGraphs.values.toList(),
     )
   }
 
@@ -864,6 +873,19 @@ class MetroResolutionService(
         ?: annotationId.shortClassName.asString()
     }
     val searchHelper = PsiSearchHelper.getInstance(project)
+    for (callableId in DYNAMIC_GRAPH_CALLABLES.keys) {
+      val callableName = callableId.callableName.asString()
+      searchHelper.processElementsWithWord(
+        { element, _ ->
+          (element.containingFile as? KtFile)?.let(files::add)
+          true
+        },
+        searchScope,
+        callableName,
+        UsageSearchContext.IN_CODE,
+        true,
+      )
+    }
     for ((searchWord, matchingIds) in idsBySearchWord) {
       ProgressManager.checkCanceled()
       val canonicalNames = matchingIds.mapToSet { it.asSingleFqName() }
@@ -900,8 +922,24 @@ class MetroResolutionService(
       } else {
         shortNames
       }
-    return PsiTreeUtil.collectElementsOfType(file, KtAnnotationEntry::class.java).any { entry ->
-      entry.shortName?.asString() in names
+    val hasRelevantAnnotation =
+      PsiTreeUtil.collectElementsOfType(file, KtAnnotationEntry::class.java).any { entry ->
+        entry.shortName?.asString() in names
+      }
+    if (hasRelevantAnnotation) return true
+
+    val dynamicGraphNames = buildSet {
+      for (callableId in DYNAMIC_GRAPH_CALLABLES.keys) {
+        add(callableId.callableName.asString())
+        for (directive in file.importDirectives) {
+          if (directive.importedFqName == callableId.asSingleFqName()) {
+            directive.aliasName?.let(::add)
+          }
+        }
+      }
+    }
+    return PsiTreeUtil.collectElementsOfType(file, KtCallExpression::class.java).any { call ->
+      call.calleeExpression?.text in dynamicGraphNames
     }
   }
 
@@ -1615,6 +1653,15 @@ private fun FileShard.librarySignature(): SourceLibraryShardSignature {
         input.bindings.mapNotNull(::bindingLibrarySignature),
       )
     },
+    dynamicGraphs.map { dynamicGraph ->
+      DynamicGraphLibrarySignature(
+        dynamicGraph.id,
+        dynamicGraph.targetGraph,
+        dynamicGraph.bindingKeys,
+        dynamicGraph.isFactory,
+        dynamicGraph.pointer.element != null,
+      )
+    },
     graphInterfaces.map(::graphInterfaceLibrarySignature),
   )
 }
@@ -1781,7 +1828,16 @@ private data class SourceLibraryShardSignature(
   val writtenBindingKeys: List<KaTypeKey>,
   val bindings: List<BindingLibrarySignature>,
   val factoryInputs: List<FactoryInputLibrarySignature>,
+  val dynamicGraphs: List<DynamicGraphLibrarySignature>,
   val graphInterfaces: List<GraphInterfaceLibrarySignature>,
+)
+
+private data class DynamicGraphLibrarySignature(
+  val id: DynamicGraphId,
+  val targetGraph: GraphReference,
+  val bindingKeys: Set<KaTypeKey>,
+  val isFactory: Boolean,
+  val pointerIsValid: Boolean,
 )
 
 private data class GraphLibrarySignature(
@@ -1997,6 +2053,7 @@ private class SourceLibrarySummaryReference {
           source.contributions,
           source.assistedSites,
           source.bindingContainers,
+          dynamicGraphs = source.dynamicGraphs,
         )
       val consumerGraphContexts = ConsumerGraphContexts(sourceIndex)
       val sourceFactories =
@@ -2037,6 +2094,7 @@ private data class SourceAggregate(
   val contributions: List<ContributionEntry>,
   val assistedSites: List<AssistedSite>,
   val bindingContainers: List<BindingContainerEntry>,
+  val dynamicGraphs: List<DynamicGraphCall>,
 ) {
   fun withAddedFactories(factories: List<KaBinding.AssistedFactory>): SourceAggregate {
     if (factories.isEmpty()) return this
@@ -2071,6 +2129,10 @@ private data class SourceAggregate(
       ProgressManager.checkCanceled()
       scopeIds += graph.scopeKeys
       addModule(graph.pointer.element)
+    }
+    for (dynamicGraph in dynamicGraphs) {
+      ProgressManager.checkCanceled()
+      addModule(dynamicGraph.pointer.element)
     }
     for (contribution in contributions) {
       ProgressManager.checkCanceled()

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndex.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndex.kt
@@ -37,6 +37,7 @@ internal class BindingIndex(
   private val incompleteAssistedFactories:
     Map<KaModule, Map<SourceAssistedFactoryIdentity, String>> =
     emptyMap(),
+  val dynamicGraphs: List<DynamicGraphCall> = emptyList(),
 ) {
   private val containersById: ScatterMap<ClassId, List<BindingContainerEntry>> by lazy {
     bindingContainers.groupToScatter { it.classId }
@@ -113,6 +114,10 @@ internal class BindingIndex(
       }
     }
     result
+  }
+
+  private val dynamicGraphsByTarget: Map<GraphReference, List<DynamicGraphCall>> by lazy {
+    dynamicGraphs.groupBy { it.targetGraph }
   }
 
   /** Potential edges only. Their contribution must survive in the eventual parent's root module. */
@@ -743,7 +748,8 @@ internal class BindingIndex(
     graphQueryContexts[context]?.let {
       return it
     }
-    val graphElement = context.rootGraph.pointer.element ?: return null
+    val graphElement =
+      context.dynamicGraph?.pointer?.element ?: context.rootGraph.pointer.element ?: return null
     val graphModule = moduleFor(graphElement) ?: return null
     val resolutionScope = graphModule.resolutionScope()
     val containers = containersFor(context, graphModule, resolutionScope)
@@ -765,7 +771,9 @@ internal class BindingIndex(
   fun extensionContextsOf(parent: GraphContext): List<GraphContext> {
     val queryContext = queryContext(parent) ?: return emptyList()
     return extensionsOf(queryContext).flatMap { extension ->
-      contextsFor(extension).filter { child -> child.chain.drop(1) == parent.chain }
+      contextsFor(extension).filter { child ->
+        child.chain.drop(1) == parent.chain && child.dynamicGraph?.id == parent.dynamicGraph?.id
+      }
     }
   }
 
@@ -801,7 +809,17 @@ internal class BindingIndex(
   }
 
   private fun buildContexts(graph: KaGraphDeclaration): List<GraphContext> {
-    return buildChains(graph, visited = setOf(graph)).map(::buildContext)
+    return buildChains(graph, visited = setOf(graph)).flatMap { chain ->
+      buildList {
+        add(buildContext(chain, dynamicGraph = null))
+        val root = chain.last()
+        val rootReference =
+          root.classId?.let { classId -> GraphReference(classId, root.pointer.virtualFile) }
+        for (dynamicGraph in rootReference?.let(dynamicGraphsByTarget::get).orEmpty()) {
+          add(buildContext(chain, dynamicGraph))
+        }
+      }
+    }
   }
 
   private fun buildChains(
@@ -834,12 +852,18 @@ internal class BindingIndex(
     return chains.ifEmpty { listOf(listOf(graph)) }
   }
 
-  private fun buildContext(chain: List<KaGraphDeclaration>): GraphContext {
+  private fun buildContext(
+    chain: List<KaGraphDeclaration>,
+    dynamicGraph: DynamicGraphCall?,
+  ): GraphContext {
     val scopes = chain.flatMapToSet { it.scopeKeys }
     val excludes = chain.flatMapToSet { it.excludes }
     // Supertype members merge into the graph, so their classes gate membership like the graph
     val graphClassIds = chain.flatMapToSet { it.selfIds + it.supertypeIds }
-    val includedBindingContainers = chain.flatMapToSet { it.includedBindingContainers }
+    val includedBindingContainers = buildSet {
+      chain.flatMapTo(this) { it.includedBindingContainers }
+      addAll(dynamicGraph?.containerKeys.orEmpty())
+    }
     val includedDependencies = chain.flatMapToSet { it.includedDependencies }
     val graphIds = chain.mapTo(mutableSetOf()) { it.declarationId }
     return GraphContext(
@@ -853,6 +877,7 @@ internal class BindingIndex(
       daggerAnvilInteropEnabled = chain.last().daggerAnvilInteropEnabled,
       graphIds = graphIds,
       graphClassIds = graphClassIds,
+      dynamicGraph = dynamicGraph,
     )
   }
 
@@ -905,6 +930,11 @@ internal class BindingIndex(
       for (containerKey in owner.includedBindingContainers) {
         containerKey.type.classId?.let(roots::add)
       }
+      if (owner.declarationId == context.rootGraph.declarationId) {
+        for (containerKey in context.dynamicGraph?.containerKeys.orEmpty()) {
+          containerKey.type.classId?.let(roots::add)
+        }
+      }
       contributionSelection(
           ownerChain,
           queryContext.graphModule,
@@ -923,7 +953,8 @@ internal class BindingIndex(
     binding: KaBinding,
     queryContext: GraphQueryContext,
   ): Boolean {
-    val graph = queryContext.graphContext.graph
+    val context = queryContext.graphContext
+    val graph = context.graph
     val ownerGraphId = binding.ownerGraphId
     if (ownerGraphId != null) {
       if (binding is KaBinding.BoundInstance) {
@@ -933,7 +964,9 @@ internal class BindingIndex(
     }
     val includedContainerKey = binding.includedContainerKey
     if (includedContainerKey != null) {
-      return includedContainerKey in graph.includedBindingContainers
+      if (includedContainerKey in graph.includedBindingContainers) return true
+      val isDynamicRoot = graph.declarationId == context.rootGraph.declarationId
+      return isDynamicRoot && includedContainerKey in context.dynamicGraph?.containerKeys.orEmpty()
     }
 
     val containerId = binding.containerId
@@ -957,9 +990,14 @@ internal class BindingIndex(
       return false
     }
 
-    val chain = queryContext.graphContext.chain
+    val context = queryContext.graphContext
+    val chain = context.chain
     for (ancestorIndex in 1 until chain.size) {
-      val ancestorPath = GraphPath(chain.drop(ancestorIndex).map { it.declarationId })
+      val ancestorPath =
+        GraphPath(
+          chain.drop(ancestorIndex).map { it.declarationId },
+          context.dynamicGraph?.id,
+        )
       val ancestorContext = findContext(ancestorPath) ?: continue
       val ancestorQueryContext = queryContext(ancestorContext) ?: continue
       for (binding in candidates) {
@@ -1151,6 +1189,7 @@ internal class BindingIndex(
     }
     if (entry.isGraphPrivate && !isBindingOwnedByCurrentGraph(entry, queryContext)) return false
     val context = queryContext.graphContext
+    if (isSupersededByDynamicBinding(entry, context)) return false
     val ownerGraphId = entry.ownerGraphId
     if (ownerGraphId != null) {
       if (entry is KaBinding.BoundInstance) {
@@ -1213,6 +1252,31 @@ internal class BindingIndex(
       is KaBinding.GraphInstance,
       is KaBinding.GraphExtension -> true
     }
+  }
+
+  private fun isSupersededByDynamicBinding(
+    binding: KaBinding,
+    context: GraphContext,
+  ): Boolean {
+    val dynamicGraph = context.dynamicGraph ?: return false
+    if (binding.multibindingId != null) return false
+    val hasDynamicReplacement =
+      binding.typeKey in dynamicGraph.bindingKeys || binding.typeKey in dynamicGraph.containerKeys
+    if (!hasDynamicReplacement) return false
+
+    val includedContainerKey = binding.includedContainerKey
+    if (includedContainerKey != null && includedContainerKey in dynamicGraph.containerKeys) {
+      return false
+    }
+    if (binding is KaBinding.BoundInstance && binding.isBindingContainerInput) {
+      val source = pointerIdentity(binding.pointer)
+      val isDynamicInput =
+        dynamicGraph.containerInputs.any { input ->
+          input.typeKey == binding.typeKey && pointerIdentity(input.pointer) == source
+        }
+      if (isDynamicInput) return false
+    }
+    return true
   }
 
   private fun isContributedBindingActive(

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingModel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingModel.kt
@@ -9,6 +9,7 @@ import dev.zacsweers.metro.compiler.graph.MergeContribution
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtElement
 
@@ -208,6 +209,26 @@ internal data class GraphDeclarationId(
   val file: VirtualFile?,
 )
 
+/** The compiler identity shared by equivalent dynamic-graph calls in one source file. */
+internal data class DynamicGraphId(
+  val requestedTypeClassId: ClassId,
+  val containerKeys: Set<KaTypeKey>,
+  val callerFile: VirtualFile,
+)
+
+/** One distinct `createDynamicGraph*` context and the bindings supplied by its containers. */
+internal class DynamicGraphCall(
+  val pointer: SmartPsiElementPointer<KtCallExpression>,
+  val id: DynamicGraphId,
+  val targetGraph: GraphReference,
+  val bindingKeys: Set<KaTypeKey>,
+  val containerInputs: List<KaBinding.BoundInstance>,
+  val isFactory: Boolean,
+) {
+  val containerKeys: Set<KaTypeKey>
+    get() = id.containerKeys
+}
+
 /** One concrete assisted-factory declaration, including its exact source or binary file. */
 internal data class SourceAssistedFactoryIdentity(
   val key: KaTypeKey,
@@ -279,7 +300,10 @@ internal class GraphComposition(
 )
 
 /** A concrete graph path, ordered from the graph itself through its ancestors. */
-internal data class GraphPath(val segments: List<GraphDeclarationId>)
+internal data class GraphPath(
+  val segments: List<GraphDeclarationId>,
+  val dynamicGraphId: DynamicGraphId? = null,
+)
 
 /**
  * The aggregated view a single graph (plus its parent chain, for extensions) has of the project:
@@ -303,6 +327,8 @@ internal class GraphContext(
   /** Exact declarations in this graph path, used for graph-owned consumers. */
   val graphIds: Set<GraphDeclarationId>,
   val graphClassIds: Set<ClassId>,
+  /** The dynamic call-site variant inherited by this graph and its extension children. */
+  val dynamicGraph: DynamicGraphCall? = null,
 ) {
   val graph: KaGraphDeclaration
     get() = chain.first()
@@ -311,8 +337,12 @@ internal class GraphContext(
   val rootGraph: KaGraphDeclaration
     get() = chain.last()
 
+  /** The source element whose compilation owns this graph context. */
+  val contextPointer: SmartPsiElementPointer<out KtElement>
+    get() = dynamicGraph?.pointer ?: graph.pointer
+
   /** Stable declaration identity for this exact parent path. */
-  val path: GraphPath = GraphPath(chain.map { it.declarationId })
+  val path: GraphPath = GraphPath(chain.map { it.declarationId }, dynamicGraph?.id)
 }
 
 /**

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroGraphDebugExporter.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroGraphDebugExporter.kt
@@ -128,7 +128,7 @@ internal class MetroGraphDebugExporter(
 
   /** Builds a report for the current version of this exact parent path under a read action. */
   fun report(context: GraphContext): String? {
-    val element = context.graph.pointer.element ?: return null
+    val element = context.contextPointer.element ?: return null
     val service = project.service<MetroGraphValidationService>()
     return service.debugLookup(element, context) { index, queryContext, options, lookup ->
       val currentContext = queryContext.graphContext
@@ -224,6 +224,13 @@ private class GraphDebugReport(
     field("includedDependencies", keys(context.includedDependencies))
     field("injectedMemberOwners", classIds(context.injectedMemberOwnerIds))
     field("daggerAnvilInteropEnabled", context.daggerAnvilInteropEnabled)
+    context.dynamicGraph?.let { dynamicGraph ->
+      field("dynamic.callSite", location(dynamicGraph.pointer))
+      field("dynamic.requestedType", classId(dynamicGraph.id.requestedTypeClassId))
+      field("dynamic.isFactory", dynamicGraph.isFactory)
+      field("dynamic.containers", keys(dynamicGraph.containerKeys))
+      field("dynamic.replacementKeys", keys(dynamicGraph.bindingKeys))
+    }
     for (graph in context.chain) {
       ProgressManager.checkCanceled()
       writeGraph(graph)

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
@@ -277,7 +277,7 @@ internal class MetroToolWindowPanel(private val project: Project) :
   }
 
   private fun validateContext(context: GraphContext) {
-    val element = context.graph.pointer.element ?: return
+    val element = context.contextPointer.element ?: return
     validationService.validateWithExtensionsAsync(element, context) {
       validationFinished(validationVisitor(context))
     }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroTreeStructure.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroTreeStructure.kt
@@ -70,7 +70,7 @@ internal sealed class MetroTreeNode(val parent: MetroTreeNode?) {
       get() = context.graph
 
     override val icon: Icon = MetroIcons.GRAPH
-    override val pointer: SmartPsiElementPointer<*> = graph.pointer
+    override val pointer: SmartPsiElementPointer<*> = context.contextPointer
     override val identity: Any = context.path
   }
 
@@ -396,14 +396,33 @@ internal class MetroTreeStructure(
         compareBy(
           { it.graph.name.orEmpty() },
           { it.chain.drop(1).joinToString { parent -> parent.name.orEmpty() } },
+          { it.dynamicGraph?.pointer?.virtualFile?.path.orEmpty() },
+          { it.dynamicGraph?.pointer?.element?.textOffset ?: -1 },
+          {
+            it.dynamicGraph
+              ?.containerKeys
+              .orEmpty()
+              .map { key -> key.render(short = false) }
+              .sorted()
+              .joinToString()
+          },
         )
       )
       .map { context ->
         val graph = context.graph
         // Surface the last validation outcome on the graph row itself
-        val cached = graph.pointer.element?.let { validationService.cachedResult(it, context) }
+        val cached =
+          context.contextPointer.element?.let { validationService.cachedResult(it, context) }
         val grayText = buildString {
-          graph.pointer.virtualFile?.name?.let(::append)
+          val dynamicGraph = context.dynamicGraph
+          if (dynamicGraph == null) {
+            graph.pointer.virtualFile?.name?.let(::append)
+          } else {
+            append("dynamic at ")
+            append(dynamicGraphLocation(dynamicGraph.pointer))
+            append(" · ")
+            append(dynamicGraph.containerKeys.map { it.type.shortType }.sorted().joinToString())
+          }
           val parents = context.chain.drop(1)
           if (parents.isNotEmpty()) {
             if (isNotEmpty()) append(" · ")
@@ -422,6 +441,13 @@ internal class MetroTreeStructure(
           grayText = grayText.takeIf { it.isNotEmpty() },
         )
       }
+  }
+
+  private fun dynamicGraphLocation(pointer: SmartPsiElementPointer<*>): String {
+    val file = pointer.virtualFile?.name ?: "<unknown>"
+    val element = pointer.element ?: return file
+    val document = element.containingFile?.viewProvider?.document ?: return file
+    return "$file:${document.getLineNumber(element.textOffset) + 1}"
   }
 
   private fun graphChildren(node: MetroTreeNode.Graph): List<MetroTreeNode> {

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
@@ -1,0 +1,339 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea
+
+import com.intellij.openapi.components.service
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import dev.zacsweers.metro.compiler.diagnostics.MetroDiagnosticId
+import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
+import dev.zacsweers.metro.idea.index.MetroResolutionService
+import dev.zacsweers.metro.idea.model.BindingIndex
+import dev.zacsweers.metro.idea.model.ConsumerEntry
+import dev.zacsweers.metro.idea.model.GraphContext
+import dev.zacsweers.metro.idea.model.KaBinding
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+
+class MetroDynamicGraphTest : BasePlatformTestCase() {
+
+  override fun setUp() {
+    super.setUp()
+    project.setMetroOptions()
+    module.addMetroRuntimeLibrary()
+    project.service<MetroGraphValidationService>().clearResults()
+  }
+
+  fun testDynamicBindingContainersReplaceStaticBindings() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        @BindingContainer
+        object RealBindings {
+          @Provides fun provideReal(): String = "real"
+        }
+
+        @BindingContainer
+        object FakeBindings {
+          @Provides fun provideFake(): String = "fake"
+        }
+
+        @DependencyGraph(bindingContainers = [RealBindings::class])
+        interface AppGraph {
+          val value: String
+        }
+
+        val dynamicGraph = createDynamicGraph<AppGraph>(FakeBindings)
+        """
+      )
+    val index = project.service<MetroResolutionService>().index(file)
+    val graph = index.graphs.single { it.name == "AppGraph" }
+    val contexts = index.contextsFor(graph)
+    val staticContext = contexts.single { it.dynamicGraph == null }
+    val dynamicContext = contexts.single { it.dynamicGraph != null }
+    val consumer =
+      checkNotNull(index.consumerEntryAt(file.declarationsIncludingNested().property("value")))
+
+    assertEquals(listOf("provideReal"), index.providerNames(consumer, staticContext))
+    assertEquals(listOf("provideFake"), index.providerNames(consumer, dynamicContext))
+    assertTrue(dynamicContext.contextPointer.element is KtCallExpression)
+
+    val result =
+      project
+        .service<MetroGraphValidationService>()
+        .validate(file, dynamicContext)
+        .requireCompleted()
+    assertTrue(result.diagnostics.isEmpty())
+  }
+
+  fun testEquivalentCallsShareAContextWithinAFileButNotAcrossFiles() {
+    val declarations =
+      myFixture.addFileToProject(
+        "test/Graph.kt",
+        """
+        package test
+
+        import dev.zacsweers.metro.*
+
+        @BindingContainer object FakeBindings
+        @DependencyGraph interface AppGraph
+        """
+          .trimIndent(),
+      ) as KtFile
+    val firstCalls =
+      myFixture.addFileToProject(
+        "test/FirstCalls.kt",
+        """
+        package test
+
+        import dev.zacsweers.metro.*
+
+        val first: AppGraph = createDynamicGraph(FakeBindings)
+        val second = createDynamicGraph<AppGraph>(FakeBindings)
+        """
+          .trimIndent(),
+      ) as KtFile
+    val secondCalls =
+      myFixture.addFileToProject(
+        "test/SecondCalls.kt",
+        """
+        package test
+
+        import dev.zacsweers.metro.*
+
+        val third = createDynamicGraph<AppGraph>(FakeBindings)
+        """
+          .trimIndent(),
+      ) as KtFile
+
+    val index = project.service<MetroResolutionService>().index(declarations)
+    val graph = index.graphs.single { it.name == "AppGraph" }
+    val dynamicContexts = index.contextsFor(graph).filter { it.dynamicGraph != null }
+
+    assertEquals(2, dynamicContexts.size)
+    assertEquals(
+      setOf(firstCalls.virtualFile, secondCalls.virtualFile),
+      dynamicContexts.mapTo(mutableSetOf()) { it.dynamicGraph!!.id.callerFile },
+    )
+  }
+
+  fun testDynamicGraphFactoryUsesReturnedGraphAndConcreteContainerTypes() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        @BindingContainer
+        object RealBindings {
+          @Provides fun provideReal(): String = "real"
+        }
+
+        @BindingContainer
+        class GenericBindings<T>(private val value: T) {
+          @Provides fun provideValue(): T = value
+        }
+
+        @DependencyGraph(bindingContainers = [RealBindings::class])
+        interface AppGraph {
+          val value: String
+
+          @DependencyGraph.Factory
+          fun interface Factory {
+            fun create(): AppGraph
+          }
+        }
+
+        val factory = createDynamicGraphFactory<AppGraph.Factory>(GenericBindings("fake"))
+        """
+      )
+    val index = project.service<MetroResolutionService>().index(file)
+    val graph = index.graphs.single { it.name == "AppGraph" }
+    val context = index.contextsFor(graph).single { it.dynamicGraph != null }
+    val dynamicGraph = checkNotNull(context.dynamicGraph)
+    val consumer =
+      checkNotNull(index.consumerEntryAt(file.declarationsIncludingNested().property("value")))
+
+    assertTrue(dynamicGraph.isFactory)
+    assertEquals("test.AppGraph.Factory", dynamicGraph.id.requestedTypeClassId.asFqNameString())
+    assertEquals(
+      listOf("test.GenericBindings<kotlin.String>"),
+      dynamicGraph.containerKeys.map { it.renderedType },
+    )
+    assertEquals(listOf("provideValue"), index.providerNames(consumer, context))
+    assertTrue(
+      project
+        .service<MetroGraphValidationService>()
+        .validate(file, context)
+        .requireCompleted()
+        .diagnostics
+        .isEmpty()
+    )
+  }
+
+  fun testDynamicBindingsFlowIntoGraphExtensions() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        @BindingContainer
+        object RealBindings {
+          @Provides fun provideReal(): String = "real"
+        }
+
+        @BindingContainer
+        object FakeBindings {
+          @Provides fun provideFake(): String = "fake"
+        }
+
+        @GraphExtension
+        interface ChildGraph {
+          val value: String
+        }
+
+        @DependencyGraph(bindingContainers = [RealBindings::class])
+        interface AppGraph {
+          val child: ChildGraph
+        }
+
+        val dynamicGraph = createDynamicGraph<AppGraph>(FakeBindings)
+        """
+      )
+    val index = project.service<MetroResolutionService>().index(file)
+    val parent = index.graphs.single { it.name == "AppGraph" }
+    val child = index.graphs.single { it.name == "ChildGraph" }
+    val parentContext = index.contextsFor(parent).single { it.dynamicGraph != null }
+    val childContext = index.contextsFor(child).single { it.dynamicGraph != null }
+    val childConsumer =
+      checkNotNull(index.consumerEntryAt(file.declarationsIncludingNested().property("value")))
+
+    assertSame(parentContext.dynamicGraph, childContext.dynamicGraph)
+    assertEquals(listOf(childContext), index.extensionContextsOf(parentContext))
+    assertEquals(listOf("provideFake"), index.providerNames(childConsumer, childContext))
+
+    val results =
+      project.service<MetroGraphValidationService>().validateWithExtensions(file, parentContext)
+    assertEquals(listOf("ChildGraph", "AppGraph"), results.map { it.graph.name })
+    assertTrue(results.all { it.requireCompleted().diagnostics.isEmpty() })
+  }
+
+  fun testDynamicMultibindingContributionsRemainAdditive() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        interface Listener
+        class RealListener : Listener
+        class FakeListener : Listener
+
+        @BindingContainer
+        object RealBindings {
+          @Provides @IntoSet fun realListener(): Listener = RealListener()
+        }
+
+        @BindingContainer
+        object FakeBindings {
+          @Provides @IntoSet fun fakeListener(): Listener = FakeListener()
+        }
+
+        @DependencyGraph(bindingContainers = [RealBindings::class])
+        interface AppGraph {
+          @Multibinds(allowEmpty = true) fun listeners(): Set<Listener>
+        }
+
+        val dynamicGraph = createDynamicGraph<AppGraph>(FakeBindings)
+        """
+      )
+    val index = project.service<MetroResolutionService>().index(file)
+    val graph = index.graphs.single { it.name == "AppGraph" }
+    val context = index.contextsFor(graph).single { it.dynamicGraph != null }
+    val queryContext = checkNotNull(index.queryContext(context))
+    val contributionNames =
+      index
+        .bindingsInContext(queryContext)
+        .filter { it.multibindingId != null }
+        .mapNotNull { (it.pointer.element as? KtNamedDeclaration)?.name }
+        .sorted()
+
+    assertEquals(listOf("fakeListener", "realListener"), contributionNames)
+    assertTrue(
+      project
+        .service<MetroGraphValidationService>()
+        .validate(file, context)
+        .requireCompleted()
+        .diagnostics
+        .isEmpty()
+    )
+  }
+
+  fun testMultipleDynamicBindingsForOneKeyRemainDuplicates() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        @BindingContainer
+        object RealBindings {
+          @Provides fun realValue(): String = "real"
+        }
+
+        @BindingContainer
+        object FirstFakeBindings {
+          @Provides fun firstFakeValue(): String = "first"
+        }
+
+        @BindingContainer
+        object SecondFakeBindings {
+          @Provides fun secondFakeValue(): String = "second"
+        }
+
+        @DependencyGraph(bindingContainers = [RealBindings::class])
+        interface AppGraph {
+          val value: String
+        }
+
+        val dynamicGraph =
+          createDynamicGraph<AppGraph>(FirstFakeBindings, SecondFakeBindings)
+        """
+      )
+    val index = project.service<MetroResolutionService>().index(file)
+    val graph = index.graphs.single { it.name == "AppGraph" }
+    val context = index.contextsFor(graph).single { it.dynamicGraph != null }
+    val result =
+      project.service<MetroGraphValidationService>().validate(file, context).requireCompleted()
+
+    assertEquals(listOf(MetroDiagnosticId.DUPLICATE_BINDING), result.diagnostics.map { it.id })
+  }
+
+  fun testAliasedIntrinsicIsRecognizedAndSameNamedFunctionIsIgnored() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        import dev.zacsweers.metro.createDynamicGraph as metroDynamicGraph
+
+        @BindingContainer object FakeBindings
+        @DependencyGraph interface AppGraph
+
+        fun <T> createDynamicGraph(vararg ignored: Any): T = error("unused")
+
+        val metro = metroDynamicGraph<AppGraph>(FakeBindings)
+        val unrelated: AppGraph = createDynamicGraph(FakeBindings)
+        """
+      )
+    val index = project.service<MetroResolutionService>().index(file)
+    val graph = index.graphs.single { it.name == "AppGraph" }
+    val dynamicContexts = index.contextsFor(graph).filter { it.dynamicGraph != null }
+    val metroCall =
+      PsiTreeUtil.collectElementsOfType(file, KtCallExpression::class.java).single {
+        it.calleeExpression?.text == "metroDynamicGraph"
+      }
+
+    assertEquals(1, dynamicContexts.size)
+    assertSame(metroCall, dynamicContexts.single().contextPointer.element)
+  }
+
+  private fun BindingIndex.providerNames(
+    consumer: ConsumerEntry,
+    context: GraphContext,
+  ): List<String> {
+    val queryContext = checkNotNull(queryContext(context))
+    return bindingsFor(consumer, queryContext)
+      .filterIsInstance<KaBinding.Provided>()
+      .mapNotNull { (it.pointer.element as? KtNamedDeclaration)?.name }
+      .sorted()
+  }
+}

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroMultiModuleResolutionTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroMultiModuleResolutionTest.kt
@@ -690,6 +690,82 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     assertEquals(appContext.graphModule, index.queryContext(extensionContext)!!.graphModule)
   }
 
+  fun testDynamicGraphUsesTheCallSiteModuleAndReplacesLibraryGraphBindings() {
+    val libraryFile =
+      fixture.addFileToProject(
+        "library/lib/LibGraph.kt",
+        """
+        package lib
+
+        import dev.zacsweers.metro.*
+
+        @BindingContainer
+        object RealBindings {
+          @Provides fun provideReal(): String = "real"
+        }
+
+        @DependencyGraph(bindingContainers = [RealBindings::class])
+        interface LibGraph {
+          val value: String
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    val appFile =
+      fixture.addFileToProject(
+        "app/app/DynamicGraph.kt",
+        """
+        package app
+
+        import dev.zacsweers.metro.*
+        import lib.LibGraph
+
+        @BindingContainer
+        object FakeBindings {
+          @Provides fun provideFake(): String = "fake"
+        }
+
+        val graph = createDynamicGraph<LibGraph>(FakeBindings)
+        """
+          .trimIndent(),
+      ) as KtFile
+    PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
+    IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
+
+    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val graph = index.graphs.single { it.name == "LibGraph" }
+    val contexts = index.contextsFor(graph)
+    val staticContext = contexts.single { it.dynamicGraph == null }
+    val dynamicContext = contexts.single { it.dynamicGraph != null }
+    val appKaModule = KaModuleProvider.getModule(fixture.project, appFile, useSiteModule = null)
+    val consumer =
+      checkNotNull(
+        index.consumerEntryAt(libraryFile.declarationsIncludingNested().property("value"))
+      )
+
+    assertEquals(appKaModule, index.queryContext(dynamicContext)!!.graphModule)
+    assertEquals(
+      listOf("provideReal"),
+      index.bindingsFor(consumer, index.queryContext(staticContext)!!).mapNotNull {
+        (it.pointer.element as? KtNamedDeclaration)?.name
+      },
+    )
+    assertEquals(
+      listOf("provideFake"),
+      index.bindingsFor(consumer, index.queryContext(dynamicContext)!!).mapNotNull {
+        (it.pointer.element as? KtNamedDeclaration)?.name
+      },
+    )
+    assertTrue(
+      fixture.project
+        .service<MetroGraphValidationService>()
+        .validate(appFile, dynamicContext)
+        .requireCompleted()
+        .diagnostics
+        .isEmpty()
+    )
+  }
+
   fun testRegularDependenciesAreNotRecursivelyVisible() {
     val libraryFile =
       fixture.addFileToProject(

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
@@ -43,6 +43,7 @@ import dev.zacsweers.metro.idea.toolwindow.writeGraphDebugReport
 import java.nio.file.Files
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFile
 
 /** Walks [MetroTreeStructure] directly, without Swing, and asserts the produced rows. */
@@ -137,6 +138,50 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
     assertEquals(
       listOf("DebugAnalytics", "ProdAnalytics"),
       structure.children(multibinding).map { it.text },
+    )
+  }
+
+  fun testDynamicGraphRowsIdentifyAndNavigateToTheirCallSite() {
+    myFixture.configureMetroFile(
+      """
+      @BindingContainer
+      object RealBindings {
+        @Provides fun provideReal(): String = "real"
+      }
+
+      @BindingContainer
+      object FakeBindings {
+        @Provides fun provideFake(): String = "fake"
+      }
+
+      @DependencyGraph(bindingContainers = [RealBindings::class])
+      interface AppGraph {
+        val value: String
+      }
+
+      val graph = createDynamicGraph<AppGraph>(FakeBindings)
+      """,
+      fileName = "DynamicGraph.kt",
+    )
+
+    val structure = structure()
+    val root = structure.rootElement as MetroTreeNode
+    val graphRows = structure.children(root).filterIsInstance<MetroTreeNode.Graph>()
+    val staticRow = graphRows.single { it.context.dynamicGraph == null }
+    val dynamicRow = graphRows.single { it.context.dynamicGraph != null }
+
+    assertEquals("DynamicGraph.kt", staticRow.grayText)
+    assertTrue(dynamicRow.grayText, dynamicRow.grayText!!.startsWith("dynamic at DynamicGraph.kt:"))
+    assertTrue(dynamicRow.grayText, "FakeBindings" in dynamicRow.grayText!!)
+    assertTrue(dynamicRow.pointer?.element is KtCallExpression)
+
+    val unscoped =
+      structure.children(dynamicRow).filterIsInstance<MetroTreeNode.Category>().single {
+        it.text == "Unscoped"
+      }
+    assertEquals(
+      listOf("FakeBindings", "String"),
+      structure.children(unscoped).map { it.text },
     )
   }
 


### PR DESCRIPTION
Add IDEA support for `createDynamicGraph` and `createDynamicGraphFactory` calls. Dynamic binding containers replace regular bindings for that graph context, continue into graph extensions, and keep multibinding contributions additive.

The Metro tool window shows static and dynamic contexts separately and navigates dynamic rows to their call sites. Tests cover factories, generic containers, extension propagation, duplicate providers, aliased calls, and multi-module call-site visibility.