### PR TITLE
Add graph context pinning to the IDEA plugin

### DIFF
--- a/idea-plugin/README.md
+++ b/idea-plugin/README.md
@@ -39,6 +39,10 @@ The plugin adds gutter icons for the standard Metro binding relationships:
 Provider markers navigate to known consumers. Consumer markers navigate to the matching providers,
 or show an unresolved marker when the IDE index has no binding for the key.
 
+When a graph context is pinned in the Metro tool window, gutter tooltips and navigation use that
+context where it applies. This makes context-dependent bindings inspectable without changing the
+underlying project-wide index.
+
 Optional dependencies are handled two ways:
 
 - An injection site is treated as optional when it carries `@OptionalBinding`/`@OptionalDependency`
@@ -84,6 +88,8 @@ Circuit-provided `Screen`/`Navigator` parameters, can show an `assisted` inlay b
 supplied at runtime rather than injected from the graph (explicit `@Assisted` parameters already
 read as assisted in source, so they get no inlay).
 
+Context-dependent implementation inlays use the graph context pinned in the Metro tool window.
+
 > TODO: Add a GIF showing an implementation inlay and click-through navigation.
 
 ### Metro Tool Window
@@ -98,6 +104,11 @@ their call sites. The browser applies each concrete binding-container type as an
 those bindings into graph extensions, and keeps multibinding contributions additive. Equivalent
 calls in one file share a context, matching the compiler, while calls from different files remain
 distinct.
+
+Use the graph selector to focus the tree on one concrete context and its reachable graph
+extensions. The pin button applies that context to editor navigation and implementation inlays for
+the current project session. If the selected path disappears after an index update, the plugin
+returns to **All Graphs**.
 
 Expanding a graph groups its bindings into scoped, unscoped, multibinding, and contributed
 categories. The search field filters by binding key or implementation name, and double-clicking a
@@ -175,8 +186,6 @@ fall back to the global view otherwise.
 
 Not yet modeled:
 
-- A pinnable graph context for editor navigation and inlays. Inlays currently appear only when all
-  applicable graph contexts agree; gutter popups summarize context-dependent candidates.
 - Exact parity with every compiler validation and diagnostic.
 - Validation-backed editor inspections and quick fixes.
 - Graph diagram views.

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/GraphContextPinService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/GraphContextPinService.kt
@@ -1,0 +1,70 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.util.Disposer
+import dev.zacsweers.metro.idea.model.GraphContext
+import dev.zacsweers.metro.idea.model.GraphPath
+import dev.zacsweers.metro.idea.model.matchingContext
+import dev.zacsweers.metro.idea.model.matchingContextEntry
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+/** Project-session presentation state for one preferred graph context. */
+@Service(Service.Level.PROJECT)
+internal class GraphContextPinService(private val project: com.intellij.openapi.project.Project) {
+  private val pinnedPathRef = AtomicReference<GraphPath?>()
+  private val listeners = Collections.newSetFromMap(ConcurrentHashMap<() -> Unit, Boolean>())
+
+  val pinnedPath: GraphPath?
+    get() = pinnedPathRef.get()
+
+  fun pin(path: GraphPath) {
+    if (pinnedPathRef.getAndSet(path) != path) notifyChanged()
+  }
+
+  fun clear() {
+    if (pinnedPathRef.getAndSet(null) != null) notifyChanged()
+  }
+
+  fun clearIf(path: GraphPath): Boolean {
+    if (!pinnedPathRef.compareAndSet(path, null)) return false
+    notifyChanged()
+    return true
+  }
+
+  fun matchingContext(contexts: Iterable<GraphContext>): GraphContext? {
+    val path = pinnedPath ?: return null
+    return contexts.matchingContext(path)
+  }
+
+  fun <T> matchingEntry(values: Map<GraphContext, T>): Map.Entry<GraphContext, T>? {
+    val path = pinnedPath ?: return null
+    return values.matchingContextEntry(path)
+  }
+
+  fun addListener(parentDisposable: Disposable, listener: () -> Unit) {
+    listeners += listener
+    Disposer.register(parentDisposable) { listeners -= listener }
+  }
+
+  private fun notifyChanged() {
+    val notify = {
+      if (!project.isDisposed) {
+        DaemonCodeAnalyzer.getInstance(project).restart()
+        listeners.forEach { it() }
+      }
+    }
+    val application = ApplicationManager.getApplication()
+    if (application.isDispatchThread) {
+      notify()
+    } else {
+      application.invokeLater(notify)
+    }
+  }
+}

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/GraphContextPresentation.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/GraphContextPresentation.kt
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea
 
+import com.intellij.openapi.module.ModuleUtilCore
 import dev.zacsweers.metro.idea.model.GraphContext
 import dev.zacsweers.metro.idea.model.GraphPath
 
@@ -18,11 +19,17 @@ internal fun GraphContext.presentableName(includeFile: Boolean = false): String 
       dynamic != null -> {
         append(" (dynamic at ")
         append(dynamic.pointer.virtualFile?.name ?: "<unknown>")
+        append(": ")
+        append(dynamic.containerKeys.map { it.type.shortType }.sorted().joinToString())
         append(')')
       }
       includeFile -> {
         graph.pointer.virtualFile?.name?.let { fileName ->
           append(" (")
+          graph.pointer.element?.let(ModuleUtilCore::findModuleForPsiElement)?.name?.let {
+            append(it)
+            append(": ")
+          }
           append(fileName)
           append(')')
         }
@@ -46,6 +53,8 @@ internal fun GraphPath.presentableName(): String {
     dynamicGraphId?.let {
       append(" (dynamic in ")
       append(it.callerFile.name)
+      append(": ")
+      append(it.containerKeys.map { key -> key.type.shortType }.sorted().joinToString())
       append(')')
     }
   }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/GraphContextPresentation.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/GraphContextPresentation.kt
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea
+
+import dev.zacsweers.metro.idea.model.GraphContext
+import dev.zacsweers.metro.idea.model.GraphPath
+
+internal fun GraphContext.presentableName(includeFile: Boolean = false): String {
+  return buildString {
+    append(graph.name ?: "<unknown>")
+    val parents = chain.drop(1)
+    if (parents.isNotEmpty()) {
+      append(" via ")
+      append(parents.joinToString(" > ") { it.name ?: "<unknown>" })
+    }
+    val dynamic = dynamicGraph
+    when {
+      dynamic != null -> {
+        append(" (dynamic at ")
+        append(dynamic.pointer.virtualFile?.name ?: "<unknown>")
+        append(')')
+      }
+      includeFile -> {
+        graph.pointer.virtualFile?.name?.let { fileName ->
+          append(" (")
+          append(fileName)
+          append(')')
+        }
+      }
+    }
+  }
+}
+
+internal fun GraphPath.presentableName(): String {
+  return buildString {
+    append(segments.firstOrNull()?.classId?.shortClassName?.asString() ?: "<unknown>")
+    val parents = segments.drop(1)
+    if (parents.isNotEmpty()) {
+      append(" via ")
+      append(
+        parents.joinToString(" > ") {
+          it.classId?.shortClassName?.asString() ?: "<unknown>"
+        }
+      )
+    }
+    dynamicGraphId?.let {
+      append(" (dynamic in ")
+      append(it.callerFile.name)
+      append(')')
+    }
+  }
+}

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroCodeVisionProvider.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroCodeVisionProvider.kt
@@ -15,9 +15,11 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.pom.Navigatable
 import com.intellij.psi.PsiFile
 import com.intellij.psi.SmartPsiElementPointer
+import dev.zacsweers.metro.idea.GraphContextPinService
 import dev.zacsweers.metro.idea.MetroSettings
 import dev.zacsweers.metro.idea.metroIdeState
 import dev.zacsweers.metro.idea.model.BindingIndex
+import dev.zacsweers.metro.idea.presentableName
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtElement
@@ -50,6 +52,7 @@ class MetroCodeVisionProvider : DaemonBoundCodeVisionProvider {
     }
     if (!ktFile.metroIdeState().isEnabled) return emptyList()
     val index = ktFile.project.service<MetroResolutionService>().index(ktFile)
+    val pinService = ktFile.project.service<GraphContextPinService>()
 
     val entries = mutableListOf<Pair<TextRange, CodeVisionEntry>>()
     ktFile.accept(
@@ -58,7 +61,7 @@ class MetroCodeVisionProvider : DaemonBoundCodeVisionProvider {
           super.visitDeclaration(dcl)
           // Parameters are too fine-grained for headers; they keep their gutter icons only.
           if (dcl !is KtNamedDeclaration || dcl is KtParameter) return
-          collectFor(dcl, index, entries)
+          collectFor(dcl, index, pinService, entries)
         }
       }
     )
@@ -68,11 +71,12 @@ class MetroCodeVisionProvider : DaemonBoundCodeVisionProvider {
   private fun collectFor(
     declaration: KtNamedDeclaration,
     index: BindingIndex,
+    pinService: GraphContextPinService,
     entries: MutableList<Pair<TextRange, CodeVisionEntry>>,
   ) {
     val bindingEntries = index.bindingEntriesAt(declaration)
     if (bindingEntries.isNotEmpty()) {
-      val consumers = index.consumersFor(bindingEntries)
+      val consumers = index.consumersFor(bindingEntries, pinService.pinnedPath)
       // A zero count is noise, not signal
       if (consumers.isNotEmpty()) {
         val key = bindingEntries.first().typeKey.render(short = true)
@@ -89,7 +93,9 @@ class MetroCodeVisionProvider : DaemonBoundCodeVisionProvider {
 
     val graph = (declaration as? KtClassOrObject)?.let { index.graphEntryAt(it) }
     if (graph != null) {
-      val contexts = index.contextsFor(graph)
+      val allContexts = index.contextsFor(graph)
+      val pinned = pinService.matchingContext(allContexts)
+      val contexts = pinned?.let(::listOf) ?: allContexts
       val queryContexts = contexts.mapNotNull(index::queryContext)
       val contributions = queryContexts.flatMap { index.contributionsFor(it) }.distinct()
       val inherited = queryContexts.flatMap { index.inheritedContributionsFor(it) }.distinct()
@@ -107,7 +113,15 @@ class MetroCodeVisionProvider : DaemonBoundCodeVisionProvider {
         declaration.textRange to
           entry(
             text = text,
-            tooltip = "Metro contributions to $scopes",
+            tooltip =
+              buildString {
+                append("Metro contributions to ")
+                append(scopes)
+                pinned?.let {
+                  append(" in ")
+                  append(it.presentableName())
+                }
+              },
             targets = (contributions + inherited).map { it.pointer },
             popupTitle = "Contributions to $scopes",
           )

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroInjectedImplementationInlayProvider.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroInjectedImplementationInlayProvider.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import dev.zacsweers.metro.idea.GraphContextPinService
 import dev.zacsweers.metro.idea.MetroSettings
 import dev.zacsweers.metro.idea.metroIdeState
 import org.jetbrains.kotlin.name.StandardClassIds
@@ -71,7 +72,10 @@ class MetroInjectedImplementationInlayProvider : InlayHintsProvider {
         return
       }
       val consumer = index.consumerEntryAt(element) ?: return
-      val bindings = index.resolveConsumer(consumer).uniformBindings ?: return
+      val resolution = index.resolveConsumer(consumer)
+      val pinned =
+        element.project.service<GraphContextPinService>().matchingEntry(resolution.perContext)
+      val bindings = pinned?.value ?: resolution.uniformBindings ?: return
       if (bindings.isEmpty()) return
 
       val contributions = bindings.count { it.multibindingId != null }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroLineMarkerProvider.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroLineMarkerProvider.kt
@@ -26,6 +26,7 @@ import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.ui.awt.RelativePoint
+import dev.zacsweers.metro.idea.GraphContextPinService
 import dev.zacsweers.metro.idea.MetroIcons
 import dev.zacsweers.metro.idea.MetroSettings
 import dev.zacsweers.metro.idea.graph.KaGraphValidationResult
@@ -33,10 +34,12 @@ import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
 import dev.zacsweers.metro.idea.metroIdeState
 import dev.zacsweers.metro.idea.model.BindingIndex
 import dev.zacsweers.metro.idea.model.ConsumerEntry
+import dev.zacsweers.metro.idea.model.GraphContext
 import dev.zacsweers.metro.idea.model.KaAnnotationSnapshot
 import dev.zacsweers.metro.idea.model.KaAnnotationValueSnapshot
 import dev.zacsweers.metro.idea.model.KaBinding
 import dev.zacsweers.metro.idea.model.KaGraphDeclaration
+import dev.zacsweers.metro.idea.presentableName
 import dev.zacsweers.metro.idea.toolwindow.ValidateMetroGraphAction
 import java.awt.event.MouseEvent
 import javax.swing.Icon
@@ -141,6 +144,10 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
     consumers: List<ConsumerEntry>,
     index: BindingIndex,
   ): RelatedItemLineMarkerInfo<*> {
+    pinnedSpecializedConsumerMarker(anchor, consumers, index)?.let {
+      return it
+    }
+
     val contexts = linkedSetOf<String>()
     val bindings = linkedSetOf<KaBinding>()
     val firstContextKey = consumers.first().contextKey
@@ -195,6 +202,62 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
     )
   }
 
+  private fun pinnedSpecializedConsumerMarker(
+    anchor: PsiElement,
+    consumers: List<ConsumerEntry>,
+    index: BindingIndex,
+  ): RelatedItemLineMarkerInfo<*>? {
+    val pinService = anchor.project.service<GraphContextPinService>()
+    val resolutions = consumers.mapNotNull { consumer ->
+      val entry =
+        pinService.matchingEntry(index.resolveConsumer(consumer).perContext)
+          ?: return@mapNotNull null
+      PinnedConsumerResolution(consumer, entry.key, entry.value)
+    }
+    if (resolutions.isEmpty()) return null
+
+    val context = resolutions.maxBy { it.context.path.segments.size }.context
+    val renderedKeys = resolutions.map { it.consumer.key.render(short = true) }.distinct()
+    val bindings = index.distinctBindingDeclarations(resolutions.flatMap { it.bindings })
+    val missingRequired = resolutions.any { !it.consumer.isOptional && it.bindings.isEmpty() }
+    val contributions = bindings.count { it.multibindingId != null }
+    val tooltip = buildString {
+      append("Metro dependency: ")
+      append(renderedKeys.joinToString(" / "))
+      when {
+        missingRequired -> append(" · no binding found")
+        contributions > 0 -> {
+          append(" · ")
+          append(contributions)
+          append(if (contributions == 1) " contribution" else " contributions")
+        }
+        bindings.size > 1 -> {
+          append(" · ")
+          append(bindings.size)
+          append(" bindings")
+        }
+        bindings.isEmpty() -> append(" · optional, uses its default")
+        else -> {
+          bindings.single().implementationName?.let {
+            append(" · provided by ")
+            append(it)
+          }
+        }
+      }
+      append(" in ")
+      append(context.presentableName())
+    }
+    return navMarker(
+      anchor = anchor,
+      icon = if (missingRequired) MetroIcons.CONSUMER_UNRESOLVED else MetroIcons.CONSUMER,
+      tooltip = tooltip,
+      popupTitle =
+        "Bindings for ${renderedKeys.joinToString(" / ")} in ${context.presentableName()}",
+      emptyText = "No Metro bindings found in ${context.presentableName()}",
+      targets = bindings.map { it.pointer },
+    )
+  }
+
   /** Injector members like `fun inject(target: Foo)` navigate to the target's injected members. */
   private fun injectorMarker(
     anchor: PsiElement,
@@ -202,11 +265,19 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
     entries: List<ConsumerEntry>,
     index: BindingIndex,
   ): RelatedItemLineMarkerInfo<*> {
+    val pinService = declaration.project.service<GraphContextPinService>()
+    var pinnedContext: GraphContext? = null
     var missingInSomeContexts = 0
     var unresolved = 0
     for (entry in entries) {
       if (entry.isOptional) continue
       val resolution = index.resolveConsumer(entry)
+      val pinned = pinService.matchingEntry(resolution.perContext)
+      if (pinned != null) {
+        pinnedContext = pinned.key
+        if (pinned.value.isEmpty()) unresolved++
+        continue
+      }
       when {
         resolution.uniformBindings == null && resolution.emptyContexts.isNotEmpty() ->
           missingInSomeContexts++
@@ -222,6 +293,10 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
       append(entries.size)
       append(" dependencies into ")
       append(targetName)
+      pinnedContext?.let {
+        append(" in ")
+        append(it.presentableName())
+      }
       if (missingInSomeContexts > 0) {
         append(" · ")
         append(missingInSomeContexts)
@@ -253,7 +328,8 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
     entries: List<KaBinding>,
     index: BindingIndex,
   ): RelatedItemLineMarkerInfo<*> {
-    val targets = index.consumersFor(entries).map { it.pointer }
+    val graphPath = anchor.project.service<GraphContextPinService>().pinnedPath
+    val targets = index.consumersFor(entries, graphPath).map { it.pointer }
     val tooltip =
       entries.joinToString(separator = "\n") { entry ->
         buildString {
@@ -283,10 +359,12 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
     index: BindingIndex,
   ): RelatedItemLineMarkerInfo<*> {
     val resolution = index.resolveConsumer(consumer)
-    val uniformBindings = resolution.uniformBindings
-    val isContextDependent = uniformBindings == null
-    val bindings = uniformBindings.orEmpty()
-    val navigationBindings = uniformBindings ?: resolution.candidateBindings
+    val pinned =
+      anchor.project.service<GraphContextPinService>().matchingEntry(resolution.perContext)
+    val presentedBindings = pinned?.value ?: resolution.uniformBindings
+    val isContextDependent = pinned == null && presentedBindings == null
+    val bindings = presentedBindings.orEmpty()
+    val navigationBindings = presentedBindings ?: resolution.candidateBindings
     val targets = navigationBindings.map { it.pointer }
     val contributions = bindings.count { it.multibindingId != null }
     val tooltip = buildString {
@@ -324,10 +402,15 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
               append(" · provided by ")
               append(it)
             }
-          resolution.perContext.keys.singleOrNull()?.graph?.name?.let {
-            append(" in ")
-            append(it)
-          }
+          resolution.perContext.keys
+            .singleOrNull()
+            ?.graph
+            ?.name
+            ?.takeIf { pinned == null }
+            ?.let {
+              append(" in ")
+              append(it)
+            }
         }
         if (bindings.size > 1 && contributions == 0) {
           append(" · ")
@@ -348,9 +431,15 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
           }
         }
       }
+      pinned?.key?.let {
+        append(" in ")
+        append(it.presentableName())
+      }
     }
-    val missingRequiredContext = !consumer.isOptional && resolution.emptyContexts.isNotEmpty()
-    val unresolvedEverywhere = !consumer.isOptional && uniformBindings?.isEmpty() == true
+    val missingRequiredContext =
+      !consumer.isOptional &&
+        if (pinned != null) pinned.value.isEmpty() else resolution.emptyContexts.isNotEmpty()
+    val unresolvedEverywhere = !consumer.isOptional && presentedBindings?.isEmpty() == true
     val icon =
       if (missingRequiredContext || unresolvedEverywhere) {
         MetroIcons.CONSUMER_UNRESOLVED
@@ -365,6 +454,8 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
         when {
           isContextDependent ->
             "Bindings for ${consumer.key.render(short = true)} across graph contexts"
+          pinned != null ->
+            "Bindings for ${consumer.key.render(short = true)} in ${pinned.key.presentableName()}"
           contributions > 0 -> "Contributions to ${consumer.key.render(short = true)}"
           else -> "Bindings for ${consumer.key.render(short = true)}"
         },
@@ -378,7 +469,9 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
     graph: KaGraphDeclaration,
     index: BindingIndex,
   ): RelatedItemLineMarkerInfo<*> {
-    val contexts = index.contextsFor(graph)
+    val allContexts = index.contextsFor(graph)
+    val pinned = anchor.project.service<GraphContextPinService>().matchingContext(allContexts)
+    val contexts = pinned?.let(::listOf) ?: allContexts
     val queryContexts = contexts.mapNotNull(index::queryContext)
     val contributions = queryContexts.flatMap { index.contributionsFor(it) }.distinct()
     val inherited = queryContexts.flatMap { index.inheritedContributionsFor(it) }.distinct()
@@ -394,6 +487,10 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
       contexts.firstOrNull()?.chain?.getOrNull(1)?.let { parent ->
         append(" · extends ")
         append(parent.name ?: "parent graph")
+      }
+      pinned?.let {
+        append(" · in ")
+        append(it.presentableName())
       }
     }
     return GraphLineMarkerInfo(
@@ -417,7 +514,9 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
     classId: ClassId,
     index: BindingIndex,
   ): RelatedItemLineMarkerInfo<PsiElement> {
-    val contexts = index.contextsFor(graph)
+    val allContexts = index.contextsFor(graph)
+    val pinned = declaration.project.service<GraphContextPinService>().matchingContext(allContexts)
+    val contexts = pinned?.let(::listOf) ?: allContexts
     val cached = contexts.mapNotNull { context ->
       declaration.project.service<MetroGraphValidationService>().cachedResult(declaration, context)
     }
@@ -439,6 +538,10 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
       }
     val tooltip = buildString {
       append("Validate Metro graph")
+      pinned?.let {
+        append(" in ")
+        append(it.presentableName())
+      }
       if (cached.isNotEmpty()) {
         append(" · last run: ")
         val summaries = mutableListOf<String>()
@@ -503,6 +606,12 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
       .createLineMarkerInfo(anchor)
   }
 }
+
+private data class PinnedConsumerResolution(
+  val consumer: ConsumerEntry,
+  val context: GraphContext,
+  val bindings: List<KaBinding>,
+)
 
 /**
  * The graph gutter marker. Clicking lists the graph's contributions. The right-click menu offers

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndex.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndex.kt
@@ -1661,7 +1661,10 @@ internal class BindingIndex(
   }
 
   /** Sites consuming any of [bindingEntries], joining multibinding contributions by id. */
-  fun consumersFor(bindingEntries: Collection<KaBinding>): List<ConsumerEntry> {
+  fun consumersFor(
+    bindingEntries: Collection<KaBinding>,
+    graphPath: GraphPath? = null,
+  ): List<ConsumerEntry> {
     val bindingSet = bindingEntries.toSet()
     val result = LinkedHashSet<ConsumerEntry>()
     val candidates = LinkedHashSet<ConsumerEntry>()
@@ -1677,9 +1680,14 @@ internal class BindingIndex(
 
     for (consumer in candidates) {
       val resolution = resolveConsumer(consumer)
+      val pinnedBindings = graphPath?.let { resolution.perContext.matchingContextEntry(it)?.value }
       val resolvesToEntry =
-        resolution.perContext.values.any { contextBindings ->
-          contextBindings.any { it in bindingSet }
+        if (pinnedBindings != null) {
+          pinnedBindings.any { it in bindingSet }
+        } else {
+          resolution.perContext.values.any { contextBindings ->
+            contextBindings.any { it in bindingSet }
+          }
         }
       if (resolvesToEntry) {
         result += consumer

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/GraphContextSelection.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/GraphContextSelection.kt
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea.model
+
+/** Whether this path is [candidate] itself or one of its concrete extension descendants. */
+internal fun GraphPath.isAtOrBelow(candidate: GraphPath): Boolean {
+  if (dynamicGraphId != candidate.dynamicGraphId) return false
+  if (segments.size < candidate.segments.size) return false
+  return segments.takeLast(candidate.segments.size) == candidate.segments
+}
+
+/** The closest context represented by [pinnedPath], including an inherited parent context. */
+internal fun Iterable<GraphContext>.matchingContext(pinnedPath: GraphPath): GraphContext? {
+  return filter { pinnedPath.isAtOrBelow(it.path) }.maxByOrNull { it.path.segments.size }
+}
+
+/** The closest context entry represented by [pinnedPath], including an inherited parent context. */
+internal fun <T> Map<GraphContext, T>.matchingContextEntry(
+  pinnedPath: GraphPath
+): Map.Entry<GraphContext, T>? {
+  return entries
+    .asSequence()
+    .filter { (context) -> pinnedPath.isAtOrBelow(context.path) }
+    .maxByOrNull { (context) -> context.path.segments.size }
+}

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/GraphContextSelection.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/GraphContextSelection.kt
@@ -9,17 +9,28 @@ internal fun GraphPath.isAtOrBelow(candidate: GraphPath): Boolean {
   return segments.takeLast(candidate.segments.size) == candidate.segments
 }
 
-/** The closest context represented by [pinnedPath], including an inherited parent context. */
+/** The closest inherited context, or the single child context reachable from [pinnedPath]. */
 internal fun Iterable<GraphContext>.matchingContext(pinnedPath: GraphPath): GraphContext? {
-  return filter { pinnedPath.isAtOrBelow(it.path) }.maxByOrNull { it.path.segments.size }
+  val contexts = toList()
+  contexts
+    .filter { pinnedPath.isAtOrBelow(it.path) }
+    .maxByOrNull { it.path.segments.size }
+    ?.let {
+      return it
+    }
+  return contexts.singleOrNull { it.path.isAtOrBelow(pinnedPath) }
 }
 
-/** The closest context entry represented by [pinnedPath], including an inherited parent context. */
+/** The closest inherited entry, or the single child entry reachable from [pinnedPath]. */
 internal fun <T> Map<GraphContext, T>.matchingContextEntry(
   pinnedPath: GraphPath
 ): Map.Entry<GraphContext, T>? {
-  return entries
+  entries
     .asSequence()
     .filter { (context) -> pinnedPath.isAtOrBelow(context.path) }
     .maxByOrNull { (context) -> context.path.segments.size }
+    ?.let {
+      return it
+    }
+  return entries.singleOrNull { (context) -> context.path.isAtOrBelow(pinnedPath) }
 }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
@@ -11,7 +11,10 @@ import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.ToggleAction
+import com.intellij.openapi.actionSystem.ex.ComboBoxAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.DumbService
@@ -30,16 +33,20 @@ import com.intellij.ui.tree.StructureTreeModel
 import com.intellij.ui.tree.TreeVisitor
 import com.intellij.ui.treeStructure.Tree
 import com.intellij.util.ui.tree.TreeUtil
+import dev.zacsweers.metro.idea.GraphContextPinService
 import dev.zacsweers.metro.idea.MetroIcons
 import dev.zacsweers.metro.idea.graph.GraphValidationProgress
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
 import dev.zacsweers.metro.idea.index.IndexBuildProgress
 import dev.zacsweers.metro.idea.index.MetroResolutionService
 import dev.zacsweers.metro.idea.model.GraphContext
+import dev.zacsweers.metro.idea.model.GraphPath
 import dev.zacsweers.metro.idea.model.KaGraphDeclaration
+import dev.zacsweers.metro.idea.presentableName
 import java.awt.BorderLayout
 import java.awt.event.MouseEvent
 import javax.swing.BoxLayout
+import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import javax.swing.event.DocumentEvent
@@ -59,13 +66,14 @@ internal class MetroToolWindowPanel(private val project: Project) :
   @Volatile private var searchText: String = ""
   private val resolutionService = project.service<MetroResolutionService>()
   private val validationService = project.service<MetroGraphValidationService>()
+  private val pinService = project.service<GraphContextPinService>()
   private val indexBuildStatus = IndexBuildStatusPanel()
   private val validationStatus = ValidationStatusPanel()
   private var indexBuildProgress: IndexBuildProgress? = null
   private var validationProgress: List<GraphValidationProgress> = emptyList()
   private lateinit var actionToolbar: ActionToolbar
   private val treeStructure =
-    MetroTreeStructure(project, resolutionService::indexForToolWindow) { searchText }
+    MetroTreeStructure(project, resolutionService::indexForToolWindow, pinService) { searchText }
 
   /** A validate request whose graph was not indexed yet, retried when a fresh index lands. */
   private var pendingValidation: Pair<ClassId, VirtualFile?>? = null
@@ -81,6 +89,10 @@ internal class MetroToolWindowPanel(private val project: Project) :
       updateIndexBuildStatus()
       treeModel.invalidateAsync()
     }
+  internal val graphContextSelectorAction =
+    GraphContextSelectorAction(pinService, treeStructure::availableContexts)
+  internal val pinSelectedGraphAction =
+    PinSelectedGraphAction(pinService) { selectedGraphNode()?.context }
 
   init {
     TreeSpeedSearch.installOn(tree)
@@ -113,6 +125,7 @@ internal class MetroToolWindowPanel(private val project: Project) :
         }
       }
     }
+    pinService.addListener(this) { treeModel.invalidateAsync() }
     resolutionService.addIndexBuildProgressListener(this) { progress ->
       indexBuildProgress = progress
       updateIndexBuildStatus()
@@ -146,6 +159,8 @@ internal class MetroToolWindowPanel(private val project: Project) :
       DefaultActionGroup(
         // Not DumbAware: the refreshed tree needs stub indexes, so wait for smart mode
         loadOrRefreshAction,
+        graphContextSelectorAction,
+        pinSelectedGraphAction,
         ValidateSelectedGraphAction(
           selectedContext = { selectedGraphNode()?.context },
           isValidationRunning = { validationService.isValidationRunning(it.path) },
@@ -359,6 +374,89 @@ internal class ValidateSelectedGraphAction(
 
   override fun actionPerformed(e: AnActionEvent) {
     selectedContext()?.takeUnless(isValidationRunning)?.let(validate)
+  }
+}
+
+internal class GraphContextSelectorAction(
+  private val pinService: GraphContextPinService,
+  private val contextProvider: () -> List<GraphContext>,
+) : ComboBoxAction(), DumbAware {
+
+  init {
+    templatePresentation.text = "All Graphs"
+    templatePresentation.description = "Choose the graph context used for editor presentation"
+    templatePresentation.icon = MetroIcons.GRAPH
+  }
+
+  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
+
+  override fun update(e: AnActionEvent) {
+    super.update(e)
+    e.presentation.text = pinService.pinnedPath?.presentableName() ?: "All Graphs"
+  }
+
+  override fun createPopupActionGroup(
+    button: JComponent,
+    dataContext: DataContext,
+  ): DefaultActionGroup {
+    return DefaultActionGroup().apply {
+      add(GraphContextOptionAction("All Graphs", null, pinService))
+      addSeparator()
+      for (context in contextProvider()) {
+        add(
+          GraphContextOptionAction(
+            context.presentableName(includeFile = true),
+            context.path,
+            pinService,
+          )
+        )
+      }
+    }
+  }
+}
+
+private class GraphContextOptionAction(
+  text: String,
+  private val path: GraphPath?,
+  private val pinService: GraphContextPinService,
+) : ToggleAction(text), DumbAware {
+
+  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+  override fun isSelected(e: AnActionEvent): Boolean = pinService.pinnedPath == path
+
+  override fun setSelected(e: AnActionEvent, state: Boolean) {
+    if (!state) return
+    if (path == null) pinService.clear() else pinService.pin(path)
+  }
+}
+
+internal class PinSelectedGraphAction(
+  private val pinService: GraphContextPinService,
+  private val selectedContext: () -> GraphContext?,
+) : ToggleAction("Pin", "Pin the selected graph context", AllIcons.General.Pin_tab), DumbAware {
+
+  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
+
+  override fun update(e: AnActionEvent) {
+    super.update(e)
+    val context = selectedContext()
+    e.presentation.isEnabled = context != null
+    e.presentation.description =
+      if (context?.path == pinService.pinnedPath) {
+        "Show all graph contexts"
+      } else {
+        "Pin the selected graph context"
+      }
+  }
+
+  override fun isSelected(e: AnActionEvent): Boolean {
+    return selectedContext()?.path == pinService.pinnedPath
+  }
+
+  override fun setSelected(e: AnActionEvent, state: Boolean) {
+    val context = selectedContext() ?: return
+    if (state) pinService.pin(context.path) else pinService.clearIf(context.path)
   }
 }
 

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroTreeStructure.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroTreeStructure.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.SmartPsiElementPointer
 import com.intellij.ui.SimpleTextAttributes
 import dev.zacsweers.metro.compiler.diagnostics.MetroSeverity
+import dev.zacsweers.metro.idea.GraphContextPinService
 import dev.zacsweers.metro.idea.MetroIcons
 import dev.zacsweers.metro.idea.graph.KaGraphDiagnostic
 import dev.zacsweers.metro.idea.graph.KaGraphValidationResult
@@ -28,6 +29,8 @@ import dev.zacsweers.metro.idea.model.KaBinding
 import dev.zacsweers.metro.idea.model.KaContextualTypeKey
 import dev.zacsweers.metro.idea.model.KaGraphDeclaration
 import dev.zacsweers.metro.idea.model.KaTypeKey
+import dev.zacsweers.metro.idea.model.isAtOrBelow
+import dev.zacsweers.metro.idea.presentableName
 import java.util.Collections
 import java.util.IdentityHashMap
 import javax.swing.Icon
@@ -303,6 +306,7 @@ internal class MetroTreeStructure(
   private val indexProvider: (Module) -> BindingIndex = { module ->
     project.service<MetroResolutionService>().index(module)
   },
+  private val pinService: GraphContextPinService = project.service(),
   private val filterText: () -> String,
 ) : AbstractTreeStructure() {
 
@@ -373,6 +377,17 @@ internal class MetroTreeStructure(
     return indexes
   }
 
+  internal fun availableContexts(): List<GraphContext> {
+    return currentContexts(currentIndexes()).sortedBy { it.presentableName(includeFile = true) }
+  }
+
+  private fun currentContexts(indexes: List<BindingIndex>): List<GraphContext> {
+    val seen = HashSet<GraphPath>()
+    return indexes
+      .flatMap { index -> index.graphs.flatMap(index::contextsFor) }
+      .filter { context -> seen.add(context.path) }
+  }
+
   /** [node]'s context in the current indexes, refreshed so children never use stale entries. */
   private fun resolveGraph(node: MetroTreeNode.Graph): Pair<BindingIndex, GraphContext>? {
     for (index in currentIndexes()) {
@@ -384,13 +399,15 @@ internal class MetroTreeStructure(
 
   private fun graphNodes(root: MetroTreeNode.Root): List<MetroTreeNode> {
     val validationService = project.service<MetroGraphValidationService>()
-    val seen = HashSet<GraphPath>()
-    val contexts =
-      currentIndexes()
-        .flatMap { index -> index.graphs.flatMap(index::contextsFor) }
-        .filter { context ->
-          seen.add(context.path)
-        }
+    val indexes = currentIndexes()
+    var contexts = currentContexts(indexes)
+    pinService.pinnedPath?.let { pinnedPath ->
+      if (contexts.none { it.path == pinnedPath }) {
+        if (indexes.isNotEmpty()) pinService.clearIf(pinnedPath)
+      } else {
+        contexts = contexts.filter { it.path.isAtOrBelow(pinnedPath) }
+      }
+    }
     return contexts
       .sortedWith(
         compareBy(

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroInlayProviderTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroInlayProviderTest.kt
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea
 
+import com.intellij.openapi.components.service
 import com.intellij.testFramework.utils.inlays.declarative.DeclarativeInlayHintsProviderTestCase
 import dev.zacsweers.metro.idea.index.MetroInjectedImplementationInlayProvider
+import dev.zacsweers.metro.idea.index.MetroResolutionService
 
 class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
 
@@ -12,6 +14,7 @@ class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
     project.setMetroOptions("enable-circuit-codegen" to "true")
     module.addMetroRuntimeLibrary()
     myFixture.addCircuitStubs()
+    project.service<GraphContextPinService>().clear()
   }
 
   fun testImplementationAndAssistedInlays() {
@@ -83,6 +86,50 @@ class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
       }
       """
         .trimIndent(),
+      MetroInjectedImplementationInlayProvider(),
+    )
+  }
+
+  fun testPinnedContextShowsItsImplementationInlay() {
+    val source =
+      """
+      package test
+
+      import dev.zacsweers.metro.*
+
+      abstract class OtherScope
+
+      interface Repo
+
+      @Inject
+      @ContributesBinding(AppScope::class)
+      class AppRepo : Repo
+
+      @Inject
+      @ContributesBinding(OtherScope::class)
+      class OtherRepo : Repo
+
+      @Inject class Consumer(val repo: Repo/*<#  AppRepo #>*/)
+
+      @DependencyGraph(AppScope::class)
+      interface AppGraph {
+        val consumer: Consumer
+      }
+
+      @DependencyGraph(OtherScope::class)
+      interface OtherGraph {
+        val consumer: Consumer
+      }
+      """
+        .trimIndent()
+    val file = myFixture.configureByText("PinnedContext.kt", source)
+    val index = project.service<MetroResolutionService>().index(file)
+    val appGraph = index.graphs.single { it.name == "AppGraph" }
+    project.service<GraphContextPinService>().pin(index.contextsFor(appGraph).single().path)
+
+    doTestProvider(
+      "PinnedContext.kt",
+      source,
       MetroInjectedImplementationInlayProvider(),
     )
   }

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroLineMarkerProviderTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroLineMarkerProviderTest.kt
@@ -17,6 +17,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     project.setMetroOptions()
     module.addMetroRuntimeLibrary()
     project.service<MetroGraphValidationService>().clearResults()
+    project.service<GraphContextPinService>().clear()
   }
 
   private fun configureAndHighlight(): List<String> {
@@ -370,6 +371,18 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     }
     assertTrue(myFixture.findAllGutters().none { it.icon === MetroIcons.GRAPH_VALIDATED })
 
+    val pinService = project.service<GraphContextPinService>()
+    val pinnedRoot = contexts.first().rootGraph
+    pinService.pin(index.contextsFor(pinnedRoot).single().path)
+    myFixture.doHighlighting()
+    assertEquals(
+      1,
+      myFixture.findAllGutters().count { it.icon === MetroIcons.GRAPH_VALIDATED },
+    )
+    pinService.clear()
+    myFixture.doHighlighting()
+    assertTrue(myFixture.findAllGutters().none { it.icon === MetroIcons.GRAPH_VALIDATED })
+
     validationService.validate(file, contexts.last())
     DaemonCodeAnalyzer.getInstance(project).restart()
     myFixture.doHighlighting()
@@ -511,8 +524,9 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
   }
 
   fun testContextDependentBindingsDoNotUseAttentionMarker() {
-    myFixture.configureMetroFile(
-      """
+    val file =
+      myFixture.configureMetroFile(
+        """
       abstract class OtherScope
 
       interface Repo
@@ -537,7 +551,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
         val consumer: Consumer
       }
       """
-    )
+      )
     myFixture.doHighlighting()
 
     val marker =
@@ -549,6 +563,37 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     assertTrue(marker.tooltipText.orEmpty()) {
       "bindings differ across 2 graph contexts · 2 candidates" in marker.tooltipText.orEmpty()
     }
+
+    val index = project.service<MetroResolutionService>().index(file)
+    val contexts =
+      index.graphs.associate { graph ->
+        graph.name to index.contextsFor(graph).single()
+      }
+    val pinService = project.service<GraphContextPinService>()
+
+    pinService.pin(contexts.getValue("AppGraph").path)
+    myFixture.doHighlighting()
+    val appMarker =
+      myFixture.findAllGutters().single {
+        it.tooltipText?.startsWith("Metro dependency: Repo") == true
+      }
+    assertSame(MetroIcons.CONSUMER, appMarker.icon)
+    assertEquals(
+      "Metro dependency: Repo · provided by AppRepo in AppGraph",
+      appMarker.tooltipText,
+    )
+
+    pinService.pin(contexts.getValue("OtherGraph").path)
+    myFixture.doHighlighting()
+    val otherMarker =
+      myFixture.findAllGutters().single {
+        it.tooltipText?.startsWith("Metro dependency: Repo") == true
+      }
+    assertSame(MetroIcons.CONSUMER, otherMarker.icon)
+    assertEquals(
+      "Metro dependency: Repo · provided by OtherRepo in OtherGraph",
+      otherMarker.tooltipText,
+    )
   }
 
   fun testNoMarkersWhenMetroDisabled() {

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroLineMarkerProviderTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroLineMarkerProviderTest.kt
@@ -575,7 +575,8 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     myFixture.doHighlighting()
     val appMarker =
       myFixture.findAllGutters().single {
-        it.tooltipText?.startsWith("Metro dependency: Repo") == true
+        it.icon === MetroIcons.CONSUMER &&
+          it.tooltipText?.startsWith("Metro dependency: Repo") == true
       }
     assertSame(MetroIcons.CONSUMER, appMarker.icon)
     assertEquals(
@@ -587,7 +588,8 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     myFixture.doHighlighting()
     val otherMarker =
       myFixture.findAllGutters().single {
-        it.tooltipText?.startsWith("Metro dependency: Repo") == true
+        it.icon === MetroIcons.CONSUMER &&
+          it.tooltipText?.startsWith("Metro dependency: Repo") == true
       }
     assertSame(MetroIcons.CONSUMER, otherMarker.icon)
     assertEquals(

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
@@ -4144,6 +4144,24 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     )
     assertTrue(different.emptyContexts.isEmpty())
 
+    val differentConsumer =
+      checkNotNull(index.consumerEntryAt(declarations.parameter("differentRepo")))
+    val appBindings =
+      index.bindingEntriesAt(declarations.klass("DifferentAppRepo")).filter {
+        it.typeKey.renderedType == "test.DifferentRepo"
+      }
+    val contextsByGraph = different.perContext.keys.associateBy { it.graph.name }
+    assertTrue(
+      index
+        .consumersFor(appBindings, contextsByGraph.getValue("AppGraph").path)
+        .contains(differentConsumer)
+    )
+    assertFalse(
+      index
+        .consumersFor(appBindings, contextsByGraph.getValue("OtherGraph").path)
+        .contains(differentConsumer)
+    )
+
     val stable = resolution("stableRepo")
     assertEquals(
       listOf("StableRepoImpl"),

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
@@ -27,6 +27,7 @@ import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
 import dev.zacsweers.metro.idea.index.IndexBuildPhase
 import dev.zacsweers.metro.idea.index.IndexBuildProgress
 import dev.zacsweers.metro.idea.index.MetroResolutionService
+import dev.zacsweers.metro.idea.model.BindingIndex
 import dev.zacsweers.metro.idea.model.GraphContext
 import dev.zacsweers.metro.idea.model.KaBinding
 import dev.zacsweers.metro.idea.toolwindow.ExportGraphDebugInfoAction
@@ -57,6 +58,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
     // Results are retained across index invalidation by design, so they survive across tests
     // sharing this project. Start each test clean.
     project.service<MetroGraphValidationService>().clearResults()
+    project.service<GraphContextPinService>().clear()
   }
 
   private var filter: String = ""
@@ -183,6 +185,77 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
       listOf("FakeBindings", "String"),
       structure.children(unscoped).map { it.text },
     )
+
+    project.service<GraphContextPinService>().pin(dynamicRow.context.path)
+    val pinnedRows = structure.children(root).filterIsInstance<MetroTreeNode.Graph>()
+    assertEquals(listOf(dynamicRow.context.path), pinnedRows.map { it.context.path })
+  }
+
+  fun testPinnedParentContextFocusesItsExtensionPath() {
+    myFixture.configureMetroFile(
+      """
+      @GraphExtension
+      interface ChildGraph
+
+      @DependencyGraph
+      interface LeftParent {
+        val child: ChildGraph
+      }
+
+      @DependencyGraph
+      interface RightParent {
+        val child: ChildGraph
+      }
+      """
+    )
+
+    val structure = structure()
+    val root = structure.rootElement as MetroTreeNode
+    val allRows = structure.children(root).filterIsInstance<MetroTreeNode.Graph>()
+    assertEquals(4, allRows.size)
+
+    val leftParent = allRows.single { it.graph.name == "LeftParent" }.context
+    project.service<GraphContextPinService>().pin(leftParent.path)
+    val leftRows = structure.children(root).filterIsInstance<MetroTreeNode.Graph>()
+    assertEquals(listOf("ChildGraph", "LeftParent"), leftRows.map { it.graph.name })
+    assertEquals(
+      "LeftParent",
+      leftRows.single { it.graph.name == "ChildGraph" }.context.rootGraph.name,
+    )
+
+    val rightParent = allRows.single { it.graph.name == "RightParent" }.context
+    project.service<GraphContextPinService>().pin(rightParent.path)
+    val rightRows = structure.children(root).filterIsInstance<MetroTreeNode.Graph>()
+    assertEquals(listOf("ChildGraph", "RightParent"), rightRows.map { it.graph.name })
+    assertEquals(
+      "RightParent",
+      rightRows.single { it.graph.name == "ChildGraph" }.context.rootGraph.name,
+    )
+
+    project.service<GraphContextPinService>().clear()
+    assertEquals(4, structure.children(root).size)
+  }
+
+  fun testMissingPinnedContextFallsBackToAllGraphs() {
+    val file = configure()
+    val realIndex = project.service<MetroResolutionService>().index(file)
+    var currentIndex = realIndex
+    val pinService = project.service<GraphContextPinService>()
+    val structure =
+      MetroTreeStructure(project, indexProvider = { currentIndex }, pinService = pinService) {
+        filter
+      }
+    val root = structure.rootElement as MetroTreeNode
+    val context = realIndex.contextsFor(realIndex.graphs.single()).single()
+    pinService.pin(context.path)
+    assertEquals(
+      listOf(context.path),
+      structure.children(root).map { (it as MetroTreeNode.Graph).context.path },
+    )
+
+    currentIndex = BindingIndex(emptyList(), emptyList(), emptyList(), emptyList())
+    assertTrue(structure.children(root).isEmpty())
+    assertNull(pinService.pinnedPath)
   }
 
   fun testGenericInheritedProvidersDoNotShowRawTypeParameters() {


### PR DESCRIPTION
Add a project-session graph context selector and pin action to the Metro tool window. A pin focuses the browser on that context and its reachable extensions.

When the pinned context applies, gutter navigation, graph summaries, validation badges, code vision, and implementation inlays use its bindings. Unrelated or ambiguous paths keep the existing aggregate behavior, and a pin is cleared if its exact graph path disappears after an index update.