### PR TITLE
IDEA plugin:Fix missing binding with type-use qualifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog
 Special thanks to the following contributors for contributing to this release!
 
 - [@grandstaish](https://github.com/grandstaish)
+- [@kevinguitar](https://github.com/kevinguitar)
 
 1.4.2
 -----

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/BindingExtraction.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/BindingExtraction.kt
@@ -579,7 +579,7 @@ private fun KtClassOrObject.classBindingData(
         } else {
           boundTypeQualifier ?: qualifier
         }
-      val elementType = unannotatedBoundType(boundType, classSymbol)
+      val elementType = unannotatedBoundType(boundType)
       val elementKey = typeKey(elementType, contributionQualifier)
       val contributionScopes = annotationScopeKeys(annotation)
       val replaces = classListArgument(annotation, "replaces").toSet()
@@ -723,17 +723,16 @@ private fun KaSession.contributedBoundType(
   }
 }
 
-private fun KaSession.unannotatedBoundType(
-  boundType: KaType,
-  classSymbol: KaNamedClassSymbol,
-): KaType {
+/** Removes outer type annotations without replacing the declared projections or nullability. */
+private fun KaSession.unannotatedBoundType(boundType: KaType): KaType {
   val annotatedType = boundType as? KaAnnotated ?: return boundType
   if (annotatedType.annotations.isEmpty()) return boundType
 
-  val classId = (boundType.fullyExpandedType as? KaClassType)?.classId ?: return boundType
-  return classSymbol.superTypes.firstOrNull { superType ->
-    (superType.fullyExpandedType as? KaClassType)?.classId == classId
-  } ?: boundType
+  val classType = boundType.fullyExpandedType as? KaClassType ?: return boundType
+  return buildClassType(classType.classId) {
+    isMarkedNullable = classType.isMarkedNullable
+    for (projection in classType.typeArguments) argument(projection)
+  }
 }
 
 /**

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
@@ -3,9 +3,7 @@
 package dev.zacsweers.metro.idea
 
 import com.intellij.openapi.components.service
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import dev.zacsweers.metro.compiler.diagnostics.MetroDiagnosticId
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
@@ -70,6 +68,8 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
   }
 
   fun testEquivalentCallsShareAContextWithinAFileButNotAcrossFiles() {
+    // Install the resolution listener before creating files so every caller is enrolled.
+    val service = project.service<MetroResolutionService>()
     val declarations =
       myFixture.addFileToProject(
         "test/Graph.kt",
@@ -109,10 +109,7 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
           .trimIndent(),
       ) as KtFile
 
-    PsiDocumentManager.getInstance(project).commitAllDocuments()
-    IndexingTestUtil.waitUntilIndexesAreReady(project)
-
-    val index = project.service<MetroResolutionService>().index(declarations)
+    val index = service.index(declarations)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val dynamicContexts = index.contextsFor(graph).filter { it.dynamicGraph != null }
 

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
@@ -3,7 +3,9 @@
 package dev.zacsweers.metro.idea
 
 import com.intellij.openapi.components.service
+import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.IndexingTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import dev.zacsweers.metro.compiler.diagnostics.MetroDiagnosticId
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
@@ -106,6 +108,9 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
+
+    PsiDocumentManager.getInstance(project).commitAllDocuments()
+    IndexingTestUtil.waitUntilIndexesAreReady(project)
 
     val index = project.service<MetroResolutionService>().index(declarations)
     val graph = index.graphs.single { it.name == "AppGraph" }

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
@@ -2630,6 +2630,39 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     assertTrue(result.topology!!.sortedKeys.any { it.renderedType == "test.RealRepo" })
   }
 
+  fun testContributesBindingWithTypeUseQualifier() {
+    val result =
+      validate(
+        """
+        @Qualifier
+        @Target(AnnotationTarget.TYPE, AnnotationTarget.VALUE_PARAMETER)
+        annotation class Chosen
+
+        interface Page<T>
+
+        @Inject
+        @ContributesBinding(AppScope::class, binding = binding<@Chosen Page<*>>())
+        class RealPage : Page<String>
+
+        @DependencyGraph(AppScope::class)
+        interface AppGraph {
+          @Chosen val page: Page<*>
+        }
+        """
+      )
+
+    assertTrue(result.diagnostics.joinToString { it.render() }, result.diagnostics.isEmpty())
+    assertTrue(
+      result.bindings.asMap().keys.joinToString {
+        it.render(short = false, includeQualifier = true)
+      },
+      result.bindings.any { key, _ ->
+        key.renderedType == "test.Page<*>" &&
+          key.qualifier?.classId?.shortClassName?.asString() == "Chosen"
+      },
+    )
+  }
+
   fun testGeneratedContributionProviderDoesNotExposeItsImplementation() {
     project.setMetroOptions("generate-contribution-providers" to "true")
 


### PR DESCRIPTION
Noticed a bug in the IDEA plugin, when there are type-use qualified bindings, the plugin doesn't seem connecting the contribution with injection.

<img width="1894" height="100" alt="CleanShot 2026-08-24 at 16 16 00@2x" src="https://github.com/user-attachments/assets/8230d6bb-fa7d-41e2-9483-44744cbcc8aa" />

<img width="1252" height="106" alt="CleanShot 2026-08-24 at 16 16 26@2x" src="https://github.com/user-attachments/assets/862fe7db-927b-4974-bee2-d31f0fd64d39" />


The `AutoMixPage` is declared as:
```kotlin
@Qualifier
@Target(AnnotationTarget.TYPE, AnnotationTarget.VALUE_PARAMETER)
annotation class AutoMixPageKey

@ContributesBinding(
    scope = MixEditorScope::class,
    binding = binding<@AutoMixPageKey Page<*>>(),
)
class AutoMixPage : Page<AutoMixPageViewModel>
```