### PR TITLE
Make shared graph analysis cooperatively cancellable

### DIFF
--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/IrBindingGraph.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/graph/IrBindingGraph.kt
@@ -1176,7 +1176,7 @@ internal class IrBindingGraph(
           requiresRuntimeCoroutines = true
         }
       }
-      structuralValidator.validate(binding, reportIssue)
+      structuralValidator.validate(binding, onIssue = reportIssue)
     }
     if (!suspendProvidersEnabled) {
       for ((contextKey, metroFunction) in node.accessors) {

--- a/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
+++ b/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraph.kt
@@ -18,7 +18,6 @@ import dev.zacsweers.metro.compiler.diagnostics.TraceEntry
 import dev.zacsweers.metro.compiler.diagnostics.buildText
 import dev.zacsweers.metro.compiler.diagnostics.textOf
 import dev.zacsweers.metro.compiler.getValue
-import dev.zacsweers.metro.compiler.mapToSet
 import dev.zacsweers.metro.compiler.reportCompilerBug
 import dev.zacsweers.metro.compiler.tracing.TraceScope
 import dev.zacsweers.metro.compiler.tracing.trace
@@ -126,6 +125,7 @@ public open class MutableBindingGraph<
    * @param validateBindings a callback to perform optional extra validation on bindings
    *   post-adjacency build.
    * @param keep optional set of keys to keep, even if they are unused.
+   * @param ensureActive cancellation callback invoked throughout graph validation.
    */
   context(traceScope: TraceScope)
   public fun seal(
@@ -134,6 +134,7 @@ public open class MutableBindingGraph<
     shrinkUnusedBindings: Boolean = true,
     onPopulated: () -> Unit = {},
     onSortedCycle: (List<TypeKey>) -> Unit = {},
+    ensureActive: () -> Unit = {},
     validateBindings:
       (
         bindings: ScatterMap<TypeKey, Binding>,
@@ -149,7 +150,7 @@ public open class MutableBindingGraph<
 
     // Order matters, prefer roots over matching kees as they have more information in their entries
     val rootsWithKeeps = keep + roots
-    val missingBindings = populateGraph(rootsWithKeeps, stack)
+    val missingBindings = populateGraph(rootsWithKeeps, stack, ensureActive)
 
     onPopulated()
 
@@ -165,7 +166,10 @@ public open class MutableBindingGraph<
       trace("Build adjacency list") {
         buildFullAdjacency(
           map = bindings,
-          sourceToTarget = { key -> bindings.getValue(key).dependencies.map { it.typeKey } },
+          sourceToTarget = { key ->
+            bindings.getValue(key).dependencies.asSequence().map { it.typeKey }.asIterable()
+          },
+          ensureActive = ensureActive,
         ) { source, missing ->
           val binding = bindings.getValue(source)
           val contextKey = binding.dependencies.first { it.typeKey == missing }
@@ -183,17 +187,41 @@ public open class MutableBindingGraph<
       }
 
     // Report all missing bindings _after_ building adjacency so we can backtrace where possible
-    missingBindings.forEach { (key, stack) -> reportMissingBinding(key, stack) }
+    missingBindings.forEach { (key, stack) ->
+      ensureActive()
+      reportMissingBinding(key, stack)
+    }
 
     val topo =
       trace("Sort and validate") {
         val allKeeps =
           if (shrinkUnusedBindings) {
-            keep.keys.mapToSet { it.typeKey }
+            buildSet {
+              for (key in keep.keys) {
+                ensureActive()
+                add(key.typeKey)
+              }
+            }
           } else {
-            fullAdjacency.keys + keep.keys.mapToSet { it.typeKey }
+            buildSet {
+              for (key in fullAdjacency.keys) {
+                ensureActive()
+                add(key)
+              }
+              for (key in keep.keys) {
+                ensureActive()
+                add(key.typeKey)
+              }
+            }
           }
-        sortAndValidate(roots, allKeeps, fullAdjacency, stack, onSortedCycle)
+        sortAndValidate(
+          roots,
+          allKeeps,
+          fullAdjacency,
+          stack,
+          onSortedCycle,
+          ensureActive,
+        )
       }
 
     // Validate bindings using the reachable adjacency computed during topo sort.
@@ -205,7 +233,10 @@ public open class MutableBindingGraph<
       // must be deferred. This is how we handle cycles that are broken by deferrable
       // types like Provider/Lazy/...
       // O(1) ("does A depend on B?")
-      topo.sortedKeys.forEachIndexed { i, key -> bindingIndices.put(key, i) }
+      topo.sortedKeys.forEachIndexed { i, key ->
+        ensureActive()
+        bindingIndices.put(key, i)
+      }
     }
 
     return topo
@@ -215,16 +246,19 @@ public open class MutableBindingGraph<
   private fun populateGraph(
     roots: Map<ContextualTypeKey, BindingStackEntry>,
     stack: BindingStack,
+    ensureActive: () -> Unit,
   ): Map<TypeKey, BindingStack> {
     // Traverse all the bindings up front to
     // First ensure all the roots' bindings are present
     // Defer missing binding reporting until after we finish populating
     val missingBindings = mutableMapOf<TypeKey, BindingStack>()
     for ((contextKey, entry) in roots) {
+      ensureActive()
       if (contextKey.typeKey !in bindings) {
         val bindings = computeBindings(contextKey, bindings, stack)
         if (bindings.isNotEmpty()) {
           for (binding in bindings) {
+            ensureActive()
             tryPut(binding, stack, binding.typeKey)
           }
         } else if (!contextKey.hasDefault) {
@@ -237,7 +271,11 @@ public open class MutableBindingGraph<
     // are computed (i.e., constructor-injected types) as they are used. We do this upfront
     // so that the graph is fully populated before we start validating it and avoid mutating
     // it while we're validating it.
-    val bindingQueue = ArrayDeque<Binding>(bindings.size * 2).apply { bindings.forEachValue(::add) }
+    val bindingQueue = ArrayDeque<Binding>(bindings.size * 2)
+    bindings.forEachValue { binding ->
+      ensureActive()
+      bindingQueue.add(binding)
+    }
 
     // Tracks type keys whose dependencies have already been walked. Bindings may appear in the
     // queue more than once (e.g. when multiple paths resolve to the same class-based binding or
@@ -246,6 +284,7 @@ public open class MutableBindingGraph<
 
     trace("Populate bindings") {
       while (bindingQueue.isNotEmpty()) {
+        ensureActive()
         val binding = bindingQueue.removeFirst()
         val typeKey = binding.typeKey
         if (typeKey !in bindings && !binding.isTransient) {
@@ -255,6 +294,7 @@ public open class MutableBindingGraph<
         if (!visited.add(typeKey)) continue
 
         for (depKey in binding.dependencies) {
+          ensureActive()
           val typeKey = depKey.typeKey
           // Fast path: if the dependency already has a binding we have nothing to do. Skip the
           // stack-entry allocation + push/pop which are only needed for missing-binding reports
@@ -266,6 +306,7 @@ public open class MutableBindingGraph<
               trace("Compute new bindings") { computeBindings(depKey, bindings, stack) }
             if (newBindings.isNotEmpty()) {
               for (newBinding in newBindings) {
+                ensureActive()
                 bindingQueue.addLast(newBinding)
               }
             } else if (depKey.hasDefault) {
@@ -288,20 +329,37 @@ public open class MutableBindingGraph<
     fullAdjacency: SortedMap<TypeKey, SortedSet<TypeKey>>,
     stack: BindingStack,
     onSortedCycle: (List<TypeKey>) -> Unit,
+    ensureActive: () -> Unit,
   ): GraphTopology<TypeKey> {
     val sortedRootKeys =
       TreeSet<TypeKey>().apply {
-        roots.keys.forEach { add(it.typeKey) }
-        addAll(keep)
+        roots.keys.forEach {
+          ensureActive()
+          add(it.typeKey)
+        }
+        for (key in keep) {
+          ensureActive()
+          add(key)
+        }
       }
 
     // Adjacency collapses parallel requests, so check every original request for an eager edge.
     val isHardEdge: (TypeKey, TypeKey) -> Boolean = { from, to ->
-      !bindings.getValue(to).isImplicitlyDeferrable &&
+      ensureActive()
+      if (bindings.getValue(to).isImplicitlyDeferrable) {
+        false
+      } else {
+        var hasHardDependency = false
         // TODO we can cache these dep lookups some day if needed
-        bindings.getValue(from).dependencies.any { dependency ->
-          dependency.typeKey == to && !dependency.isDeferrable
+        for (dependency in bindings.getValue(from).dependencies) {
+          ensureActive()
+          if (dependency.typeKey == to && !dependency.isDeferrable) {
+            hasHardDependency = true
+            break
+          }
         }
+        hasHardDependency
+      }
     }
 
     // Run topo sort. It gives back either a valid order or calls onCycle for errors
@@ -311,9 +369,14 @@ public open class MutableBindingGraph<
           fullAdjacency = fullAdjacency,
           roots = sortedRootKeys,
           isDeferrable = { from, to -> !isHardEdge(from, to) },
+          ensureActive = ensureActive,
           onSortedCycle = onSortedCycle,
           onCycle = { sccVertices ->
-            val sccSet = sccVertices.toSet()
+            val sccSet = HashSet<TypeKey>(sccVertices.size)
+            for (vertex in sccVertices) {
+              ensureActive()
+              sccSet += vertex
+            }
 
             val cyclePath: List<TypeKey> =
               sccVertices.firstNotNullOfOrNull { candidate ->
@@ -322,12 +385,14 @@ public open class MutableBindingGraph<
                   sccNodes = sccSet,
                   fullAdjacency = fullAdjacency,
                   isEdgeAllowed = isHardEdge,
+                  ensureActive = ensureActive,
                 )
               } ?: sccVertices
 
             val entriesInCycle = buildList {
               val size = cyclePath.size
               for (i in 0..size) {
+                ensureActive()
                 val currentDep = cyclePath[i % size]
                 val prevReq = if (i == 0) cyclePath.last() else cyclePath[i - 1]
                 val callingBinding = bindings.getValue(prevReq)
@@ -358,20 +423,24 @@ public open class MutableBindingGraph<
     sccNodes: Set<V>,
     fullAdjacency: Map<V, Set<V>>,
     isEdgeAllowed: (from: V, to: V) -> Boolean,
+    ensureActive: () -> Unit,
   ): List<V>? {
     val parents = mutableMapOf<V, V>()
     val queue = ArrayDeque<V>().apply { add(startNode) }
     val visited = mutableSetOf<V>()
 
     while (queue.isNotEmpty()) {
+      ensureActive()
       val current = queue.removeFirst()
       val neighbors = fullAdjacency[current].orEmpty()
       for (neighbor in neighbors) {
+        ensureActive()
         if (neighbor !in sccNodes || !isEdgeAllowed(current, neighbor)) continue
         if (neighbor == startNode) {
           val cycle = mutableListOf<V>()
           var curr: V? = current
           while (curr != null) {
+            ensureActive()
             cycle.add(curr)
             curr = parents[curr]
           }

--- a/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraphValidator.kt
+++ b/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraphValidator.kt
@@ -31,9 +31,14 @@ public class BindingGraphValidator<
   private val rootKeys: Set<TypeKey> = emptySet(),
   private val reverseAdjacency: Map<TypeKey, Set<TypeKey>> = emptyMap(),
 ) {
-  /** Reports every structural issue originating at [binding] to [onIssue]. */
+  /**
+   * Reports every structural issue originating at [binding] to [onIssue].
+   *
+   * @param ensureActive cancellation callback polled while checking dependents and contributions.
+   */
   public fun validate(
     binding: Binding,
+    ensureActive: () -> Unit = {},
     onIssue: (GraphValidationIssue<Binding, Scope, MapKey>) -> Unit,
   ) {
     val bindingScope = scopeOf(binding)
@@ -43,6 +48,7 @@ public class BindingGraphValidator<
 
     if (assistedKindOf(binding) == AssistedBindingKind.TARGET) {
       for (requestingKey in reverseAdjacency[binding.typeKey].orEmpty()) {
+        ensureActive()
         val requestingBinding = bindings[requestingKey] ?: continue
         if (assistedKindOf(requestingBinding) != AssistedBindingKind.FACTORY) {
           onIssue(GraphValidationIssue.InvalidAssistedInjection(binding, requestingBinding))
@@ -64,11 +70,13 @@ public class BindingGraphValidator<
 
     val contributionsByMapKey = mutableMapOf<MapKey?, MutableList<Binding>>()
     for (sourceKey in sourceKeys) {
+      ensureActive()
       val contribution = bindings[sourceKey] ?: continue
       if (!isMapContribution(contribution)) continue
       contributionsByMapKey.getOrPut(mapKeyOf(contribution), ::mutableListOf) += contribution
     }
     for ((mapKey, contributions) in contributionsByMapKey) {
+      ensureActive()
       if (contributions.size > 1) {
         onIssue(GraphValidationIssue.DuplicateMapKey(binding, mapKey, contributions))
       }

--- a/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/ContributionMerging.kt
+++ b/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/ContributionMerging.kt
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.compiler.graph
 
-import dev.zacsweers.metro.compiler.filterToSet
-import dev.zacsweers.metro.compiler.flatMapToSet
 import org.jetbrains.kotlin.name.ClassId
 
 /**
@@ -34,6 +32,7 @@ public class MergePlan(
  *   excluding/replacing the origin removes its generated contributions too.
  * @param nestedChildrenOf returns the present ids nested under a given class (compiler-only
  *   `MetroContribution` marker shape); defaults to none.
+ * @param ensureActive cancellation callback polled while merging contributions.
  * @param replacesOf the classes a surviving contribution replaces. Only invoked for survivors.
  */
 public fun computeMergePlan(
@@ -41,25 +40,55 @@ public fun computeMergePlan(
   excluded: Set<ClassId>,
   originToIds: Map<ClassId, Set<ClassId>> = emptyMap(),
   nestedChildrenOf: (ClassId) -> Set<ClassId> = { emptySet() },
+  ensureActive: () -> Unit = {},
   replacesOf: (ClassId) -> Set<ClassId>,
 ): MergePlan {
   val removed = mutableSetOf<ClassId>()
   val unmatchedExclusions = mutableSetOf<ClassId>()
 
   for (target in excluded) {
-    val matched = removeTarget(target, presentIds, originToIds, nestedChildrenOf, removed)
+    ensureActive()
+    val matched =
+      removeTarget(
+        target,
+        presentIds,
+        originToIds,
+        nestedChildrenOf,
+        removed,
+        ensureActive,
+      )
     if (!matched) unmatchedExclusions += target
   }
 
   // Replaces are collected only from survivors, mirroring the compiler: excluded contributions
   // don't get their `replaces` honored, and replacement matching is against the post-exclude set.
-  val survivors = presentIds - removed
-  val replaced = survivors.flatMapToSet { replacesOf(it) }
+  val survivors = mutableSetOf<ClassId>()
+  for (presentId in presentIds) {
+    ensureActive()
+    if (presentId !in removed) survivors += presentId
+  }
+  val replaced = mutableSetOf<ClassId>()
+  for (survivor in survivors) {
+    ensureActive()
+    for (replacement in replacesOf(survivor)) {
+      ensureActive()
+      replaced += replacement
+    }
+  }
 
   val unmatchedReplacements = mutableSetOf<ClassId>()
   for (target in replaced) {
+    ensureActive()
     // Replacements don't expand through the nested-marker shape (matches the compiler).
-    val matched = removeTarget(target, survivors, originToIds, { emptySet() }, removed)
+    val matched =
+      removeTarget(
+        target,
+        survivors,
+        originToIds,
+        { emptySet() },
+        removed,
+        ensureActive,
+      )
     if (!matched) unmatchedReplacements += target
   }
 
@@ -72,13 +101,21 @@ private inline fun removeTarget(
   originToIds: Map<ClassId, Set<ClassId>>,
   nestedChildrenOf: (ClassId) -> Set<ClassId>,
   removed: MutableSet<ClassId>,
+  ensureActive: () -> Unit,
 ): Boolean {
+  ensureActive()
   val direct = target in presentIds
   if (direct) removed += target
   val originHits = originToIds[target].orEmpty()
-  removed += originHits
+  for (originHit in originHits) {
+    ensureActive()
+    removed += originHit
+  }
   val nested = nestedChildrenOf(target)
-  removed += nested
+  for (nestedId in nested) {
+    ensureActive()
+    removed += nestedId
+  }
   return direct || originHits.isNotEmpty() || nested.isNotEmpty()
 }
 
@@ -97,12 +134,16 @@ public interface MergeContribution {
  * excludes-first ordering. A convenience for callers that hold their contributions as a simple list
  * keyed by [MergeContribution.mergeId] (the IDE's binding model), where each item already stands
  * for its own origin so no origin/nested indirection is needed.
+ *
+ * @param ensureActive cancellation callback polled while filtering contributions.
  */
 public fun <T : MergeContribution> applyExcludesAndReplaces(
   items: List<T>,
   excluded: Set<ClassId> = emptySet(),
+  ensureActive: () -> Unit = {},
 ): List<T> {
   if (items.isEmpty()) return items
+  ensureActive()
   if (items.size == 1) {
     val item = items[0]
     val mergeId = item.mergeId ?: return items
@@ -111,28 +152,59 @@ public fun <T : MergeContribution> applyExcludesAndReplaces(
   }
 
   val afterExcludes =
-    if (excluded.isEmpty()) items
-    else items.filter { it.mergeId == null || it.mergeId !in excluded }
+    if (excluded.isEmpty()) {
+      items
+    } else {
+      val filtered = ArrayList<T>(items.size)
+      for (item in items) {
+        ensureActive()
+        if (item.mergeId == null || item.mergeId !in excluded) filtered += item
+      }
+      filtered
+    }
   if (afterExcludes.isEmpty()) {
     return afterExcludes
   }
-  val replaced = afterExcludes.flatMapTo(hashSetOf()) { it.replaces }
+  val replaced = hashSetOf<ClassId>()
+  for (item in afterExcludes) {
+    ensureActive()
+    for (replacement in item.replaces) {
+      ensureActive()
+      replaced += replacement
+    }
+  }
   if (replaced.isEmpty()) return afterExcludes
   // Survivor replaces match against all survivors, including the declaring item itself, keeping
   // this in agreement with computeMergePlan for self-replacing contributions.
-  return afterExcludes.filter { it.mergeId == null || it.mergeId !in replaced }
+  val result = ArrayList<T>(afterExcludes.size)
+  for (item in afterExcludes) {
+    ensureActive()
+    if (item.mergeId == null || item.mergeId !in replaced) result += item
+  }
+  return result
 }
 
+/** Finds lower priority contributions while checking for cancellation. */
 public inline fun <BindingType, ConflictKeyType : Any> computeLowerPriorityContributions(
   bindings: List<BindingType>,
+  ensureActive: () -> Unit = {},
   conflictKeySelector: (BindingType) -> ConflictKeyType,
   prioritySelector: (BindingType) -> Int,
 ): Set<BindingType> {
   if (bindings.size < 2) return emptySet()
-  if (bindings.none { prioritySelector(it) != Int.MIN_VALUE }) return emptySet()
+  var hasExplicitPriority = false
+  for (binding in bindings) {
+    ensureActive()
+    if (prioritySelector(binding) != Int.MIN_VALUE) {
+      hasExplicitPriority = true
+      break
+    }
+  }
+  if (!hasExplicitPriority) return emptySet()
 
   val highestPrioritiesByKey = HashMap<ConflictKeyType, Int>(bindings.size)
   for (binding in bindings) {
+    ensureActive()
     val conflictKey = conflictKeySelector(binding)
     val priority = prioritySelector(binding)
     val highestPriority = highestPrioritiesByKey[conflictKey]
@@ -141,7 +213,12 @@ public inline fun <BindingType, ConflictKeyType : Any> computeLowerPriorityContr
     }
   }
 
-  return bindings.filterToSet { binding ->
-    prioritySelector(binding) < highestPrioritiesByKey.getValue(conflictKeySelector(binding))
+  val result = mutableSetOf<BindingType>()
+  for (binding in bindings) {
+    ensureActive()
+    val priority = prioritySelector(binding)
+    val highestPriority = highestPrioritiesByKey.getValue(conflictKeySelector(binding))
+    if (priority < highestPriority) result += binding
   }
+  return result
 }

--- a/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/DiagnosticRoutes.kt
+++ b/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/DiagnosticRoutes.kt
@@ -17,16 +17,20 @@ public class DiagnosticRoutes<
   private var parents: Map<TypeKey, TypeKey>? = null
   private var rootEntries: Map<TypeKey, Entry>? = null
 
-  /** Returns stack entries from a root to [key], preserving the original root request. */
+  /**
+   * Returns stack entries from a root to [key], preserving the original root request.
+   *
+   * @param ensureActive cancellation callback polled while indexing and building the route.
+   */
   public fun routeToRoot(
     key: TypeKey,
+    ensureActive: () -> Unit = {},
     createDependencyEntry: (callingKey: TypeKey, dependencyKey: TypeKey) -> Entry,
   ): List<Entry> {
     // No need to walk through the graph without roots.
     if (roots.isEmpty()) return emptyList()
-
     if (parents == null) {
-      buildIndex()
+      buildIndex(ensureActive)
     }
 
     val indexedParents = checkNotNull(parents)
@@ -37,30 +41,44 @@ public class DiagnosticRoutes<
     var current = key
     var parent = indexedParents.getValue(current)
     while (parent != current) {
+      ensureActive()
       path.add(current)
       current = parent
       parent = indexedParents.getValue(current)
     }
+    ensureActive()
     path.add(current)
 
     // Add entries root-first so pushing them preserves the existing binding stack order.
     val rootIndex = path.lastIndex
     val result = ArrayList<Entry>(path.size)
+    ensureActive()
     result.add(checkNotNull(rootEntries).getValue(path[rootIndex]))
     for (index in rootIndex - 1 downTo 0) {
+      ensureActive()
       result.add(createDependencyEntry(path[index + 1], path[index]))
     }
     return result
   }
 
   /** Builds deterministic shortest paths from every graph root without recursion. */
-  private fun buildIndex() {
+  private fun buildIndex(ensureActive: () -> Unit) {
     val indexedParents = HashMap<TypeKey, TypeKey>(calculateInitialCapacity(adjacency.size))
     val indexedRoots = HashMap<TypeKey, Entry>(calculateInitialCapacity(roots.size))
     val queue = ArrayDeque<TypeKey>(roots.size)
 
     // A stable sort preserves the first contextual request when roots share a type key.
-    for ((contextKey, entry) in roots.entries.sortedBy { it.key.typeKey }) {
+    val sortedRoots = ArrayList<Map.Entry<ContextualTypeKey, Entry>>(roots.size)
+    for (root in roots.entries) {
+      ensureActive()
+      sortedRoots += root
+    }
+    sortedRoots.sortWith { left, right ->
+      ensureActive()
+      left.key.typeKey.compareTo(right.key.typeKey)
+    }
+    for ((contextKey, entry) in sortedRoots) {
+      ensureActive()
       val rootKey = contextKey.typeKey
       if (rootKey in indexedParents) continue
       indexedParents[rootKey] = rootKey
@@ -70,8 +88,10 @@ public class DiagnosticRoutes<
 
     // Forward adjacency already lists dependencies in deterministic sorted order.
     while (queue.isNotEmpty()) {
+      ensureActive()
       val callingKey = queue.removeFirst()
       for (dependencyKey in adjacency[callingKey].orEmpty()) {
+        ensureActive()
         if (dependencyKey in indexedParents) continue
         indexedParents[dependencyKey] = callingKey
         queue.addLast(dependencyKey)

--- a/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/MetroSort.kt
+++ b/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/MetroSort.kt
@@ -8,7 +8,6 @@ import androidx.collection.MutableObjectIntMap
 import androidx.collection.ObjectIntMap
 import androidx.collection.ScatterMap
 import dev.zacsweers.metro.compiler.calculateInitialCapacity
-import dev.zacsweers.metro.compiler.filterToSet
 import dev.zacsweers.metro.compiler.getAndAdd
 import dev.zacsweers.metro.compiler.tracing.TraceScope
 import dev.zacsweers.metro.compiler.tracing.trace
@@ -16,6 +15,7 @@ import java.util.Collections.emptySortedSet
 import java.util.PriorityQueue
 import java.util.SortedMap
 import java.util.SortedSet
+import java.util.TreeSet
 
 /**
  * @param sortedKeys Topologically sorted list of keys.
@@ -111,6 +111,7 @@ public data class GraphAdjacency<T>(
  * @param onCycle called with the offending cycle if no deferrable edge
  * @param roots optional set of source roots for computing reachability. If null, all keys will be
  *   kept.
+ * @param ensureActive cancellation callback polled throughout sorting. Defaults to no checks.
  * @param onSortedCycle optional callback reporting (sorted) cycles.
  */
 context(traceScope: TraceScope)
@@ -120,6 +121,7 @@ public fun <V : Comparable<V>> metroSort(
   onCycle: (List<V>) -> Unit,
   roots: SortedSet<V>? = null,
   isImplicitlyDeferrable: (V) -> Boolean = { false },
+  ensureActive: () -> Unit = {},
   onSortedCycle: (List<V>) -> Unit = {},
 ): GraphTopology<V> {
   val deferredTypes = HashSet<V>()
@@ -128,15 +130,26 @@ public fun <V : Comparable<V>> metroSort(
   // Also builds reachable adjacency (forward and reverse) in the same pass (avoiding separate
   // filter)
   val (components, componentOf, reachableAdjacency) =
-    trace("Compute SCCs") { fullAdjacency.computeStronglyConnectedComponents(roots) }
+    trace("Compute SCCs") {
+      fullAdjacency.computeStronglyConnectedComponents(roots, ensureActive)
+    }
 
   // Check for cycles
   trace("Check for cycles") {
     for (component in components) {
+      ensureActive()
       val vertices = component.vertices
 
       if (vertices.size == 1) {
-        val isSelfLoop = fullAdjacency[vertices[0]].orEmpty().any { it == vertices[0] }
+        val vertex = vertices[0]
+        var isSelfLoop = false
+        for (target in fullAdjacency[vertex].orEmpty()) {
+          ensureActive()
+          if (target == vertex) {
+            isSelfLoop = true
+            break
+          }
+        }
         if (!isSelfLoop) {
           // trivial acyclic
           continue
@@ -152,6 +165,7 @@ public fun <V : Comparable<V>> metroSort(
           componentId = component.id,
           isDeferrable = isDeferrable,
           isImplicitlyDeferrable = isImplicitlyDeferrable,
+          ensureActive = ensureActive,
         )
 
       if (contributorsToCycle.isEmpty()) {
@@ -167,7 +181,7 @@ public fun <V : Comparable<V>> metroSort(
   val componentOrder =
     trace("Component order from Tarjan finish order") {
       MutableIntList(components.size).apply {
-        for (id in components.indices) {
+        components.indices.forEachCancellable(ensureActive) { id ->
           add(id)
         }
       }
@@ -183,6 +197,7 @@ public fun <V : Comparable<V>> metroSort(
         isDeferrable = isDeferrable,
         onSortedCycle = onSortedCycle,
         expectedSize = fullAdjacency.size,
+        ensureActive = ensureActive,
       )
     }
 
@@ -246,6 +261,7 @@ private fun <V : Comparable<V>> findMinimalDeferralSet(
   componentId: Int,
   isDeferrable: (V, V) -> Boolean,
   isImplicitlyDeferrable: (V) -> Boolean,
+  ensureActive: () -> Unit,
 ): Set<V> {
   // Build the SCC-internal adjacency and deferrable edges ONCE upfront
   // This avoids rebuilding these structures for each candidate test.
@@ -255,10 +271,10 @@ private fun <V : Comparable<V>> findMinimalDeferralSet(
   val deferrableEdgesFrom = HashMap<V, MutableSet<V>>(cap)
   val potentialCandidates = HashSet<V>(cap)
 
-  for (from in vertices) {
+  vertices.forEachCancellable(ensureActive) { from ->
     // Targets bounded by `from`'s outgoing degree.
     val targets = LinkedHashSet<V>(calculateInitialCapacity(fullAdjacency[from]?.size ?: 0))
-    for (to in fullAdjacency[from].orEmpty()) {
+    fullAdjacency[from].orEmpty().forEachCancellable(ensureActive) { to ->
       // Only consider edges that stay inside the SCC
       if (componentOf[to] == componentId) {
         targets.add(to)
@@ -277,7 +293,7 @@ private fun <V : Comparable<V>> findMinimalDeferralSet(
   }
 
   // Create reusable cycle checker that can mask edges dynamically
-  val cycleChecker = ReusableCycleChecker(vertices, sccAdjacency, deferrableEdgesFrom)
+  val cycleChecker = ReusableCycleChecker(vertices, sccAdjacency, deferrableEdgesFrom, ensureActive)
 
   // Two flavors of "deferrable" inform candidate priority:
   // - implicit (whole-node, e.g., @AssistedFactory, user already marked it on-demand)
@@ -287,16 +303,18 @@ private fun <V : Comparable<V>> findMinimalDeferralSet(
   // A DeferralKind { WHOLE_NODE, EDGE, NONE } ordinal would express this more cleanly but isn't
   // worth the ripple through the rest of this logic.
   // Sort candidates once upfront instead of sorting in each loop.
-  val sortedCandidates =
-    potentialCandidates.sortedWith(
-      compareBy(
-        { !isImplicitlyDeferrable(it) }, // implicitly deferrable first (false < true)
-        { it }, // then by natural order
-      )
-    )
+  val sortedCandidates = ArrayList<V>(potentialCandidates.size)
+  potentialCandidates.forEachCancellable(ensureActive) { candidate ->
+    sortedCandidates += candidate
+  }
+  sortedCandidates.sortWith { left, right ->
+    ensureActive()
+    val implicitPriority = (!isImplicitlyDeferrable(left)).compareTo(!isImplicitlyDeferrable(right))
+    if (implicitPriority != 0) implicitPriority else left.compareTo(right)
+  }
 
   // Try each candidate
-  for (candidate in sortedCandidates) {
+  sortedCandidates.forEachCancellable(ensureActive) { candidate ->
     if (cycleChecker.isAcyclicWith(setOf(candidate))) {
       return setOf(candidate)
     }
@@ -310,6 +328,7 @@ private fun <V : Comparable<V>> findMinimalDeferralSet(
 
   // Try removing less preferred bindings first.
   for (index in sortedCandidates.lastIndex downTo 0) {
+    ensureActive()
     // Every single candidate was already tested, so two remaining candidates are both necessary.
     if (potentialCandidates.size == 2) break
 
@@ -364,20 +383,30 @@ private fun <V : Comparable<V>> expandComponents(
   isDeferrable: (V, V) -> Boolean,
   onSortedCycle: (List<V>) -> Unit,
   expectedSize: Int,
+  ensureActive: () -> Unit,
 ): List<V> {
   val sortedKeys = ArrayList<V>(expectedSize)
-  componentOrder.forEach { id ->
+  (0 until componentOrder.size).forEachCancellable(ensureActive) { index ->
+    val id = componentOrder[index]
     val component = components[id]
     if (component.vertices.size == 1) {
       // Single vertex (no cycle, or cycle-of-one from a self-loop). Emit it directly.
       sortedKeys += component.vertices[0]
     } else {
       // Multi-vertex SCC: sort the cycle internally, ignoring soft edges from deferred sources.
-      val deferredInScc = component.vertices.filterToSet { it in deferredTypes }
+      val deferredInScc = HashSet<V>()
+      component.vertices.forEachCancellable(ensureActive) { vertex ->
+        if (vertex in deferredTypes) deferredInScc += vertex
+      }
       sortedKeys +=
-        sortVerticesInSCC(component.vertices, forwardAdjacency, isDeferrable, deferredInScc).also {
-          onSortedCycle(it)
-        }
+        sortVerticesInSCC(
+            component.vertices,
+            forwardAdjacency,
+            isDeferrable,
+            deferredInScc,
+            ensureActive,
+          )
+          .also { onSortedCycle(it) }
     }
   }
   return sortedKeys
@@ -420,9 +449,14 @@ private fun <V : Comparable<V>> sortVerticesInSCC(
   fullAdjacency: SortedMap<V, SortedSet<V>>,
   isDeferrable: (V, V) -> Boolean,
   deferredInScc: Set<V>,
+  ensureActive: () -> Unit,
 ): List<V> {
   if (vertices.size <= 1) return vertices
-  val inScc = vertices.toSet()
+  val cap = calculateInitialCapacity(vertices.size)
+  val inScc = HashSet<V>(cap)
+  vertices.forEachCancellable(ensureActive) { vertex ->
+    inScc += vertex
+  }
 
   // An edge is "soft" inside this SCC only if it's deferrable and the source is deferred
   val isSoftEdge: (from: V, to: V) -> Boolean = { from, to ->
@@ -430,13 +464,14 @@ private fun <V : Comparable<V>> sortVerticesInSCC(
   }
 
   // v -> hard prereqs (non-soft edges). Bounded by SCC size.
-  val cap = calculateInitialCapacity(vertices.size)
   val hardDeps = HashMap<V, MutableSet<V>>(cap)
   // prereq -> dependents (via hard edges). Bounded by SCC size.
   val revHard = HashMap<V, MutableSet<V>>(cap)
 
   for (v in vertices) {
+    ensureActive()
     for (dep in fullAdjacency[v].orEmpty()) {
+      ensureActive()
       if (dep !in inScc) continue
       if (isSoftEdge(v, dep)) {
         // ignore only these edges when ordering
@@ -447,7 +482,10 @@ private fun <V : Comparable<V>> sortVerticesInSCC(
     }
   }
 
-  val hardIn = vertices.associateWithTo(HashMap(cap)) { hardDeps[it]?.size ?: 0 }
+  val hardIn = HashMap<V, Int>(cap)
+  vertices.forEachCancellable(ensureActive) { vertex ->
+    hardIn[vertex] = hardDeps[vertex]?.size ?: 0
+  }
 
   // Sort ready by:
   // 1 - nodes that are in deferredInScc (i.e., emit DelegateFactory before its users)
@@ -468,13 +506,16 @@ private fun <V : Comparable<V>> sortVerticesInSCC(
     }
 
   // Seed with nodes that have no hard deps
-  vertices.filterTo(ready) { hardIn.getValue(it) == 0 }
+  vertices.forEachCancellable(ensureActive) { vertex ->
+    if (hardIn.getValue(vertex) == 0) ready += vertex
+  }
 
   val result = ArrayDeque<V>(vertices.size)
   while (ready.isNotEmpty()) {
+    ensureActive()
     val v = ready.remove()
     result += v
-    for (depender in revHard[v].orEmpty()) {
+    revHard[v].orEmpty().forEachCancellable(ensureActive) { depender ->
       val degree = hardIn.getValue(depender) - 1
       hardIn[depender] = degree
       if (degree == 0) {
@@ -596,6 +637,7 @@ public data class TarjanResult<V : Comparable<V>>(
  *   walked (the entire graph is reachable). If provided, only vertices reachable from these roots
  *   are visited; the rest stay [UNVISITED] and are filtered out of
  *   [TarjanResult.reachableAdjacency].
+ * @param ensureActive cancellation callback invoked during traversal and adjacency construction.
  * @return The list of components (in reverse topological order), the vertex->component-id map, and
  *   the reachable forward/reverse adjacency over visited vertices only.
  * @receiver A directed graph as `vertex -> outgoing edges`. Both the key set and each edge set must
@@ -605,7 +647,8 @@ public data class TarjanResult<V : Comparable<V>>(
  *   algorithm</a>
  */
 public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnectedComponents(
-  roots: SortedSet<V>? = null
+  roots: SortedSet<V>? = null,
+  ensureActive: () -> Unit = {},
 ): TarjanResult<V> {
   // Map vertices to dense int ids in sorted order so adjacency lookups, visited bookkeeping, and
   // the DFS stack can run on primitive arrays. This avoids per-edge string-keyed map lookups
@@ -625,6 +668,7 @@ public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnect
   val vertexToId = MutableObjectIntMap<V>(n)
   run {
     for ((i, key) in keys.withIndex()) {
+      ensureActive()
       idToVertex[i] = key
       vertexToId[key] = i
     }
@@ -638,14 +682,14 @@ public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnect
   // Build int-indexed adjacency. Each row is already sorted because the source SortedSet is
   // sorted and ids preserve that order.
   val adj = arrayOfNulls<IntArray>(n)
-  for ((vertex, edges) in this) {
+  entries.forEachCancellable(ensureActive) { (vertex, edges) ->
     val fromId = vertexToId[vertex]
     if (edges.isEmpty()) {
       adj[fromId] = EMPTY_INT_ARRAY
     } else {
       val arr = IntArray(edges.size)
       var i = 0
-      for (e in edges) {
+      edges.forEachCancellable(ensureActive) { e ->
         arr[i++] = vertexToId[e]
       }
       adj[fromId] = arr
@@ -689,6 +733,7 @@ public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnect
     onStack[start] = true
 
     while (callStack.isNotEmpty()) {
+      ensureActive()
       val top = callStack.size - 1
       val v = callStack[top]
       val edges = adj[v]!!
@@ -722,6 +767,7 @@ public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnect
         val componentId = nextComponentId++
         val members = MutableIntList()
         while (true) {
+          ensureActive()
           val popped = dfsStack.removeAt(dfsStack.size - 1)
           onStack[popped] = false
           members.add(popped)
@@ -745,12 +791,12 @@ public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnect
   }
 
   if (roots != null) {
-    for (root in roots) {
+    roots.forEachCancellable(ensureActive) { root ->
       val rootId = vertexToId.getOrDefault(root, UNVISITED)
       if (rootId != UNVISITED) visit(rootId)
     }
   } else {
-    for (id in 0 until n) {
+    (0 until n).forEachCancellable(ensureActive) { id ->
       visit(id)
     }
   }
@@ -759,8 +805,10 @@ public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnect
   val components = ArrayList<Component<V>>(componentMembers.size)
   val componentOf = MutableObjectIntMap<V>(n)
   for ((cid, members) in componentMembers.withIndex()) {
+    ensureActive()
     val component = Component<V>(cid)
-    members.forEach { id ->
+    (0 until members.size).forEachCancellable(ensureActive) { index ->
+      val id = members[index]
       val vertex = vertexAt(id)
       component.vertices += vertex
       componentOf[vertex] = cid
@@ -774,13 +822,12 @@ public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnect
   // outside the chosen `roots`). The contract here is to return a `SortedMap<V, SortedSet<V>>`
   // covering ONLY the vertices the DFS touched, with edges to UNVISITED targets filtered out.
   //
-  // Build into HashMap/HashSet (O(1) inserts, sized to known counts) and convert to the sorted
-  // contract in a single bulk pass at the end. For dense graphs (~6500 edges per vertex on the
-  // benchmark) per-edge TreeSet inserts (O(log m) each) added up; HashSet -> toSortedSet() does
-  // the sort once per row with much smaller per-edge constants.
+  // Collect edges in HashMap/HashSet with O(1) inserts, then sort the result. This kept graph
+  // traversal cheaper for dense benchmark graphs (~6500 edges per vertex).
   val rawForward = HashMap<V, HashSet<V>>(n)
   val reachableReverse = HashMap<V, MutableSet<V>>(n)
   for (id in 0 until n) {
+    ensureActive()
     // Skip vertices the DFS never visited. They're not part of the reachable subgraph.
     if (indexOfId[id] == UNVISITED) continue
     val vertex = vertexAt(id)
@@ -793,6 +840,7 @@ public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnect
     }
     val reachableEdges = HashSet<V>(edges.size)
     for (toId in edges) {
+      ensureActive()
       // Filter out edges that leave the reachable subgraph: if the DFS didn't reach `toId`,
       // it's not part of the result and any edge into it is dropped.
       if (indexOfId[toId] == UNVISITED) continue
@@ -804,23 +852,35 @@ public fun <V : Comparable<V>> SortedMap<V, SortedSet<V>>.computeStronglyConnect
     rawForward[vertex] = reachableEdges
   }
 
-  // Convert HashMap<V, HashSet<V>> -> SortedMap<V, SortedSet<V>>. The TreeMap inserts here are
-  // O(log(n)) but they happen once per vertex (not once per edge); per-row sorts via
-  // `toSortedSet()` are O(mlog(m)) in bulk.
+  // Convert the reachable subgraph to the sorted result. Each vertex adds one TreeMap entry at
+  // O(log(n)), and each row is inserted into its final TreeSet. Converting rows directly also
+  // avoids an intermediate sorted collection.
   val reachableForward = sortedMapOf<V, SortedSet<V>>()
-  for ((vertex, set) in rawForward) {
-    reachableForward[vertex] = if (set.isEmpty()) emptySortedSet() else set.toSortedSet()
+  rawForward.entries.forEachCancellable(ensureActive) { (vertex, set) ->
+    reachableForward[vertex] =
+      if (set.isEmpty()) emptySortedSet() else set.toNaturalSortedSet(ensureActive)
   }
 
   return TarjanResult(components, componentOf, GraphAdjacency(reachableForward, reachableReverse))
 }
 
+/** Builds an ordered set while checking for cancellation. */
+private fun <V : Comparable<V>> Set<V>.toNaturalSortedSet(ensureActive: () -> Unit): SortedSet<V> {
+  val result = TreeSet<V>()
+  forEachCancellable(ensureActive) { value ->
+    result += value
+  }
+  return result
+}
+
 private const val UNVISITED = -1
 private val EMPTY_INT_ARRAY = IntArray(0)
 
+/** Builds the full adjacency map while checking for cancellation. */
 public fun <T : Comparable<T>> buildFullAdjacency(
   map: ScatterMap<T, *>,
   sourceToTarget: (T) -> Iterable<T>,
+  ensureActive: () -> Unit = {},
   onMissing: (source: T, missing: T) -> Unit,
 ): SortedMap<T, SortedSet<T>> {
   /**
@@ -830,9 +890,11 @@ public fun <T : Comparable<T>> buildFullAdjacency(
   val adjacency = sortedMapOf<T, SortedSet<T>>()
 
   map.forEachKey { key ->
+    ensureActive()
     val dependencies = adjacency.getOrPut(key, ::sortedSetOf)
 
     for (targetKey in sourceToTarget(key)) {
+      ensureActive()
       if (targetKey !in map) {
         // may throw, or silently allow
         onMissing(key, targetKey)

--- a/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/ReusableCycleChecker.kt
+++ b/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/ReusableCycleChecker.kt
@@ -12,6 +12,7 @@ internal class ReusableCycleChecker<V>(
   private val vertices: List<V>,
   private val sccAdjacency: Map<V, Set<V>>,
   private val deferrableEdgesFrom: Map<V, Set<V>>,
+  private val ensureActive: () -> Unit = {},
 ) {
   // Reuse these traversal structures across checks to reduce allocations.
   private val visited: HashSet<V>
@@ -35,6 +36,7 @@ internal class ReusableCycleChecker<V>(
     resetTraversal()
 
     for (node in vertices) {
+      ensureActive()
       if (node !in visited && !isAcyclicFrom(node, deferredNodes)) {
         return false
       }
@@ -68,6 +70,7 @@ internal class ReusableCycleChecker<V>(
     pushFrame(node, deferredNodes)
 
     while (frames.isNotEmpty()) {
+      ensureActive()
       val frame = frames.last()
       if (!frame.neighbors.hasNext()) {
         frames.removeLast()

--- a/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/forEachCancellable.kt
+++ b/metro-common/src/main/kotlin/dev/zacsweers/metro/compiler/graph/forEachCancellable.kt
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.compiler.graph
+
+/** Calls [ensureActive] before each value, preserving iteration order. */
+internal inline fun <T> Iterable<T>.forEachCancellable(
+  ensureActive: () -> Unit,
+  action: (T) -> Unit,
+) {
+  for (value in this) {
+    ensureActive()
+    action(value)
+  }
+}
+
+/** Keeps integer traversal unboxed and calls [ensureActive] before each value. */
+internal inline fun IntProgression.forEachCancellable(
+  ensureActive: () -> Unit,
+  action: (Int) -> Unit,
+) {
+  for (value in this) {
+    ensureActive()
+    action(value)
+  }
+}

--- a/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraphTest.kt
+++ b/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraphTest.kt
@@ -132,6 +132,23 @@ class BindingGraphTest : TraceScope by TraceScope.noop() {
   }
 
   @Test
+  fun `seal checks for cancellation`() {
+    val graph = newStringBindingGraph()
+    repeat(300) { index -> graph.tryPut("Binding$index".typeKey.toBinding()) }
+    var checks = 0
+
+    assertFailsWith<BindingGraphCancellationException> {
+      graph.seal(
+        shrinkUnusedBindings = false,
+        ensureActive = {
+          if (++checks == 2) throw BindingGraphCancellationException()
+        },
+      )
+    }
+    assertThat(checks).isEqualTo(2)
+  }
+
+  @Test
   fun `TypeKey dependsOn withDeferrableTypes`() {
     val a = "A".typeKey
     val b = "B".typeKey
@@ -478,6 +495,8 @@ class BindingGraphTest : TraceScope by TraceScope.noop() {
       )
   }
 }
+
+private class BindingGraphCancellationException : RuntimeException()
 
 private val String.typeKey: StringTypeKey
   get() = contextualTypeKey.typeKey

--- a/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraphValidatorTest.kt
+++ b/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/BindingGraphValidatorTest.kt
@@ -4,6 +4,7 @@ package dev.zacsweers.metro.compiler.graph
 
 import androidx.collection.MutableScatterMap
 import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
 import org.junit.Test
 
 class BindingGraphValidatorTest {
@@ -109,6 +110,33 @@ class BindingGraphValidatorTest {
           contributions = listOf(first, second),
         )
       )
+  }
+
+  @Test
+  fun `map validation checks cancellation after work has started`() {
+    val contributions = List(300) { index -> validationBinding("Contribution$index") }
+    val multibinding = validationBinding("Map<String, Value>")
+    val validator =
+      validator(
+        bindings = bindingsOf(*(contributions + multibinding).toTypedArray()),
+        multibindingKindOf = { candidate ->
+          MultibindingKind.MAP.takeIf { candidate == multibinding }
+        },
+        multibindingSourceKeys = { contributions.map { it.typeKey } },
+        isMapContribution = { true },
+      )
+    var checks = 0
+
+    assertFailsWith<ValidationCancellationException> {
+      validator.validate(
+        multibinding,
+        ensureActive = {
+          if (++checks == 2) throw ValidationCancellationException()
+        },
+      ) {}
+    }
+
+    assertThat(checks).isEqualTo(2)
   }
 
   @Test
@@ -222,6 +250,8 @@ private typealias StringBindingGraphValidator =
     String,
     String,
   >
+
+private class ValidationCancellationException : RuntimeException()
 
 private fun StringBindingGraphValidator.validateAll(
   binding: StringBinding

--- a/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/ContributionMergeTest.kt
+++ b/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/ContributionMergeTest.kt
@@ -3,12 +3,49 @@
 package dev.zacsweers.metro.compiler.graph
 
 import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertFailsWith
 import org.jetbrains.kotlin.name.ClassId
 import org.junit.Test
 
 class ContributionMergeTest {
 
   private fun id(name: String): ClassId = ClassId.fromString("test/$name")
+
+  @Test
+  fun `merge plan checks for cancellation`() {
+    val presentIds = buildSet { repeat(300) { index -> add(id("Contribution$index")) } }
+    var checks = 0
+
+    assertFailsWith<MergeCancellationException> {
+      computeMergePlan(
+        presentIds = presentIds,
+        excluded = emptySet(),
+        ensureActive = {
+          if (++checks == 2) throw MergeCancellationException()
+        },
+        replacesOf = { emptySet() },
+      )
+    }
+
+    assertThat(checks).isEqualTo(2)
+  }
+
+  @Test
+  fun `exclude and replace filtering checks for cancellation`() {
+    val items = List(300) { index -> Item(id("Contribution$index"), emptySet()) }
+    var checks = 0
+
+    assertFailsWith<MergeCancellationException> {
+      applyExcludesAndReplaces(
+        items = items,
+        ensureActive = {
+          if (++checks == 2) throw MergeCancellationException()
+        },
+      )
+    }
+
+    assertThat(checks).isEqualTo(2)
+  }
 
   @Test
   fun `excludes remove by id`() {
@@ -172,6 +209,26 @@ class ContributionMergeTest {
   )
 
   @Test
+  fun `priority filtering checks for cancellation`() {
+    val contributions =
+      List(300) { index -> PrioritizedContribution(id("Contribution$index"), "Service", index) }
+    var checks = 0
+
+    assertFailsWith<MergeCancellationException> {
+      computeLowerPriorityContributions(
+        bindings = contributions,
+        ensureActive = {
+          if (++checks == 2) throw MergeCancellationException()
+        },
+        conflictKeySelector = PrioritizedContribution::conflictKey,
+        prioritySelector = PrioritizedContribution::priority,
+      )
+    }
+
+    assertThat(checks).isEqualTo(2)
+  }
+
+  @Test
   fun `higher priority removes only the conflicting contribution from an origin`() {
     val losing = PrioritizedContribution(id("Original"), "FirstService", priority = 1)
     val retained = PrioritizedContribution(id("Original"), "SecondService", priority = 1)
@@ -239,3 +296,5 @@ class ContributionMergeTest {
     assertThat(lowerPriorityContributions(low, high)).isEmpty()
   }
 }
+
+private class MergeCancellationException : RuntimeException()

--- a/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/DiagnosticRoutesTest.kt
+++ b/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/DiagnosticRoutesTest.kt
@@ -5,9 +5,58 @@ package dev.zacsweers.metro.compiler.graph
 import com.google.common.truth.Truth.assertThat
 import java.util.TreeMap
 import java.util.TreeSet
+import kotlin.test.assertFailsWith
 import org.junit.Test
 
 class DiagnosticRoutesTest {
+  @Test
+  fun `route indexing checks for cancellation`() {
+    val root = routeContextKey("Node0")
+    val adjacency = TreeMap<StringTypeKey, Set<StringTypeKey>>()
+    repeat(300) { index ->
+      adjacency[routeKey("Node$index")] = TreeSet(setOf(routeKey("Node${index + 1}")))
+    }
+    adjacency[routeKey("Node300")] = TreeSet()
+    val routes = DiagnosticRoutes(mapOf(root to StringBindingStack.Entry(root)), adjacency)
+    var checks = 0
+
+    assertFailsWith<RouteCancellationException> {
+      routes.routeToRoot(
+        key = routeKey("Node300"),
+        ensureActive = {
+          if (++checks == 2) throw RouteCancellationException()
+        },
+        createDependencyEntry = ::dependencyEntry,
+      )
+    }
+
+    assertThat(checks).isEqualTo(2)
+  }
+
+  @Test
+  fun `cached route reconstruction checks for cancellation`() {
+    val root = routeContextKey("Root")
+    val routes =
+      DiagnosticRoutes(
+        roots = mapOf(root to StringBindingStack.Entry(root)),
+        adjacency =
+          sortedAdjacency(
+            "Root" to setOf("Middle"),
+            "Middle" to setOf("Target"),
+            "Target" to emptySet(),
+          ),
+      )
+    routes.routeToRoot(routeKey("Target"), createDependencyEntry = ::dependencyEntry)
+
+    assertFailsWith<RouteCancellationException> {
+      routes.routeToRoot(
+        key = routeKey("Target"),
+        ensureActive = { throw RouteCancellationException() },
+        createDependencyEntry = ::dependencyEntry,
+      )
+    }
+  }
+
   @Test
   fun `uses the shortest deterministic route from a graph root`() {
     val firstRoot = routeContextKey("FirstRoot")
@@ -26,7 +75,7 @@ class DiagnosticRoutesTest {
       )
     val routes = DiagnosticRoutes(roots, adjacency)
 
-    val route = routes.routeToRoot(routeKey("Target"), ::dependencyEntry)
+    val route = routes.routeToRoot(routeKey("Target"), createDependencyEntry = ::dependencyEntry)
 
     assertThat(route.map { it.usage }).containsExactly("second", "SecondRoot -> Target").inOrder()
   }
@@ -40,9 +89,14 @@ class DiagnosticRoutesTest {
         adjacency = sortedAdjacency("Root" to emptySet(), "Unreachable" to emptySet()),
       )
 
-    assertThat(routes.routeToRoot(routeKey("Unreachable"), ::dependencyEntry)).isEmpty()
+    assertThat(
+        routes.routeToRoot(routeKey("Unreachable"), createDependencyEntry = ::dependencyEntry)
+      )
+      .isEmpty()
   }
 }
+
+private class RouteCancellationException : RuntimeException()
 
 private fun dependencyEntry(
   callingKey: StringTypeKey,

--- a/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/MetroSortTest.kt
+++ b/metro-common/src/test/kotlin/dev/zacsweers/metro/compiler/graph/MetroSortTest.kt
@@ -32,6 +32,70 @@ import org.jetbrains.annotations.TestOnly
 
 class MetroSortTest : TraceScope by TraceScope.noop() {
   @Test
+  fun metroSortChecksForCancellation() {
+    val adjacency = sortedMapOf<String, SortedSet<String>>()
+    repeat(300) { index -> adjacency[index.toString()] = sortedSetOf() }
+    var checks = 0
+
+    assertFailsWith<TestCancellationException> {
+      metroSort(
+        fullAdjacency = adjacency,
+        isDeferrable = { _, _ -> false },
+        onCycle = { fail("cycle") },
+        ensureActive = {
+          if (++checks == 2) throw TestCancellationException()
+        },
+      )
+    }
+    assertEquals(2, checks)
+  }
+
+  @Test
+  fun adjacencyBuildChecksForCancellation() {
+    val bindings = MutableScatterMap<String, Any>()
+    repeat(300) { index -> bindings[index.toString()] = Any() }
+    var checks = 0
+
+    assertFailsWith<TestCancellationException> {
+      buildFullAdjacency(
+        map = bindings,
+        sourceToTarget = { emptyList() },
+        ensureActive = {
+          if (++checks == 2) throw TestCancellationException()
+        },
+        onMissing = { _, _ -> fail("missing") },
+      )
+    }
+    assertEquals(2, checks)
+  }
+
+  @Test
+  fun candidateSortingChecksForCancellation() {
+    val adjacency = sortedMapOf<String, SortedSet<String>>()
+    repeat(300) { index ->
+      adjacency[index.toString()] = sortedSetOf(((index + 1) % 300).toString())
+    }
+    var sortingStarted = false
+
+    assertFailsWith<TestCancellationException> {
+      metroSort(
+        fullAdjacency = adjacency,
+        isDeferrable = { _, _ -> true },
+        onCycle = { fail("cycle") },
+        isImplicitlyDeferrable = {
+          sortingStarted = true
+          false
+        },
+        ensureActive = {
+          if (sortingStarted) throw TestCancellationException()
+        },
+      )
+    }
+
+    assertTrue(sortingStarted)
+  }
+
+  @Test
   fun emptyEdges() {
     val unsorted = listOf("a", "b", "c")
     val sorted = listOf("a", "b", "c")
@@ -618,6 +682,8 @@ class MetroSortTest : TraceScope by TraceScope.noop() {
   }
 }
 
+private class TestCancellationException : RuntimeException()
+
 /**
  * Returns a new list where each element is preceded by its results in [sourceToTarget]. The first
  * element will return no values in [sourceToTarget].
@@ -662,7 +728,7 @@ private fun <T : Comparable<T>> Iterable<T>.topologicalSort(
         put(key, Any())
       }
     }
-  val fullAdjacency = buildFullAdjacency(fakeMap, sourceToTarget, onMissing)
+  val fullAdjacency = buildFullAdjacency(fakeMap, sourceToTarget, onMissing = onMissing)
   val topology = with(TraceScope.noop()) { metroSort(fullAdjacency, isDeferrable, onCycle) }
   return topology.sortedKeys
 }


### PR DESCRIPTION
Add an optional `ensureActive` callback to the shared graph code. IDE callers can use it to stop a long traversal when a read action is canceled, allowing pending edits to proceed. Compiler callers keep their current behavior.
