### PR TITLE
Publish immutable IDE indexes with scoped resolution sessions

### DIFF
--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/CooperativeCancellation.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/CooperativeCancellation.kt
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea
+
+import com.intellij.openapi.progress.ProgressManager
+
+/** Checks cancellation every 64 work items. Pass a counter that advances through the operation. */
+internal fun checkCanceledEvery(workIndex: Int) {
+  if (workIndex and CANCELLATION_CHECK_MASK == 0) {
+    ProgressManager.checkCanceled()
+  }
+}
+
+private const val CANCELLATION_CHECK_MASK = 0x3f

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/BindingExtraction.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/BindingExtraction.kt
@@ -11,6 +11,7 @@ import dev.zacsweers.metro.compiler.graph.computeMultibindingId
 import dev.zacsweers.metro.compiler.graph.createMapBindingId
 import dev.zacsweers.metro.compiler.graph.resolveImplicitBoundType
 import dev.zacsweers.metro.idea.annotationScopeKeys
+import dev.zacsweers.metro.idea.checkCanceledEvery
 import dev.zacsweers.metro.idea.classLiteralClassId
 import dev.zacsweers.metro.idea.hasAnyAnnotation
 import dev.zacsweers.metro.idea.model.ContributionEntry
@@ -201,13 +202,17 @@ internal fun KaSession.callableBindingView(
 /** Resolves an assisted factory's SAM for the concrete type requested by its graph. */
 internal fun KaSession.assistedFactoryFunction(factoryType: KaClassType): CallableBindingView? {
   val scope = factoryType.scope ?: return null
-  val signature =
-    scope.getCallableSignatures().filterIsInstance<KaFunctionSignature<*>>().singleOrNull {
-      candidate ->
-      val symbol = candidate.symbol
-      symbol is KaNamedFunctionSymbol && symbol.modality == KaSymbolModality.ABSTRACT
-    } ?: return null
-  return callableBindingView(signature)
+  var signature: KaFunctionSignature<*>? = null
+  for ((index, candidate) in scope.getCallableSignatures().withIndex()) {
+    checkCanceledEvery(index)
+    if (candidate !is KaFunctionSignature<*>) continue
+    val symbol = candidate.symbol
+    if (symbol !is KaNamedFunctionSymbol || symbol.modality != KaSymbolModality.ABSTRACT) continue
+    if (signature != null) return null
+    signature = candidate
+  }
+  val factorySignature = signature ?: return null
+  return callableBindingView(factorySignature)
 }
 
 /**
@@ -221,7 +226,8 @@ internal fun KaSession.mapKeyInfo(
   options: MetroOptions,
   implicitClassId: ClassId? = null,
 ): MapKeyInfo? {
-  for (annotation in annotated.annotations) {
+  for ((index, annotation) in annotated.annotations.withIndex()) {
+    checkCanceledEvery(index)
     val classId = annotation.classId ?: continue
     val annotationClass = findClass(classId) as? KaNamedClassSymbol ?: continue
     val mapKeyMeta =
@@ -450,7 +456,10 @@ internal fun CallableBindingView.bindingData(
         val dependencies =
           listOfNotNull(receiverDependency) +
             callable.valueParameters
-              .filterNot { it.symbol.hasAnyAnnotation(options.assistedAnnotations) }
+              .filterIndexed { index, parameter ->
+                checkCanceledEvery(index)
+                !parameter.symbol.hasAnyAnnotation(options.assistedAnnotations)
+              }
               .map { dependencyKey(it.returnType, it.symbol, options) }
         listOf(
           BindingData(
@@ -568,7 +577,8 @@ private fun KtClassOrObject.classBindingData(
 
     val intoSetIds =
       options.contributesIntoSetAnnotations + options.customContributesIntoSetAnnotations
-    for (annotation in contributesAnnotations) {
+    for ((index, annotation) in contributesAnnotations.withIndex()) {
+      checkCanceledEvery(index)
       val classId = annotation.classId ?: continue
       val boundType = contributedBoundType(ktClass, classSymbol, annotation) ?: continue
       val annotatedBoundType = boundType as? KaAnnotated
@@ -711,7 +721,11 @@ private fun KaSession.contributedBoundType(
   }
   // The implicit bound type (supertype @DefaultBinding, else sole supertype) is resolved by the
   // shared decision so the IDE and compiler agree on ambiguity. Ambiguous/multiple → unresolved.
-  val superTypes = classSymbol.superTypes.filterNot { it.isAnyType }
+  val superTypes =
+    classSymbol.superTypes.filterIndexed { index, type ->
+      checkCanceledEvery(index)
+      !type.isAnyType
+    }
   val resolution =
     resolveImplicitBoundType(superTypes) { superType ->
       val supertypeSymbol = (superType.fullyExpandedType as? KaClassType)?.symbol as? KaClassSymbol
@@ -731,7 +745,10 @@ private fun KaSession.unannotatedBoundType(boundType: KaType): KaType {
   val classType = boundType.fullyExpandedType as? KaClassType ?: return boundType
   return buildClassType(classType.classId) {
     isMarkedNullable = classType.isMarkedNullable
-    for (projection in classType.typeArguments) argument(projection)
+    for ((index, projection) in classType.typeArguments.withIndex()) {
+      checkCanceledEvery(index)
+      argument(projection)
+    }
   }
 }
 
@@ -749,9 +766,15 @@ private fun KaSession.resolveDefaultBindingType(supertypeSymbol: KaClassSymbol):
   }
   val mirror =
     supertypeSymbol.declaredMemberScope.classifiers
+      .withIndex()
+      .onEach { checkCanceledEvery(it.index) }
+      .map { it.value }
       .filterIsInstance<KaNamedClassSymbol>()
       .firstOrNull { it.name.asString() == "DefaultBindingMirror" } ?: return null
   return mirror.declaredMemberScope.callables
+    .withIndex()
+    .onEach { checkCanceledEvery(it.index) }
+    .map { it.value }
     .filterIsInstance<KaNamedFunctionSymbol>()
     .firstOrNull { it.name.asString() == "defaultBinding" }
     ?.returnType
@@ -768,9 +791,11 @@ internal fun KaSession.findInjectConstructorSymbol(
   if (!classSymbol.isInjectableKind()) return null
   val classLevel = hasClassLevelInject(classSymbol, options)
   val constructors = classSymbol.memberScope.constructors.toList()
-  val annotatedConstructor = constructors.firstOrNull {
-    it.hasAnyAnnotation(options.allInjectAnnotations)
-  }
+  val annotatedConstructor =
+    constructors.withIndex().firstNotNullOfOrNull { (index, constructor) ->
+      checkCanceledEvery(index)
+      constructor.takeIf { it.hasAnyAnnotation(options.allInjectAnnotations) }
+    }
   if (annotatedConstructor != null) return annotatedConstructor
   return if (classLevel) constructors.firstOrNull { it.isPrimary } else null
 }
@@ -787,7 +812,10 @@ internal fun KaSession.injectConstructorDependencyKeys(
   return constructor
     ?.valueParameters
     .orEmpty()
-    .filterNot { it.hasAnyAnnotation(options.assistedAnnotations) }
+    .filterIndexed { index, parameter ->
+      checkCanceledEvery(index)
+      !parameter.hasAnyAnnotation(options.assistedAnnotations)
+    }
     .map { dependencyKey(it, options) }
 }
 
@@ -845,6 +873,7 @@ internal fun KaSession.injectConstructorDependencyKeys(
   }
 
   val substitutions = typeParameters.mapIndexedNotNull { index, parameter ->
+    checkCanceledEvery(index)
     val argument = classType.typeArguments.getOrNull(index)?.type ?: return@mapIndexedNotNull null
     parameter to argument
   }
@@ -854,7 +883,10 @@ internal fun KaSession.injectConstructorDependencyKeys(
 
   val substitutor = if (substitutions.isEmpty()) null else createSubstitutor(substitutions.toMap())
   return constructor.valueParameters
-    .filterNot { it.hasAnyAnnotation(options.assistedAnnotations) }
+    .filterIndexed { index, parameter ->
+      checkCanceledEvery(index)
+      !parameter.hasAnyAnnotation(options.assistedAnnotations)
+    }
     .map { parameter ->
       val dependencyType = substitutor?.substitute(parameter.returnType) ?: parameter.returnType
       onDependencyType?.invoke(dependencyType)
@@ -908,7 +940,8 @@ internal fun KaSession.memberInjectSites(
   val scope = classType.scope ?: return memberInjectSites(classSymbol, options)
   val ownerIds = owners.mapNotNullTo(linkedSetOf()) { it.classId }
   val result = mutableListOf<MemberInjectSite>()
-  for (signature in scope.getCallableSignatures()) {
+  for ((index, signature) in scope.getCallableSignatures().withIndex()) {
+    checkCanceledEvery(index)
     val view = callableBindingView(signature) ?: continue
     val symbol = view.symbol
     val ownerId = symbol.callableId?.classId ?: continue
@@ -932,7 +965,8 @@ internal fun KaSession.memberInjectSites(
       }
       is KaNamedFunctionSymbol -> {
         if (symbol.hasAnyAnnotation(options.allInjectAnnotations)) {
-          view.valueParameters.mapTo(result) { parameter ->
+          view.valueParameters.withIndex().mapTo(result) { (index, parameter) ->
+            checkCanceledEvery(index)
             onDependencyType?.invoke(parameter.returnType)
             MemberInjectSite(
               ownerId,
@@ -953,7 +987,8 @@ internal fun KaSession.memberInjectSites(
   options: MetroOptions,
 ): List<MemberInjectSite> {
   val result = mutableListOf<MemberInjectSite>()
-  for (owner in memberInjectOwners(classSymbol)) {
+  for ((index, owner) in memberInjectOwners(classSymbol).withIndex()) {
+    checkCanceledEvery(index)
     collectDeclaredMemberInjectKeys(owner, options, result)
   }
   return result
@@ -969,7 +1004,9 @@ internal fun KaSession.memberInjectOwners(
 ): List<KaNamedClassSymbol> {
   val result = mutableListOf<KaNamedClassSymbol>()
   var current: KaNamedClassSymbol? = classSymbol
+  var depth = 0
   while (current != null) {
+    checkCanceledEvery(depth++)
     result += current
     current =
       superClassSymbol(current)?.takeIf {
@@ -985,7 +1022,8 @@ private fun KaSession.collectDeclaredMemberInjectKeys(
   result: MutableList<MemberInjectSite>,
 ) {
   val injectIds = options.allInjectAnnotations
-  for (callable in classSymbol.declaredMemberScope.callables) {
+  for ((index, callable) in classSymbol.declaredMemberScope.callables.withIndex()) {
+    checkCanceledEvery(index)
     when (callable) {
       is KaPropertySymbol -> {
         // @Inject has no PROPERTY target. A bare annotation lands on the backing field.
@@ -1004,7 +1042,8 @@ private fun KaSession.collectDeclaredMemberInjectKeys(
       }
       is KaNamedFunctionSymbol ->
         if (callable.hasAnyAnnotation(injectIds)) {
-          callable.valueParameters.mapTo(result) { parameter ->
+          callable.valueParameters.withIndex().mapTo(result) { (index, parameter) ->
+            checkCanceledEvery(index)
             MemberInjectSite(
               classSymbol.classId,
               parameter.psi as? KtElement ?: callable.psi as? KtElement,
@@ -1018,7 +1057,8 @@ private fun KaSession.collectDeclaredMemberInjectKeys(
 }
 
 private fun KaSession.superClassSymbol(classSymbol: KaNamedClassSymbol): KaNamedClassSymbol? {
-  for (superType in classSymbol.superTypes) {
+  for ((index, superType) in classSymbol.superTypes.withIndex()) {
+    checkCanceledEvery(index)
     val symbol =
       (superType.fullyExpandedType as? KaClassType)?.symbol as? KaNamedClassSymbol ?: continue
     if (symbol.classKind == KaClassKind.CLASS) return symbol
@@ -1031,7 +1071,11 @@ internal fun classListArgument(annotation: KaAnnotation, name: String): List<Cla
   val argument =
     annotation.arguments.firstOrNull { it.name.asString() == name } ?: return emptyList()
   return when (val value = argument.expression) {
-    is KaAnnotationValue.ArrayValue -> value.values.mapNotNull { classLiteralClassId(it) }
+    is KaAnnotationValue.ArrayValue ->
+      value.values.mapIndexedNotNull { index, annotationValue ->
+        checkCanceledEvery(index)
+        classLiteralClassId(annotationValue)
+      }
     else -> listOfNotNull(classLiteralClassId(value))
   }
 }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/FilePresentationBundle.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/FilePresentationBundle.kt
@@ -1,0 +1,397 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea.index
+
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.psi.util.PsiTreeUtil
+import dev.zacsweers.metro.idea.model.AssistedSite
+import dev.zacsweers.metro.idea.model.BindingIndex
+import dev.zacsweers.metro.idea.model.BindingResolutionSession
+import dev.zacsweers.metro.idea.model.ConsumerEntry
+import dev.zacsweers.metro.idea.model.ConsumerResolution
+import dev.zacsweers.metro.idea.model.ContributionEntry
+import dev.zacsweers.metro.idea.model.GraphContext
+import dev.zacsweers.metro.idea.model.GraphPath
+import dev.zacsweers.metro.idea.model.IndexGenerationToken
+import dev.zacsweers.metro.idea.model.KaBinding
+import dev.zacsweers.metro.idea.model.KaGraphDeclaration
+import dev.zacsweers.metro.idea.model.matchingContextEntry
+import java.util.IdentityHashMap
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+
+internal data class FilePresentationKey(
+  val generationToken: IndexGenerationToken,
+  val file: VirtualFile,
+)
+
+/**
+ * Resolved editor data for one file and index generation.
+ *
+ * Source ranges can be refreshed after edits while the binding results stay unchanged. This lets
+ * manual refresh mode keep its graph data without attaching decorations to outdated offsets.
+ */
+internal class FilePresentationBundle
+private constructor(
+  val generationToken: IndexGenerationToken,
+  val file: VirtualFile,
+  private val semantics: FilePresentationSemantics,
+  private val anchorInputs: List<DeclarationAnchorInput>,
+  private val anchors: DeclarationAnchorMap,
+) {
+  internal constructor(
+    generationToken: IndexGenerationToken,
+    file: VirtualFile,
+    declarations: Map<BindingIndex.SourcePointerIdentity, FileDeclarationPresentation>,
+    anchorInputs: List<DeclarationAnchorInput>,
+    index: BindingIndex,
+  ) : this(
+    generationToken,
+    file,
+    FilePresentationSemantics(declarations, index),
+    anchorInputs.toList(),
+    DeclarationAnchorMap.EMPTY,
+  )
+
+  /** Ignores outdated offsets until a background anchor rebuild catches up with the file. */
+  fun declaration(element: KtElement): FileDeclarationPresentation? {
+    val elementFile = element.containingFile as? KtFile ?: return null
+    if (elementFile.virtualFile != file) return null
+    if (!anchorsAreCurrent(elementFile.modificationStamp)) return null
+    val range = element.textRange
+    val identity = BindingIndex.SourcePointerIdentity(file, range.startOffset, range.endOffset)
+    return anchors.byCurrentSourceIdentity[identity]
+  }
+
+  internal fun anchorsAreCurrent(modificationStamp: Long): Boolean {
+    return anchors.modificationStamp == modificationStamp
+  }
+
+  /** Checks whether an anchor rebuild preserved the original binding results. */
+  internal fun sharesSemanticData(other: FilePresentationBundle): Boolean {
+    return semantics === other.semantics
+  }
+
+  /**
+   * Updates source ranges from smart pointers under the caller's read action. Declarations whose
+   * recorded identity no longer matches and ambiguous pointer matches are omitted.
+   */
+  internal fun rebuildAnchors(ktFile: KtFile): FilePresentationBundle {
+    if (ktFile.virtualFile != file) return this
+    val modificationStamp = ktFile.modificationStamp
+    if (anchorsAreCurrent(modificationStamp)) return this
+
+    val resolved = mutableListOf<ResolvedDeclarationAnchor>()
+    for (input in anchorInputs) {
+      ProgressManager.checkCanceled()
+      val element = input.pointer.element as? KtElement ?: continue
+      if (!element.isValid || element.containingFile !== ktFile) continue
+      val signature = DeclarationAnchorSignature.capture(element)
+      if (signature != input.signature) continue
+      val presentation = semantics.declarations[input.sourceIdentity] ?: continue
+      val range = element.textRange
+      val currentIdentity =
+        BindingIndex.SourcePointerIdentity(file, range.startOffset, range.endOffset)
+      resolved +=
+        ResolvedDeclarationAnchor(
+          currentIdentity,
+          presentation,
+        )
+    }
+
+    val currentDeclarations =
+      linkedMapOf<BindingIndex.SourcePointerIdentity, FileDeclarationPresentation>()
+    for ((identity, candidates) in resolved.groupBy(ResolvedDeclarationAnchor::currentIdentity)) {
+      ProgressManager.checkCanceled()
+      val candidate = candidates.singleOrNull() ?: continue
+      currentDeclarations[identity] = candidate.presentation
+    }
+    return FilePresentationBundle(
+      generationToken,
+      file,
+      semantics,
+      anchorInputs,
+      DeclarationAnchorMap(modificationStamp, currentDeclarations.toMap()),
+    )
+  }
+
+  fun distinctBindingDeclarations(entries: Iterable<KaBinding>): List<KaBinding> {
+    return semantics.index.distinctBindingDeclarations(entries.toList())
+  }
+
+  /** Includes contextual dependencies so generic aliases with different targets remain distinct. */
+  fun bindingResolutionIdentities(entries: Iterable<KaBinding>): Set<Any> {
+    return semantics.index.bindingResolutionIdentities(entries.toList())
+  }
+}
+
+/** Binding results reused when edits move declarations. */
+private class FilePresentationSemantics(
+  declarations: Map<BindingIndex.SourcePointerIdentity, FileDeclarationPresentation>,
+  val index: BindingIndex,
+) {
+  val declarations = declarations.toMap()
+}
+
+/** Current source ranges for one file modification stamp. */
+private class DeclarationAnchorMap(
+  val modificationStamp: Long,
+  val byCurrentSourceIdentity: Map<BindingIndex.SourcePointerIdentity, FileDeclarationPresentation>,
+) {
+  companion object {
+    val EMPTY = DeclarationAnchorMap(Long.MIN_VALUE, emptyMap())
+  }
+}
+
+/** Pointer and declaration details captured when the index generation was built. */
+internal data class DeclarationAnchorInput(
+  val sourceIdentity: BindingIndex.SourcePointerIdentity,
+  val pointer: SmartPsiElementPointer<out PsiElement>,
+  val signature: DeclarationAnchorSignature,
+)
+
+/** Rejects pointer matches whose declaration kind, name, or enclosing declarations changed. */
+internal data class DeclarationAnchorSignature(
+  val elementClassName: String,
+  val role: String?,
+  val ownerChain: List<NamedDeclarationAnchorIdentity>,
+) {
+  companion object {
+    fun capture(element: KtElement): DeclarationAnchorSignature {
+      val role =
+        when (element) {
+          is KtPropertyAccessor -> if (element.isGetter) "getter" else "setter"
+          else -> null
+        }
+      val declaration =
+        when (element) {
+          is KtConstructor<*> -> element.getContainingClassOrObject()
+          is KtPropertyAccessor -> element.property
+          is KtNamedDeclaration -> element
+          else -> PsiTreeUtil.getParentOfType(element, KtNamedDeclaration::class.java, false)
+        }
+      val ownerChain = mutableListOf<NamedDeclarationAnchorIdentity>()
+      var current = declaration
+      while (current != null) {
+        ownerChain += NamedDeclarationAnchorIdentity(current.javaClass.name, current.name)
+        current = PsiTreeUtil.getParentOfType(current, KtNamedDeclaration::class.java, true)
+      }
+      ownerChain.reverse()
+      return DeclarationAnchorSignature(element.javaClass.name, role, ownerChain)
+    }
+  }
+}
+
+/** A declaration's kind and name in the path used to validate anchors. */
+internal data class NamedDeclarationAnchorIdentity(
+  val elementClassName: String,
+  val name: String?,
+)
+
+/** A pointer match accepted for the current file version. */
+private class ResolvedDeclarationAnchor(
+  val currentIdentity: BindingIndex.SourcePointerIdentity,
+  val presentation: FileDeclarationPresentation,
+)
+
+internal class FileDeclarationPresentation(
+  val sourceIdentity: BindingIndex.SourcePointerIdentity,
+  val bindingEntries: List<KaBinding>,
+  val reverseUsage: ReverseUsagePresentation?,
+  val consumerEntries: List<ConsumerEntry>,
+  val consumerResolutions: Map<ConsumerEntry, ConsumerResolution>,
+  val inlayConsumer: ConsumerEntry?,
+  val graph: GraphPresentation?,
+  val assistedSite: AssistedSite?,
+)
+
+/** Filters resolved consumers when the user pins a graph, preserving their original order. */
+internal class ReverseUsagePresentation(candidates: List<ReverseUsageCandidate>) {
+  private val candidates = candidates.toList()
+
+  fun consumersFor(path: GraphPath?): List<ConsumerEntry> {
+    if (path == null) return candidates.map(ReverseUsageCandidate::consumer)
+    return candidates.mapNotNull { candidate ->
+      val resolves = candidate.resolvesByContext.matchingContextEntry(path)?.value ?: true
+      candidate.consumer.takeIf { resolves }
+    }
+  }
+}
+
+/** A false answer keeps this consumer excluded when that graph context is pinned. */
+internal class ReverseUsageCandidate(
+  val consumer: ConsumerEntry,
+  resolvesByContext: Map<GraphContext, Boolean>,
+) {
+  val resolvesByContext = resolvesByContext.toMap()
+}
+
+internal class GraphPresentation(
+  val graph: KaGraphDeclaration,
+  val contexts: List<GraphContextPresentation>,
+)
+
+internal class GraphContextPresentation(
+  val context: GraphContext,
+  val contributions: List<ContributionEntry>,
+  val inheritedContributions: List<ContributionEntry>,
+)
+
+/** Resolves a file's editor features with one session so they reuse graph queries. */
+internal class FilePresentationBundleBuilder(
+  private val index: BindingIndex,
+  private val session: BindingResolutionSession,
+  private val file: VirtualFile,
+  private val declarationAnchorSignatures:
+    Map<BindingIndex.SourcePointerIdentity, DeclarationAnchorSignature>,
+) {
+  private val declarations = linkedMapOf<BindingIndex.SourcePointerIdentity, MutableDeclaration>()
+  private val resolutions = IdentityHashMap<ConsumerEntry, ConsumerResolution>()
+
+  fun build(): FilePresentationBundle {
+    for (binding in index.bindingEntriesInFile(file)) {
+      ProgressManager.checkCanceled()
+      val sourceIdentity = index.sourceIdentityFor(binding) ?: continue
+      declaration(sourceIdentity, binding.pointer).bindings += binding
+    }
+    for (consumer in index.consumerEntriesInFile(file)) {
+      ProgressManager.checkCanceled()
+      val sourceIdentity = consumer.sourceIdentity ?: continue
+      declaration(sourceIdentity, consumer.pointer).consumers += consumer
+    }
+    for (graph in index.graphEntriesInFile(file)) {
+      ProgressManager.checkCanceled()
+      val sourceIdentity = graph.sourceIdentity ?: continue
+      declaration(sourceIdentity, graph.pointer).graph = graph
+    }
+    for (site in index.assistedSitesInFile(file)) {
+      ProgressManager.checkCanceled()
+      val sourceIdentity = site.sourceIdentity ?: continue
+      declaration(sourceIdentity, site.pointer).assistedSite = site
+    }
+
+    val frozen = linkedMapOf<BindingIndex.SourcePointerIdentity, FileDeclarationPresentation>()
+    val anchorInputs = mutableListOf<DeclarationAnchorInput>()
+    for ((sourceIdentity, declaration) in declarations) {
+      ProgressManager.checkCanceled()
+      val consumerResolutions =
+        declaration.consumers.associateWithTo(linkedMapOf()) { consumer -> resolution(consumer) }
+      val bindingEntries = declaration.bindings.toList()
+      val reverseUsage = bindingEntries.takeIf { it.isNotEmpty() }?.let(::reverseUsage)
+      val graphPresentation = declaration.graph?.let(::graphPresentation)
+      frozen[sourceIdentity] =
+        FileDeclarationPresentation(
+          sourceIdentity = sourceIdentity,
+          bindingEntries = bindingEntries,
+          reverseUsage = reverseUsage,
+          consumerEntries = declaration.consumers.toList(),
+          consumerResolutions = consumerResolutions.toMap(),
+          inlayConsumer = inlayConsumer(declaration.consumers, consumerResolutions),
+          graph = graphPresentation,
+          assistedSite = declaration.assistedSite,
+        )
+      declarationAnchorSignatures[sourceIdentity]?.let { signature ->
+        anchorInputs += DeclarationAnchorInput(sourceIdentity, declaration.anchor, signature)
+      }
+    }
+    ProgressManager.checkCanceled()
+    return FilePresentationBundle(
+      generationToken = index.generationToken,
+      file = file,
+      declarations = frozen,
+      anchorInputs = anchorInputs,
+      index = index,
+    )
+  }
+
+  private fun declaration(
+    sourceIdentity: BindingIndex.SourcePointerIdentity,
+    pointer: SmartPsiElementPointer<out PsiElement>,
+  ): MutableDeclaration {
+    return declarations.getOrPut(sourceIdentity) { MutableDeclaration(pointer) }
+  }
+
+  private fun resolution(consumer: ConsumerEntry): ConsumerResolution {
+    resolutions[consumer]?.let {
+      return it
+    }
+    val resolved = session.resolveConsumer(consumer)
+    val frozenPerContext =
+      resolved.perContext.entries.associateTo(linkedMapOf()) { (context, bindings) ->
+        context to bindings.toList()
+      }
+    val frozen =
+      ConsumerResolution(
+        global = resolved.global.toList(),
+        perContext = frozenPerContext,
+        hasGraphs = index.graphs.isNotEmpty(),
+        index = index,
+      )
+    resolutions[consumer] = frozen
+    return frozen
+  }
+
+  private fun reverseUsage(bindingEntries: List<KaBinding>): ReverseUsagePresentation {
+    val bindingSet = bindingEntries.toSet()
+    val candidates =
+      session.consumersFor(bindingEntries).map { consumer ->
+        ProgressManager.checkCanceled()
+        val resolvesByContext =
+          resolution(consumer).perContext.mapValues { (_, bindings) ->
+            bindings.any(bindingSet::contains)
+          }
+        ReverseUsageCandidate(consumer, resolvesByContext)
+      }
+    return ReverseUsagePresentation(candidates)
+  }
+
+  private fun graphPresentation(graph: KaGraphDeclaration): GraphPresentation {
+    val contexts =
+      session.contextsFor(graph).mapNotNull { context ->
+        ProgressManager.checkCanceled()
+        val queryContext = session.queryContext(context) ?: return@mapNotNull null
+        GraphContextPresentation(
+          context = context,
+          contributions = session.contributionsFor(queryContext).toList(),
+          inheritedContributions = session.inheritedContributionsFor(queryContext).toList(),
+        )
+      }
+    return GraphPresentation(graph, contexts)
+  }
+
+  private fun inlayConsumer(
+    consumers: List<ConsumerEntry>,
+    consumerResolutions: Map<ConsumerEntry, ConsumerResolution>,
+  ): ConsumerEntry? {
+    if (consumers.size == 1) return consumers.single()
+    if (consumers.none { it.graphRequestKind == null }) return consumers.firstOrNull()
+    val first = consumers.firstOrNull() ?: return null
+    val firstBindings = consumerResolutions.getValue(first).uniformBindings ?: return null
+    val firstResolution = bindingResolutionIdentities(firstBindings)
+    for (entryIndex in 1 until consumers.size) {
+      val entry = consumers[entryIndex]
+      if (entry.contextKey != first.contextKey) return null
+      val bindings = consumerResolutions.getValue(entry).uniformBindings ?: return null
+      if (bindingResolutionIdentities(bindings) != firstResolution) return null
+    }
+    return first
+  }
+
+  private fun bindingResolutionIdentities(entries: Iterable<KaBinding>): Set<Any> {
+    return index.bindingResolutionIdentities(entries.toList())
+  }
+
+  private class MutableDeclaration(
+    val anchor: SmartPsiElementPointer<out PsiElement>,
+    val bindings: MutableList<KaBinding> = mutableListOf(),
+    val consumers: MutableList<ConsumerEntry> = mutableListOf(),
+    var graph: KaGraphDeclaration? = null,
+    var assistedSite: AssistedSite? = null,
+  )
+}

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/FileShardBuilder.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/FileShardBuilder.kt
@@ -14,6 +14,7 @@ import dev.zacsweers.metro.compiler.circuit.CircuitClassIds
 import dev.zacsweers.metro.compiler.flatMapToSet
 import dev.zacsweers.metro.compiler.graph.computeMultibindingId
 import dev.zacsweers.metro.idea.annotationScopeKeys
+import dev.zacsweers.metro.idea.checkCanceledEvery
 import dev.zacsweers.metro.idea.hasAnyAnnotation
 import dev.zacsweers.metro.idea.implicitSingleInAnnotation
 import dev.zacsweers.metro.idea.model.AssistedSite
@@ -52,6 +53,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
 import org.jetbrains.kotlin.analysis.api.symbols.KaValueParameterSymbol
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -69,6 +71,7 @@ import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtTypeAlias
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
@@ -101,6 +104,12 @@ internal class FileShardBuilder(
   private val processedFactoryInputs = HashSet<FactoryInputEntry.Id>()
   private val processedDynamicGraphs = HashSet<DynamicGraphId>()
   private val cacheDependencies = HashSet<PsiFile>()
+  private val sharedDeclarationDependencies = HashSet<PsiFile>()
+  private var cancellationWorkIndex = 0
+
+  private fun checkCanceled() {
+    checkCanceledEvery(cancellationWorkIndex++)
+  }
 
   /**
    * The PSI files backing [FileShard.dependencyFiles], for the caller's CachedValue registration.
@@ -114,6 +123,7 @@ internal class FileShardBuilder(
     // the original short-name-only path without seven repeated PSI import walks.
     val aliasedImports = mutableMapOf<FqName, MutableSet<String>>()
     for (directive in file.importDirectives) {
+      checkCanceled()
       val alias = directive.aliasName ?: continue
       val importedName = directive.importedFqName ?: continue
       aliasedImports.getOrPut(importedName, ::mutableSetOf) += alias
@@ -151,10 +161,11 @@ internal class FileShardBuilder(
       }
     }
 
-    for (entry in PsiTreeUtil.collectElementsOfType(file, KtAnnotationEntry::class.java)) {
-      ProgressManager.checkCanceled()
-      val shortName = entry.shortName?.asString() ?: continue
-      val declaration = entry.getStrictParentOfType<KtDeclaration>() ?: continue
+    PsiTreeUtil.processElements(file) { element ->
+      checkCanceled()
+      val entry = element as? KtAnnotationEntry ?: return@processElements true
+      val shortName = entry.shortName?.asString() ?: return@processElements true
+      val declaration = entry.getStrictParentOfType<KtDeclaration>() ?: return@processElements true
       if (shortName in bindingCallableNames) processBindingCallable(declaration)
       if (shortName in injectNames) processInjectAnnotated(declaration)
       if (shortName in contributesNames) processContribution(declaration)
@@ -164,11 +175,14 @@ internal class FileShardBuilder(
       if (options.enableCircuitCodegen && shortName in circuitNames) {
         processCircuitInject(declaration)
       }
+      true
     }
-    for (call in PsiTreeUtil.collectElementsOfType(file, KtCallExpression::class.java)) {
-      ProgressManager.checkCanceled()
-      val name = call.calleeExpression?.text ?: continue
+    PsiTreeUtil.processElements(file) { element ->
+      checkCanceled()
+      val call = element as? KtCallExpression ?: return@processElements true
+      val name = call.calleeExpression?.text ?: return@processElements true
       if (name in dynamicGraphNames) processDynamicGraphCall(call)
+      true
     }
     return FileShard(
       bindings,
@@ -180,6 +194,7 @@ internal class FileShardBuilder(
       factoryInputs,
       dynamicGraphs,
       cacheDependencies.mapNotNullTo(mutableSetOf()) { it.virtualFile },
+      sharedDeclarationDependencies.mapNotNullTo(mutableSetOf()) { it.virtualFile },
       graphInterfaces,
     )
   }
@@ -213,6 +228,7 @@ internal class FileShardBuilder(
       val containerKeys = linkedSetOf<KaTypeKey>()
       val inputs = mutableListOf<FactoryInputEntry>()
       for (argument in call.valueArguments) {
+        checkCanceled()
         val expression = argument.getArgumentExpression() ?: continue
         val containerType = expression.expressionType?.fullyExpandedType as? KaClassType ?: continue
         val containerClass = containerType.symbol as? KaNamedClassSymbol ?: continue
@@ -235,6 +251,7 @@ internal class FileShardBuilder(
       val id = DynamicGraphId(requestedType.classId, containerKeys.toSet(), callerFile)
       if (!processedDynamicGraphs.add(id)) return@analyze
       for (input in inputs) {
+        checkCanceled()
         val inputBinding = input.bindings.firstOrNull()
         if (inputBinding is KaBinding.BoundInstance) {
           bindings += inputBinding
@@ -299,6 +316,7 @@ internal class FileShardBuilder(
           val consumerContributionScopes = dataEntries.flatMapToSet { it.contributionScopes }
           val ownerDependency = graphOwnerDependency(target)
           for (data in dataEntries) {
+            checkCanceled()
             bindings +=
               data.toKaBinding(
                 ptr(target),
@@ -324,6 +342,7 @@ internal class FileShardBuilder(
           // Provider function parameters are consumers themselves.
           if (target is KtNamedFunction && !target.isAnnotatedWithAny(options.bindsAnnotations)) {
             for (parameter in target.valueParameters) {
+              checkCanceled()
               addParameterConsumer(
                 parameter,
                 originClassId = consumerOriginClassId,
@@ -399,6 +418,7 @@ internal class FileShardBuilder(
           } else {
             // Member injection site: parameters are consumers
             for (parameter in declaration.valueParameters) {
+              checkCanceled()
               addParameterConsumer(
                 parameter,
                 memberOwnerClassId = declaration.containingClassOrObject?.getClassId(),
@@ -425,6 +445,7 @@ internal class FileShardBuilder(
     val typeKey = KaTypeKey(KaTypeSnapshot(classId.asSingleFqName().asString(), name, classId))
     val dependencies =
       symbol.valueParameters
+        .onEach { checkCanceled() }
         .filterNot { it.hasAnyAnnotation(options.assistedAnnotations) }
         .map { dependencyKey(it, options) }
     bindings +=
@@ -437,6 +458,7 @@ internal class FileShardBuilder(
         constructorDependencies = dependencies,
       )
     for (parameter in function.valueParameters) {
+      checkCanceled()
       addParameterConsumer(parameter, originClassId = classId)
     }
   }
@@ -451,12 +473,14 @@ internal class FileShardBuilder(
       val dataEntries = ktClass.bindingData(this, options)
       val consumerContributionScopes = dataEntries.flatMapToSet { it.contributionScopes }
       for (data in dataEntries) {
+        checkCanceled()
         bindings += data.toKaBinding(ptr(ktClass))
       }
       // Gate constructor consumers on the owning class's binding only when it originates one.
       val originClassId = ktClass.getClassId().takeIf { dataEntries.isNotEmpty() }
       val injectConstructor = findInjectConstructor(ktClass, classSymbol, options)
       for (parameter in injectConstructor?.valueParameters.orEmpty()) {
+        checkCanceled()
         addParameterConsumer(
           parameter,
           originClassId = originClassId,
@@ -539,6 +563,7 @@ internal class FileShardBuilder(
         factoryContext = classType,
       )
     for (type in sequenceOf(classType) + classType.allSupertypes) {
+      checkCanceled()
       if (type.isAnyType) continue
       val superType = type as? KaClassType ?: continue
       if (!typeKeys.add(typeKey(superType, null))) continue
@@ -596,6 +621,7 @@ internal class FileShardBuilder(
         )
 
       for (member in ktClass.declarations) {
+        checkCanceled()
         when (member) {
           is KtClassOrObject -> {
             val memberClassId = member.getClassId() ?: continue
@@ -608,6 +634,7 @@ internal class FileShardBuilder(
             includedBindingContainers += graphInputs.bindingContainers
             includedDependencies += graphInputs.graphDependencies
             for (input in graphInputs.inputs) {
+              checkCanceled()
               val inputBinding = input.bindings.firstOrNull()
               if (inputBinding is KaBinding.BoundInstance) {
                 bindings += inputBinding
@@ -641,6 +668,7 @@ internal class FileShardBuilder(
           if (type == null) emptySequence() else sequenceOf(type) + type.allSupertypes
         }
       for (superType in writtenSupertypes) {
+        checkCanceled()
         if (superType.isAnyType) continue
         val classType = superType as? KaClassType ?: continue
         val superClass = classType.symbol as? KaNamedClassSymbol ?: continue
@@ -700,6 +728,7 @@ internal class FileShardBuilder(
         options.multibindsAnnotations +
         bindsOptionalOfAnnotations(options)
     for (signature in scope.getCallableSignatures()) {
+      checkCanceled()
       val view = callableBindingView(signature) ?: continue
       val callable = view.symbol
       if (callable.callableId?.classId != superClass.classId) continue
@@ -738,6 +767,7 @@ internal class FileShardBuilder(
     val overriddenDeclarations = mutableListOf<GraphCallableReference>()
     val seenDeclarations = HashSet<KtElement>()
     for (overridden in callable.allOverriddenSymbols) {
+      checkCanceled()
       val original = overridden.fakeOverrideOriginal
       val declaration = original.psi as? KtElement ?: continue
       if (!seenDeclarations.add(declaration)) continue
@@ -878,7 +908,9 @@ internal class FileShardBuilder(
     if (ownerType != null) roots += ownerType
     val seen = hashSetOf<KaTypeKey>()
     for (root in roots) {
+      checkCanceled()
       for (type in sequenceOf(root) + root.allSupertypes) {
+        checkCanceled()
         val factoryType = type as? KaClassType ?: continue
         if (!seen.add(typeKey(factoryType, null))) continue
         if (!factoryType.symbol.hasAnyAnnotation(options.graphExtensionFactoryAnnotations)) continue
@@ -919,6 +951,7 @@ internal class FileShardBuilder(
         ?: (declaration as? KtCallableDeclaration)?.containingClassOrObject?.containerClassId()
     var addedBinding = false
     for (data in callable.bindingData(this, options)) {
+      checkCanceled()
       val templates = target.bindingTemplates
       if (templates != null) {
         templates += GraphInterfaceBinding(ptr(declaration), data)
@@ -941,6 +974,7 @@ internal class FileShardBuilder(
     }
     if (!addedBinding) return
     for (parameter in callable.valueParameters) {
+      checkCanceled()
       val source = parameter.symbol.psi as? KtElement ?: continue
       addConsumer(
         source,
@@ -1016,14 +1050,16 @@ internal class FileShardBuilder(
     val targetType = targetParameterType.fullyExpandedType as? KaClassType ?: return
     val targetSymbol = targetType.symbol as? KaNamedClassSymbol ?: return
     for (owner in memberInjectOwners(targetSymbol)) {
+      checkCanceled()
       owner.classId?.let(injectedMemberOwnerIds::add)
       owner.psi?.containingFile?.let(cacheDependencies::add)
     }
     for (site in
       memberInjectSites(targetType, options) { dependencyType ->
-        ProgressManager.checkCanceled()
+        checkCanceled()
         processRequestedAssistedFactory(dependencyType)
       }) {
+      checkCanceled()
       val contextKey = site.key
       targetConsumers +=
         ConsumerEntry(
@@ -1056,6 +1092,7 @@ internal class FileShardBuilder(
   private fun KaSession.processRequestedAssistedFactory(type: KaType) {
     var factoryType = type.fullyExpandedType as? KaClassType ?: return
     while (true) {
+      checkCanceled()
       val classId = factoryType.classId
       val isWrapper =
         classId in options.providerTypes ||
@@ -1152,12 +1189,14 @@ internal class FileShardBuilder(
           // parameters.
           val dependencies =
             symbol.valueParameters
+              .onEach { checkCanceled() }
               .filterNot { it.hasAnyAnnotation(options.assistedAnnotations) }
               .filterNot { isCircuitProvidedType(it.returnType) }
               .map { dependencyKey(it, options) }
           addCircuitContribution(declaration, scopes, factoryClassId, dependencies)
 
           for (parameter in declaration.valueParameters) {
+            checkCanceled()
             addCircuitParameterConsumer(parameter, contributionScopes = scopes)
           }
         }
@@ -1170,7 +1209,9 @@ internal class FileShardBuilder(
             classSymbol.annotations.firstOrNull { it.classId == CircuitClassIds.CircuitInject }
               ?: return@analyze
           val supertypeIds =
-            classSymbol.defaultType.allSupertypes.mapNotNull { (it as? KaClassType)?.classId }
+            classSymbol.defaultType.allSupertypes
+              .onEach { checkCanceled() }
+              .mapNotNull { (it as? KaClassType)?.classId }
           val factoryClassId =
             when {
               CircuitClassIds.Ui in supertypeIds -> CircuitClassIds.UiFactory
@@ -1184,6 +1225,7 @@ internal class FileShardBuilder(
             findInjectConstructorSymbol(classSymbol, options)
               ?.valueParameters
               .orEmpty()
+              .onEach { checkCanceled() }
               .filterNot { it.hasAnyAnnotation(options.assistedAnnotations) }
               .filterNot { isCircuitProvidedType(it.returnType) }
               .map { dependencyKey(it, options) }
@@ -1315,8 +1357,28 @@ internal class FileShardBuilder(
     val metadataAnnotations =
       options.qualifierAnnotations + options.scopeAnnotations + options.mapKeyAnnotations
     for (annotation in annotated.annotations) {
+      checkCanceled()
       val annotationClassId = annotation.classId ?: continue
       val annotationClass = findClass(annotationClassId) ?: continue
+
+      // Track constants and type aliases in annotation arguments so their edits rebuild this shard.
+      val argumentList = (annotation.psi as? KtAnnotationEntry)?.valueArgumentList
+      if (argumentList != null) {
+        PsiTreeUtil.processElements(argumentList) { element ->
+          ProgressManager.checkCanceled()
+          for (reference in element.references) {
+            val referenced = reference.resolve()
+            val isSharedDeclaration =
+              referenced is KtTypeAlias ||
+                (referenced is KtProperty && referenced.hasModifier(KtTokens.CONST_KEYWORD))
+            if (!isSharedDeclaration) continue
+            val referencedFile = referenced.containingFile ?: continue
+            if (referencedFile !== useSiteFile) sharedDeclarationDependencies += referencedFile
+          }
+          true
+        }
+      }
+
       if (annotationClass.annotations.none { it.classId in metadataAnnotations }) continue
       val declarationFile = annotationClass.psi?.containingFile ?: continue
       if (declarationFile !== useSiteFile) cacheDependencies += declarationFile

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/IndexModels.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/IndexModels.kt
@@ -166,6 +166,10 @@ internal class FileShard(
   val dynamicGraphs: List<DynamicGraphCall>,
   /** Referenced declaration files whose changes require this shard to be rebuilt. */
   val dependencyFiles: Set<VirtualFile>,
+  /**
+   * Files containing referenced constants or type aliases. Fingerprint changes rebuild this shard.
+   */
+  val sharedDeclarationFiles: Set<VirtualFile>,
   val graphInterfaces: List<GraphInterfaceSurface> = emptyList(),
 ) {
   companion object {
@@ -179,6 +183,7 @@ internal class FileShard(
         emptyList(),
         emptyList(),
         emptyList(),
+        emptySet(),
         emptySet(),
       )
   }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/LibraryIndexPostProcessor.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/LibraryIndexPostProcessor.kt
@@ -17,6 +17,7 @@ import dev.zacsweers.metro.idea.annotationScopeKeys
 import dev.zacsweers.metro.idea.classLiteralClassId
 import dev.zacsweers.metro.idea.hasAnyAnnotation
 import dev.zacsweers.metro.idea.model.BindingIndex
+import dev.zacsweers.metro.idea.model.BindingResolutionSession
 import dev.zacsweers.metro.idea.model.ConsumerEntry
 import dev.zacsweers.metro.idea.model.ContributionEntry
 import dev.zacsweers.metro.idea.model.DeclarationResolutionScope
@@ -31,7 +32,6 @@ import dev.zacsweers.metro.idea.qualifierAnnotation
 import dev.zacsweers.metro.idea.scopeAnnotation
 import java.util.Collections
 import java.util.IdentityHashMap
-import java.util.concurrent.ConcurrentHashMap
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.KaPlatformInterface
 import org.jetbrains.kotlin.analysis.api.analyze
@@ -63,7 +63,7 @@ internal class LibraryIndexPostProcessor(
   private val graphs: List<KaGraphDeclaration>,
   private val contributions: MutableList<ContributionEntry>,
   private val sourceFactoryUseSites: SourceAssistedFactoryUseSites,
-  private val consumerGraphContexts: ConsumerGraphContexts,
+  private val consumerOwnership: ConsumerOwnershipBundle,
   private val initialSourceFactories: SourceFactoryResolution,
 ) {
   private val pointerManager = SmartPointerManager.getInstance(project)
@@ -78,7 +78,7 @@ internal class LibraryIndexPostProcessor(
         project,
         bindings,
         consumers,
-        consumerGraphContexts,
+        consumerOwnership,
         initialSourceFactories,
       )
     val resumed = sourceFactories.resumeBoundaries()
@@ -353,9 +353,9 @@ internal class LibraryIndexPostProcessor(
       if (consumer.multibindingId != null) {
         continue
       }
-      val containerOwners = consumerGraphContexts.owningGraphPointers(consumer)
+      val containerOwners = consumerOwnership.owningGraphPointers(consumer)
       if (containerOwners == null) {
-        val context = consumerGraphContexts.pointer(consumer).element ?: continue
+        val context = consumerOwnership.pointer(consumer).element ?: continue
         queue += LibraryInjectRequest(consumer.key, classId, context, direct = true)
       } else {
         for (owner in containerOwners) {
@@ -592,49 +592,134 @@ internal fun sourceAssistedFactoryUseSites(
   project: Project,
   bindings: List<KaBinding>,
   consumers: List<ConsumerEntry>,
-  graphs: List<KaGraphDeclaration>,
-  graphContexts: ConsumerGraphContexts = ConsumerGraphContexts(graphs),
+  consumerOwnership: ConsumerOwnershipBundle,
 ): SourceAssistedFactoryUseSites {
-  return SourceAssistedFactoryPostProcessor(project, bindings, consumers, graphContexts)
+  return SourceAssistedFactoryPostProcessor(project, bindings, consumers, consumerOwnership)
     .resolveInitial()
     .factoryUseSites
 }
 
-/** Inherited callables resolve from their exact owning graph, not the upstream declaration file. */
+/** Graph owners captured once for dependency resolution in the owning modules. */
 @OptIn(KaPlatformInterface::class)
-internal class ConsumerGraphContexts(private val index: BindingIndex) {
-  constructor(
-    graphs: List<KaGraphDeclaration>
-  ) : this(BindingIndex(emptyList(), emptyList(), graphs, emptyList()))
+internal class ConsumerOwnershipBundle
+private constructor(
+  private val pointersByGraphId: Map<GraphDeclarationId, SmartPsiElementPointer<out KtElement>>,
+  private val pointersByIncludedContainer:
+    Map<KaTypeKey, List<SmartPsiElementPointer<out KtElement>>>,
+  private val graphOwnersByConsumer: Map<ConsumerEntry, FrozenConsumerOwners>,
+) {
+  private constructor(
+    state: ConsumerOwnershipState
+  ) : this(
+    state.pointersByGraphId,
+    state.pointersByIncludedContainer,
+    state.graphOwnersByConsumer,
+  )
 
-  private val graphs = index.graphs
-  private val queryContextsByGraphId =
-    ConcurrentHashMap<GraphDeclarationId, List<GraphQueryContext>>()
-  private val graphsById: Map<GraphDeclarationId, KaGraphDeclaration> by lazy {
-    graphs.associateBy { it.declarationId }
+  fun pointer(consumer: ConsumerEntry): SmartPsiElementPointer<out KtElement> {
+    val graphId = consumer.graphId ?: return consumer.pointer
+    return pointersByGraphId[graphId] ?: consumer.pointer
   }
-  private val rootPointersByGraphId:
-    Map<GraphDeclarationId, List<SmartPsiElementPointer<out KtElement>>> by lazy {
-    if (graphs.none { it.isExtension }) {
-      emptyMap()
-    } else {
-      // Graph paths already encode exact same-FQN parent identities. Reuse that implementation
-      // rather than maintaining a second ancestry walk for source/classpath resolution.
-      buildMap {
-        for (graph in graphs) {
-          if (!graph.isExtension) continue
-          val roots = index.contextsFor(graph).map { it.rootGraph.pointer }.distinct()
-          if (roots.isNotEmpty()) put(graph.declarationId, roots)
-        }
+
+  /** Returns the graph roots used to resolve an included container, with one entry per module. */
+  fun includedContainerPointers(
+    consumer: ConsumerEntry
+  ): List<SmartPsiElementPointer<out KtElement>>? {
+    if (consumer.graphId != null) return null
+    val containerKey = consumer.includedContainerKey ?: return null
+    return pointersByIncludedContainer[containerKey]
+  }
+
+  /**
+   * Returns graph contexts for resolving [consumer], or null to use [pointer]. An empty list means
+   * the consumer has no active graph owner.
+   */
+  fun owningGraphPointers(consumer: ConsumerEntry): List<SmartPsiElementPointer<out KtElement>>? {
+    val graphId = consumer.graphId
+    if (graphId != null) {
+      if (graphId !in pointersByGraphId) return emptyList()
+      return when (val owners = graphOwnersByConsumer[consumer]) {
+        null -> null
+        FrozenConsumerOwners.None -> emptyList()
+        is FrozenConsumerOwners.GraphRoots -> owners.pointers
+      }
+    }
+    return includedContainerPointers(consumer)
+  }
+
+  companion object {
+    fun build(index: BindingIndex): ConsumerOwnershipBundle {
+      return ConsumerOwnershipBundle(buildState(index))
+    }
+
+    private fun buildState(index: BindingIndex): ConsumerOwnershipState {
+      return index.withResolutionSession { session ->
+        ConsumerOwnershipBuilder(index, session).build()
       }
     }
   }
-  private val pointersByGraphId:
-    Map<GraphDeclarationId, SmartPsiElementPointer<out KtElement>> by lazy {
-    graphs.associate { it.declarationId to it.pointer }
+}
+
+@OptIn(KaPlatformInterface::class)
+private class ConsumerOwnershipBuilder(
+  private val index: BindingIndex,
+  private val session: BindingResolutionSession,
+) {
+  private val graphs = index.graphs
+  private val graphsById = graphs.associateBy { it.declarationId }
+  private val pointersByGraphId = graphs.associate { it.declarationId to it.pointer }
+
+  fun build(): ConsumerOwnershipState {
+    val rootPointersByGraphId = buildRootPointersByGraphId()
+    val pointersByIncludedContainer = buildIncludedContainerPointers(rootPointersByGraphId)
+    val graphOwnersByConsumer = linkedMapOf<ConsumerEntry, FrozenConsumerOwners>()
+    val consumersByGraphId = linkedMapOf<GraphDeclarationId, MutableList<ConsumerEntry>>()
+    for (consumer in index.consumers) {
+      ProgressManager.checkCanceled()
+      val graphId = consumer.graphId ?: continue
+      consumersByGraphId.getOrPut(graphId) { mutableListOf() } += consumer
+    }
+    for ((graphId, consumers) in consumersByGraphId) {
+      ProgressManager.checkCanceled()
+      val graph = graphsById[graphId]
+      if (graph == null) {
+        for (consumer in consumers) graphOwnersByConsumer[consumer] = FrozenConsumerOwners.None
+        continue
+      }
+      val contexts = session.contextsFor(graph).mapNotNull(session::queryContext)
+      for (consumer in consumers) {
+        ProgressManager.checkCanceled()
+        val owners = ownerPointers(consumer, graphId, contexts)
+        if (owners != null) graphOwnersByConsumer[consumer] = owners
+      }
+    }
+    ProgressManager.checkCanceled()
+    return ConsumerOwnershipState(
+      pointersByGraphId.toMap(),
+      pointersByIncludedContainer,
+      graphOwnersByConsumer.toMap(),
+    )
   }
-  private val pointersByIncludedContainer:
-    Map<KaTypeKey, List<SmartPsiElementPointer<out KtElement>>> by lazy {
+
+  private fun buildRootPointersByGraphId():
+    Map<GraphDeclarationId, List<SmartPsiElementPointer<out KtElement>>> {
+    val needsExtensionRoots = graphs.any {
+      it.isExtension && it.includedBindingContainers.isNotEmpty()
+    }
+    if (!needsExtensionRoots) return emptyMap()
+    return buildMap {
+      for (graph in graphs) {
+        ProgressManager.checkCanceled()
+        if (!graph.isExtension || graph.includedBindingContainers.isEmpty()) continue
+        val roots = session.contextsFor(graph).map { it.rootGraph.pointer }.distinct()
+        if (roots.isNotEmpty()) put(graph.declarationId, roots)
+      }
+    }
+  }
+
+  private fun buildIncludedContainerPointers(
+    rootPointersByGraphId: Map<GraphDeclarationId, List<SmartPsiElementPointer<out KtElement>>>
+  ): Map<KaTypeKey, List<SmartPsiElementPointer<out KtElement>>> {
     val pointers = linkedMapOf<KaTypeKey, MutableList<SmartPsiElementPointer<out KtElement>>>()
     val modulesByContainer = HashMap<KaTypeKey, MutableSet<KaModule>>()
     for (graph in graphs) {
@@ -652,50 +737,42 @@ internal class ConsumerGraphContexts(private val index: BindingIndex) {
         }
       }
     }
-    pointers
+    return pointers.mapValues { (_, values) -> values.toList() }
   }
 
-  fun pointer(consumer: ConsumerEntry): SmartPsiElementPointer<out KtElement> {
-    val graphId = consumer.graphId ?: return consumer.pointer
-    return pointersByGraphId[graphId] ?: consumer.pointer
-  }
-
-  /** Factory-input shards are shared, so every graph including their exact key can own a site. */
-  fun includedContainerPointers(
-    consumer: ConsumerEntry
-  ): List<SmartPsiElementPointer<out KtElement>>? {
-    if (consumer.graphId != null) return null
-    val containerKey = consumer.includedContainerKey ?: return null
-    return pointersByIncludedContainer[containerKey]
-  }
-
-  /** Null is the allocation-free ordinary single-owner path used by [pointer]. */
-  fun owningGraphPointers(consumer: ConsumerEntry): List<SmartPsiElementPointer<out KtElement>>? {
-    val graphId = consumer.graphId
-    if (graphId != null) {
-      val graph = graphsById[graphId] ?: return emptyList()
-      val contexts =
-        queryContextsByGraphId.computeIfAbsent(graphId) {
-          index.contextsFor(graph).mapNotNull(index::queryContext)
-        }
-      if (contexts.size == 1) {
-        val context = contexts.single()
-        if (!index.isConsumerInContext(consumer, context)) return emptyList()
-        // Keep the normal one-graph owner path allocation-free after checking actual membership.
-        if (context.graphContext.rootGraph.declarationId == graphId) return null
-        return listOf(context.graphContext.rootGraph.pointer)
-      }
-      val owners = mutableListOf<SmartPsiElementPointer<out KtElement>>()
-      val modules = mutableSetOf<KaModule>()
-      for (context in contexts) {
-        ProgressManager.checkCanceled()
-        if (!index.isConsumerInContext(consumer, context)) continue
-        if (modules.add(context.graphModule)) owners += context.graphContext.rootGraph.pointer
-      }
-      return owners
+  private fun ownerPointers(
+    consumer: ConsumerEntry,
+    graphId: GraphDeclarationId,
+    contexts: List<GraphQueryContext>,
+  ): FrozenConsumerOwners? {
+    if (contexts.size == 1) {
+      val context = contexts.single()
+      if (!session.isConsumerInContext(consumer, context)) return FrozenConsumerOwners.None
+      if (context.graphContext.rootGraph.declarationId == graphId) return null
+      return FrozenConsumerOwners.GraphRoots(listOf(context.graphContext.rootGraph.pointer))
     }
-    return includedContainerPointers(consumer)
+    val owners = mutableListOf<SmartPsiElementPointer<out KtElement>>()
+    val modules = mutableSetOf<KaModule>()
+    for (context in contexts) {
+      ProgressManager.checkCanceled()
+      if (!session.isConsumerInContext(consumer, context)) continue
+      if (modules.add(context.graphModule)) owners += context.graphContext.rootGraph.pointer
+    }
+    if (owners.isEmpty()) return FrozenConsumerOwners.None
+    return FrozenConsumerOwners.GraphRoots(owners)
   }
+}
+
+private class ConsumerOwnershipState(
+  val pointersByGraphId: Map<GraphDeclarationId, SmartPsiElementPointer<out KtElement>>,
+  val pointersByIncludedContainer: Map<KaTypeKey, List<SmartPsiElementPointer<out KtElement>>>,
+  val graphOwnersByConsumer: Map<ConsumerEntry, FrozenConsumerOwners>,
+)
+
+private sealed interface FrozenConsumerOwners {
+  data object None : FrozenConsumerOwners
+
+  class GraphRoots(val pointers: List<SmartPsiElementPointer<out KtElement>>) : FrozenConsumerOwners
 }
 
 /** Session-free source factory groups that remain reusable when equivalent shards are rebuilt. */

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroResolutionService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroResolutionService.kt
@@ -46,14 +46,20 @@ import dev.zacsweers.metro.compiler.mapToSet
 import dev.zacsweers.metro.idea.MetroIdeModuleState
 import dev.zacsweers.metro.idea.MetroIdeProjectService
 import dev.zacsweers.metro.idea.MetroSettings
+import dev.zacsweers.metro.idea.checkCanceledEvery
 import dev.zacsweers.metro.idea.metroIdeState
 import dev.zacsweers.metro.idea.model.AssistedSite
 import dev.zacsweers.metro.idea.model.BindingContainerEntry
 import dev.zacsweers.metro.idea.model.BindingIndex
+import dev.zacsweers.metro.idea.model.BindingIndexBuilder
+import dev.zacsweers.metro.idea.model.BindingIndexModuleView
+import dev.zacsweers.metro.idea.model.BindingIndexResolutionInputs
 import dev.zacsweers.metro.idea.model.ConsumerEntry
 import dev.zacsweers.metro.idea.model.ContributionEntry
 import dev.zacsweers.metro.idea.model.DynamicGraphCall
 import dev.zacsweers.metro.idea.model.DynamicGraphId
+import dev.zacsweers.metro.idea.model.FileOrdinal
+import dev.zacsweers.metro.idea.model.FileOrdinalTable
 import dev.zacsweers.metro.idea.model.GraphCallableReference
 import dev.zacsweers.metro.idea.model.GraphCallableSignature
 import dev.zacsweers.metro.idea.model.GraphDeclarationId
@@ -66,7 +72,9 @@ import dev.zacsweers.metro.idea.model.KaContextualTypeKey
 import dev.zacsweers.metro.idea.model.KaGraphDeclaration
 import dev.zacsweers.metro.idea.model.KaTypeKey
 import dev.zacsweers.metro.idea.model.KaTypeSnapshot
+import dev.zacsweers.metro.idea.model.ModuleViewId
 import dev.zacsweers.metro.idea.model.SourceAssistedFactoryIdentity
+import dev.zacsweers.metro.idea.model.sourcePointerIdentity
 import java.util.Collections
 import java.util.IdentityHashMap
 import java.util.concurrent.ConcurrentHashMap
@@ -80,7 +88,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.jetbrains.annotations.TestOnly
+import org.jetbrains.kotlin.analysis.api.KaPlatformInterface
 import org.jetbrains.kotlin.analysis.api.permissions.allowAnalysisOnEdt
+import org.jetbrains.kotlin.analysis.api.platform.projectStructure.KaResolutionScope
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModuleProvider
 import org.jetbrains.kotlin.idea.compiler.configuration.KotlinCompilerSettingsListener
@@ -578,19 +588,21 @@ class MetroResolutionService(
           LibraryShard.EMPTY
         }
       progress?.phase(IndexBuildPhase.BUILDING_GRAPH_INDEX)
-      val index =
-        BindingIndex(
-          bindings = source.bindings + library.bindings,
-          consumers = source.consumers,
-          graphs = source.graphs,
-          contributions = source.contributions + library.contributions,
-          assistedSites = source.assistedSites,
-          bindingContainers = source.bindingContainers,
-          incompleteAssistedFactories =
+      val indexBuilder =
+        BindingIndexBuilder().apply {
+          bindings += source.bindings + library.bindings
+          consumers += source.consumers
+          graphs += source.graphs
+          contributions += source.contributions + library.contributions
+          assistedSites += source.assistedSites
+          bindingContainers += source.bindingContainers
+          incompleteAssistedFactories +=
             if (key.resolveFromLibraries) library.incompleteFactories
-            else summary.sourceFactories.incompleteFactories,
-          dynamicGraphs = source.dynamicGraphs,
-        )
+            else summary.sourceFactories.incompleteFactories
+          dynamicGraphs += source.dynamicGraphs
+        }
+      indexBuilder.captureResolutionInputs(project)
+      val index = indexBuilder.build()
       // Only cache when nothing invalidated the pass semantically. A plain re-drain of new dirty
       // files under the same generation still describes this exact source snapshot.
       if (invalidations.get().generation == start.generation) {
@@ -844,7 +856,7 @@ class MetroResolutionService(
           source.graphs,
           contributions,
           summary.factoryUseSites,
-          summary.consumerGraphContexts,
+          summary.consumerOwnership,
           summary.sourceFactories,
         )
         .postProcess()
@@ -1364,6 +1376,131 @@ class MetroResolutionService(
     const val MAX_CACHED_INDEXES = 8
     const val MAX_CACHED_OPTION_FINGERPRINTS = 64
   }
+}
+
+/** Builds the immutable source index used to capture dependency ownership. */
+private fun buildSourceOwnershipIndex(project: Project, source: SourceAggregate): BindingIndex {
+  val builder =
+    BindingIndexBuilder().apply {
+      bindings += source.bindings
+      consumers += source.consumers
+      graphs += source.graphs
+      contributions += source.contributions
+      assistedSites += source.assistedSites
+      bindingContainers += source.bindingContainers
+      dynamicGraphs += source.dynamicGraphs
+    }
+  builder.captureResolutionInputs(project)
+  return builder.build()
+}
+
+/** Captures module visibility and source declaration identities during the index read. */
+@OptIn(KaPlatformInterface::class)
+private fun BindingIndexBuilder.captureResolutionInputs(project: Project) {
+  val representatives = linkedMapOf<VirtualFile, PsiElement>()
+  val pointerSourceIdentities =
+    IdentityHashMap<SmartPsiElementPointer<*>, BindingIndex.SourcePointerIdentity>()
+  val capturedBindings = Collections.newSetFromMap(IdentityHashMap<KaBinding, Boolean>())
+  var pointerCaptureWorkIndex = 0
+
+  fun capture(pointer: SmartPsiElementPointer<*>) {
+    checkCanceledEvery(pointerCaptureWorkIndex++)
+    val identity = sourcePointerIdentity(pointer)
+    if (identity != null) pointerSourceIdentities[pointer] = identity
+    val file = pointer.virtualFile ?: return
+    if (file in representatives) return
+    val element = pointer.element ?: return
+    representatives.putIfAbsent(file, element)
+  }
+
+  fun captureBinding(binding: KaBinding) {
+    capturedBindings += binding
+    capture(binding.pointer)
+  }
+
+  for (binding in bindings) captureBinding(binding)
+  for (consumer in consumers) {
+    capture(consumer.pointer)
+    consumer.injectedMemberPointer?.let { pointer -> capture(pointer) }
+  }
+  for (graph in graphs) {
+    capture(graph.pointer)
+    for (factory in graph.extensionFactories) capture(factory.pointer)
+    for (implementation in graph.defaultImplementations) {
+      capture(implementation.declaration.pointer)
+      for (overridden in implementation.overriddenDeclarations) capture(overridden.pointer)
+    }
+    for (contribution in graph.contributedInterfaces) {
+      capture(contribution.contribution.pointer)
+      for (binding in contribution.bindings) captureBinding(binding)
+      for (consumer in contribution.consumers) capture(consumer.pointer)
+      for (factory in contribution.extensionFactories) capture(factory.pointer)
+      for (implementation in contribution.defaultImplementations) {
+        capture(implementation.declaration.pointer)
+        for (overridden in implementation.overriddenDeclarations) capture(overridden.pointer)
+      }
+    }
+  }
+  for (contribution in contributions) capture(contribution.pointer)
+  for (site in assistedSites) capture(site.pointer)
+  for (container in bindingContainers) capture(container.pointer)
+  for (dynamicGraph in dynamicGraphs) {
+    capture(dynamicGraph.pointer)
+    for (input in dynamicGraph.containerInputs) captureBinding(input)
+  }
+  capturedBindingSourceIdentities =
+    IdentityHashMap<KaBinding, BindingIndex.SourcePointerIdentity>().apply {
+      for (binding in capturedBindings) {
+        checkCanceledEvery(pointerCaptureWorkIndex++)
+        pointerSourceIdentities[binding.pointer]?.let { identity -> put(binding, identity) }
+      }
+    }
+
+  val fileOrdinalTable =
+    FileOrdinalTable.freeze(
+      representatives.keys.withIndex().associate { (ordinal, file) ->
+        file to FileOrdinal(ordinal)
+      }
+    )
+  val moduleByFile = linkedMapOf<VirtualFile, ModuleViewId>()
+  val moduleIds = linkedMapOf<KaModule, ModuleViewId>()
+  val moduleRepresentatives = linkedMapOf<KaModule, PsiElement>()
+  for ((file, element) in representatives) {
+    ProgressManager.checkCanceled()
+    val module = KaModuleProvider.getModule(project, element, useSiteModule = null)
+    val moduleId = moduleIds.getOrPut(module) { ModuleViewId(moduleIds.size) }
+    moduleByFile[file] = moduleId
+    moduleRepresentatives.putIfAbsent(module, element)
+  }
+
+  val moduleViews = linkedMapOf<ModuleViewId, BindingIndexModuleView>()
+  for ((module, moduleId) in moduleIds) {
+    ProgressManager.checkCanceled()
+    val scope = KaResolutionScope.forModule(module)
+    val visibleFiles = BooleanArray(fileOrdinalTable.size)
+    for ((file, element) in representatives) {
+      ProgressManager.checkCanceled()
+      if (scope.contains(element)) {
+        visibleFiles[fileOrdinalTable.getValue(file).value] = true
+      }
+    }
+    val moduleElement = checkNotNull(moduleRepresentatives[module])
+    moduleViews[moduleId] =
+      BindingIndexModuleView(
+        id = moduleId,
+        module = module,
+        visibleFileOrdinals = visibleFiles,
+        fileOrdinalTable = fileOrdinalTable,
+        daggerAnvilInteropEnabled = moduleElement.metroIdeState().options.enableDaggerAnvilInterop,
+      )
+  }
+  resolutionInputs =
+    BindingIndexResolutionInputs(
+      fileOrdinalTable,
+      moduleByFile,
+      moduleViews,
+      pointerSourceIdentities,
+    )
 }
 
 private enum class IndexRequestMode {
@@ -2090,32 +2227,23 @@ private class SourceLibrarySummaryReference {
       summary?.let {
         return it
       }
-      val sourceIndex =
-        BindingIndex(
-          source.bindings,
-          source.consumers,
-          source.graphs,
-          source.contributions,
-          source.assistedSites,
-          source.bindingContainers,
-          dynamicGraphs = source.dynamicGraphs,
-        )
-      val consumerGraphContexts = ConsumerGraphContexts(sourceIndex)
+      val sourceIndex = buildSourceOwnershipIndex(project, source)
+      val consumerOwnership = ConsumerOwnershipBundle.build(sourceIndex)
       val sourceFactories =
         SourceAssistedFactoryPostProcessor(
             project,
             source.bindings,
             source.consumers,
-            consumerGraphContexts,
+            consumerOwnership,
           )
           .resolveInitial()
       val completeSource = source.withAddedFactories(sourceFactories.addedBindings)
-      val inputs = completeSource.libraryInputs(project, sourceFactories, consumerGraphContexts)
+      val inputs = completeSource.libraryInputs(project, sourceFactories, consumerOwnership)
       val result =
         SourceLibrarySummary(
           inputs,
           sourceFactories.factoryUseSites,
-          consumerGraphContexts,
+          consumerOwnership,
           sourceFactories,
         )
       ProgressManager.checkCanceled()
@@ -2128,7 +2256,7 @@ private class SourceLibrarySummaryReference {
 private data class SourceLibrarySummary(
   val inputs: LibraryInputs,
   val factoryUseSites: SourceAssistedFactoryUseSites,
-  val consumerGraphContexts: ConsumerGraphContexts,
+  val consumerOwnership: ConsumerOwnershipBundle,
   val sourceFactories: SourceFactoryResolution,
 )
 
@@ -2149,7 +2277,7 @@ private data class SourceAggregate(
   fun libraryInputs(
     project: Project,
     sourceFactories: SourceFactoryResolution,
-    consumerGraphContexts: ConsumerGraphContexts,
+    consumerOwnership: ConsumerOwnershipBundle,
   ): LibraryInputs {
     val sourceFactoryUseSites = sourceFactories.factoryUseSites
     val scopeIds = linkedSetOf<ClassId>()
@@ -2187,9 +2315,9 @@ private data class SourceAggregate(
     for (consumer in consumers) {
       ProgressManager.checkCanceled()
       val classId = consumer.typeClassId
-      val containerOwners = consumerGraphContexts.owningGraphPointers(consumer)
+      val containerOwners = consumerOwnership.owningGraphPointers(consumer)
       if (containerOwners == null) {
-        val module = addModule(consumerGraphContexts.pointer(consumer).element) ?: continue
+        val module = addModule(consumerOwnership.pointer(consumer).element) ?: continue
         if (classId == null || consumer.multibindingId != null) continue
         injectRequests += LibraryInjectInput(module, consumer.key, classId)
       } else {

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/SourceAssistedFactoryPostProcessor.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/SourceAssistedFactoryPostProcessor.kt
@@ -67,7 +67,7 @@ internal class SourceAssistedFactoryPostProcessor(
   private val project: Project,
   bindings: List<KaBinding>,
   private val consumers: List<ConsumerEntry>,
-  private val graphContexts: ConsumerGraphContexts,
+  private val consumerOwnership: ConsumerOwnershipBundle,
   previous: SourceFactoryResolution? = null,
 ) {
   private val pointerManager = SmartPointerManager.getInstance(project)
@@ -133,9 +133,9 @@ internal class SourceAssistedFactoryPostProcessor(
     for (consumer in consumers) {
       ProgressManager.checkCanceled()
       if (consumer.multibindingId != null) continue
-      val owners = graphContexts.owningGraphPointers(consumer)
+      val owners = consumerOwnership.owningGraphPointers(consumer)
       if (owners == null) {
-        enqueue(consumer.key, graphContexts.pointer(consumer), direct = true)
+        enqueue(consumer.key, consumerOwnership.pointer(consumer), direct = true)
       } else {
         for (owner in owners) enqueue(consumer.key, owner, direct = true)
       }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndex.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndex.kt
@@ -2,23 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea.model
 
-import androidx.collection.MutableScatterMap
-import androidx.collection.ScatterMap
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.SmartPsiElementPointer
-import dev.zacsweers.metro.compiler.flatMapToSet
 import dev.zacsweers.metro.compiler.graph.applyExcludesAndReplaces
 import dev.zacsweers.metro.compiler.graph.computeLowerPriorityContributions
 import dev.zacsweers.metro.compiler.graph.computeMergePlan
-import dev.zacsweers.metro.idea.metroIdeState
+import dev.zacsweers.metro.idea.checkCanceledEvery
 import java.util.IdentityHashMap
-import java.util.concurrent.ConcurrentHashMap
-import org.jetbrains.kotlin.analysis.api.KaPlatformInterface
-import org.jetbrains.kotlin.analysis.api.platform.projectStructure.KaResolutionScope
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
-import org.jetbrains.kotlin.analysis.api.projectStructure.KaModuleProvider
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtElement
 
@@ -28,301 +21,25 @@ import org.jetbrains.kotlin.psi.KtElement
  * Resolution starts with project-wide key matches, then filters those candidates through each
  * graph's aggregation context for editor features that need graph membership.
  */
-internal class BindingIndex(
-  val bindings: List<KaBinding>,
-  val consumers: List<ConsumerEntry>,
-  val graphs: List<KaGraphDeclaration>,
-  val contributions: List<ContributionEntry>,
-  val assistedSites: List<AssistedSite> = emptyList(),
-  val bindingContainers: List<BindingContainerEntry> = emptyList(),
-  private val incompleteAssistedFactories:
-    Map<KaModule, Map<SourceAssistedFactoryIdentity, String>> =
-    emptyMap(),
-  val dynamicGraphs: List<DynamicGraphCall> = emptyList(),
-) {
-  private val containersById: ScatterMap<ClassId, List<BindingContainerEntry>> by lazy {
-    bindingContainers.groupToScatter { it.classId }
-  }
+internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
+  val generationToken = data.generationToken
+  val bindings = data.bindings
+  val consumers = data.consumers
+  val graphs = data.graphs
+  val contributions = data.contributions
+  val assistedSites = data.assistedSites
+  val bindingContainers = data.bindingContainers
+  private val incompleteAssistedFactories = data.incompleteAssistedFactories
+  val dynamicGraphs = data.dynamicGraphs
+  internal val resolutionInputs = data.resolutionInputs
+  private val lookups = data.lookups
 
-  private val bindingsByOrigin: ScatterMap<ClassId, List<KaBinding>> by lazy {
-    bindings.groupToScatter { it.originClassId }
-  }
+  /** Creates mutable query state for one operation. Concurrent access is unsupported. */
+  fun createResolutionSession(): BindingResolutionSession = BindingResolutionSession(this)
 
-  private val bindingsByMemberOwner: ScatterMap<ClassId, List<KaBinding>> by lazy {
-    val result = MutableScatterMap<ClassId, MutableList<KaBinding>>()
-    for (binding in bindings) {
-      for (ownerId in binding.memberInjectionOwnerIds) {
-        result.getOrPut(ownerId, ::mutableListOf) += binding
-      }
-    }
-    @Suppress("UNCHECKED_CAST")
-    result as ScatterMap<ClassId, List<KaBinding>>
-  }
-
-  private val graphContexts = ConcurrentHashMap<KaGraphDeclaration, List<GraphContext>>()
-  private val graphQueryContexts = ConcurrentHashMap<GraphContext, GraphQueryContext>()
-  private val ownContainersByContext =
-    ConcurrentHashMap<GraphQueryContext, ConcurrentHashMap<GraphDeclarationId, Set<ClassId>>>()
-  private val replacedOriginsByContext = ConcurrentHashMap<GraphQueryContext, Set<ClassId>>()
-  private val validationReplacedOriginsByContext =
-    ConcurrentHashMap<GraphQueryContext, Set<ClassId>>()
-  private val lowerPriorityBindingsByContext =
-    ConcurrentHashMap<GraphQueryContext, Set<KaBinding>>()
-  private val validationLowerPriorityBindingsByContext =
-    ConcurrentHashMap<GraphQueryContext, Set<KaBinding>>()
-  private val removedOriginsByContext = ConcurrentHashMap<GraphQueryContext, Set<ClassId>>()
-  private val validationRemovedOriginsByContext =
-    ConcurrentHashMap<GraphQueryContext, Set<ClassId>>()
-  private val consumerResolutions = ConcurrentHashMap<ConsumerEntry, ConsumerResolution>()
-  private val nearestFactoryInputOwners =
-    ConcurrentHashMap<GraphContext, NearestFactoryInputOwners>()
-  private val graphCompositions = ConcurrentHashMap<GraphCompositionKey, SelectedGraphComposition>()
-  /** Avoid rebuilding a suffix path for every binding checked in the same immutable query view. */
-  private val graphCompositionsByOwner =
-    ConcurrentHashMap<
-      GraphQueryContext,
-      ConcurrentHashMap<GraphDeclarationId, SelectedGraphComposition>,
-    >()
-  private val contributionSelections =
-    ConcurrentHashMap<GraphCompositionKey, ContributionSelection>()
-
-  private val contributionsByScope: ScatterMap<ClassId, List<ContributionEntry>> by lazy {
-    val result = MutableScatterMap<ClassId, MutableList<ContributionEntry>>()
-    for (contribution in contributions) {
-      for (scope in contribution.scopeKeys) {
-        result.getOrPut(scope, ::mutableListOf) += contribution
-      }
-    }
-    @Suppress("UNCHECKED_CAST")
-    result as ScatterMap<ClassId, List<ContributionEntry>>
-  }
-
-  /** These are exact candidate objects from this immutable index, not declaration-name aliases. */
-  private val contributedBindingOwners: Map<KaBinding, GraphInterfaceContribution> by lazy {
-    val result = IdentityHashMap<KaBinding, GraphInterfaceContribution>()
-    for (graph in graphs) {
-      for (contribution in graph.contributedInterfaces) {
-        for (binding in contribution.bindings) result[binding] = contribution
-      }
-    }
-    result
-  }
-
-  private val graphsByReference: Map<GraphReference, List<KaGraphDeclaration>> by lazy {
-    val result = linkedMapOf<GraphReference, MutableList<KaGraphDeclaration>>()
-    for (graph in graphs) {
-      for (reference in graph.selfReferences) {
-        result.getOrPut(reference, ::mutableListOf) += graph
-      }
-    }
-    result
-  }
-
-  private val dynamicGraphsByTarget: Map<GraphReference, List<DynamicGraphCall>> by lazy {
-    dynamicGraphs.groupBy { it.targetGraph }
-  }
-
-  /** Potential edges only. Their contribution must survive in the eventual parent's root module. */
-  private val potentialParentsByReference: Map<GraphReference, List<KaGraphDeclaration>> by lazy {
-    val result = linkedMapOf<GraphReference, MutableList<KaGraphDeclaration>>()
-    for (graph in graphs) {
-      val references = linkedSetOf<GraphReference>()
-      references += graph.extensionCreations
-      for (contribution in graph.contributedInterfaces) references +=
-        contribution.extensionCreations
-      for (reference in references) result.getOrPut(reference, ::mutableListOf) += graph
-    }
-    result
-  }
-
-  private val allGraphContexts: List<GraphContext> by lazy {
-    graphs.flatMap { graph ->
-      ProgressManager.checkCanceled()
-      contextsFor(graph)
-    }
-  }
-
-  private val contextsByGraphId: ScatterMap<GraphDeclarationId, List<GraphContext>> by lazy {
-    val result = MutableScatterMap<GraphDeclarationId, MutableList<GraphContext>>()
-    for (context in allGraphContexts) {
-      for (graphId in context.graphIds) {
-        result.getOrPut(graphId, ::mutableListOf) += context
-      }
-    }
-    @Suppress("UNCHECKED_CAST")
-    result as ScatterMap<GraphDeclarationId, List<GraphContext>>
-  }
-
-  /** Session-free identities also record whether an inherited declaration is publicly visible. */
-  private val specializedBindingIdentities: Map<SpecializedBindingIdentity, Boolean> by lazy {
-    buildMap {
-      for (binding in bindings) {
-        if (binding is KaBinding.BoundInstance) continue
-        if (binding in contributedBindingOwners) continue
-        val graphId = binding.ownerGraphId ?: continue
-        val identity = pointerIdentity(binding.pointer) ?: continue
-        val specialization =
-          SpecializedBindingIdentity(graphId, identity, binding.javaClass, binding.typeKey)
-        val alreadyPublic = get(specialization) == true
-        put(specialization, alreadyPublic || !binding.isGraphPrivate)
-      }
-    }
-  }
-
-  /** A concrete specialization replaces its raw declaration even when its return key changes. */
-  private val specializedDeclarationIdentities: Set<SpecializedDeclarationIdentity> by lazy {
-    if (specializedBindingIdentities.isEmpty()) {
-      emptySet()
-    } else {
-      buildSet {
-        for (identity in specializedBindingIdentities.keys) {
-          add(
-            SpecializedDeclarationIdentity(
-              identity.graphId,
-              identity.pointer,
-              identity.bindingClass,
-            )
-          )
-        }
-      }
-    }
-  }
-
-  private val contributedSpecializedBindings:
-    Map<SpecializedBindingIdentity, List<KaBinding>> by lazy {
-    val result = linkedMapOf<SpecializedBindingIdentity, MutableList<KaBinding>>()
-    for (binding in contributedBindingOwners.keys) {
-      val owner = binding.ownerGraphId ?: continue
-      val source = pointerIdentity(binding.pointer) ?: continue
-      val identity = SpecializedBindingIdentity(owner, source, binding.javaClass, binding.typeKey)
-      result.getOrPut(identity, ::mutableListOf) += binding
-    }
-    result
-  }
-
-  private val contributedSpecializedDeclarations:
-    Map<SpecializedDeclarationIdentity, List<KaBinding>> by lazy {
-    val result = linkedMapOf<SpecializedDeclarationIdentity, MutableList<KaBinding>>()
-    for (binding in contributedBindingOwners.keys) {
-      val owner = binding.ownerGraphId ?: continue
-      val source = pointerIdentity(binding.pointer) ?: continue
-      val identity = SpecializedDeclarationIdentity(owner, source, binding.javaClass)
-      result.getOrPut(identity, ::mutableListOf) += binding
-    }
-    result
-  }
-
-  /** Raw source callables remain authoritative when their interface was written explicitly. */
-  private val unownedBindingDeclarations: Map<BindingDeclarationIdentity, List<KaBinding>> by lazy {
-    val result = linkedMapOf<BindingDeclarationIdentity, MutableList<KaBinding>>()
-    for (binding in bindings) {
-      if (binding.ownerGraphId != null || binding.containerId == null) continue
-      val source = pointerIdentity(binding.pointer) ?: continue
-      val identity = BindingDeclarationIdentity(source, binding.javaClass, binding.typeKey)
-      result.getOrPut(identity, ::mutableListOf) += binding
-    }
-    result
-  }
-
-  private val contextsByScope: ScatterMap<ClassId, List<GraphContext>> by lazy {
-    val result = MutableScatterMap<ClassId, MutableList<GraphContext>>()
-    for (context in allGraphContexts) {
-      for (scope in context.scopes) {
-        result.getOrPut(scope, ::mutableListOf) += context
-      }
-    }
-    @Suppress("UNCHECKED_CAST")
-    result as ScatterMap<ClassId, List<GraphContext>>
-  }
-
-  // Contributions are keyed solely by multibindingId, mirroring the compiler's
-  // @MultibindingElement qualifier swap. Their element key must not satisfy plain consumers.
-  private val bindingsByKey: ScatterMap<KaTypeKey, List<KaBinding>> by lazy {
-    bindings.groupToScatter { binding ->
-      binding.typeKey.takeIf { binding.multibindingId == null }
-    }
-  }
-
-  private val bindingsByType: ScatterMap<KaTypeSnapshot, List<KaBinding>> by lazy {
-    bindings.groupToScatter { it.typeKey.type }
-  }
-
-  private val assistedFactoriesByTarget:
-    ScatterMap<KaTypeKey, List<KaBinding.AssistedFactory>> by lazy {
-    bindings.filterIsInstance<KaBinding.AssistedFactory>().groupToScatter { it.targetTypeKey }
-  }
-
-  private val consumersByKey: ScatterMap<KaTypeKey, List<ConsumerEntry>> by lazy {
-    consumers.groupToScatter { it.key }
-  }
-
-  private val contributionsByMultibindingId: ScatterMap<String, List<KaBinding>> by lazy {
-    bindings.groupToScatter { it.multibindingId }
-  }
-
-  private val consumersByMultibindingId: ScatterMap<String, List<ConsumerEntry>> by lazy {
-    consumers.groupToScatter { it.multibindingId }
-  }
-
-  private val accessorsByGraph: ScatterMap<GraphDeclarationId, List<ConsumerEntry>> by lazy {
-    consumers.groupToScatter { it.graphId }
-  }
-
-  // PSI-identity lookups for editor features classifying the element under the caret/pass.
-  // Bucketed by the pointers' virtual files (no PSI dereference) so the index never pins PSI
-  // project-wide; only the queried file's bucket dereferences its pointers. Must be accessed in
-  // a read action.
-  private val bindingsByFile: ScatterMap<VirtualFile, List<KaBinding>> by lazy {
-    bindings.groupToScatter { it.pointer.virtualFile }
-  }
-
-  private val consumersByFile: ScatterMap<VirtualFile, List<ConsumerEntry>> by lazy {
-    consumers.groupToScatter { it.pointer.virtualFile }
-  }
-
-  private val specializedConsumerIdentities: Set<SpecializedConsumerIdentity> by lazy {
-    buildSet {
-      for (consumer in consumers) {
-        val graphId = consumer.graphId ?: continue
-        if (consumer.graphRequestKind != null) continue
-        if (consumer.graphContribution != null) continue
-        val identity = pointerIdentity(consumer.pointer) ?: continue
-        add(SpecializedConsumerIdentity(graphId, identity))
-      }
-    }
-  }
-
-  private val contributedSpecializedConsumers:
-    Map<SpecializedConsumerIdentity, List<ConsumerEntry>> by lazy {
-    val result = linkedMapOf<SpecializedConsumerIdentity, MutableList<ConsumerEntry>>()
-    for (consumer in consumers) {
-      if (consumer.graphContribution == null || consumer.graphRequestKind != null) continue
-      val graphId = consumer.graphId ?: continue
-      val source = pointerIdentity(consumer.pointer) ?: continue
-      val identity = SpecializedConsumerIdentity(graphId, source)
-      result.getOrPut(identity, ::mutableListOf) += consumer
-    }
-    result
-  }
-
-  /** Specializations can be discovered independently from several consuming source-file shards. */
-  private val duplicatedAssistedFactoryKeys: Set<KaTypeKey> by lazy {
-    val seen = HashSet<Triple<ClassId?, VirtualFile?, KaTypeKey>>()
-    buildSet {
-      for (binding in bindings) {
-        if (binding !is KaBinding.AssistedFactory) continue
-        val identity = Triple(binding.originClassId, binding.pointer.virtualFile, binding.typeKey)
-        if (!seen.add(identity)) add(binding.typeKey)
-      }
-    }
-  }
-
-  private val graphsByFile: ScatterMap<VirtualFile, List<KaGraphDeclaration>> by lazy {
-    graphs.groupToScatter { it.pointer.virtualFile }
-  }
-
-  private val assistedSitesByFile: ScatterMap<VirtualFile, List<AssistedSite>> by lazy {
-    assistedSites.groupToScatter { it.pointer.virtualFile }
+  /** Creates a session for [block]'s queries. */
+  fun <T> withResolutionSession(block: (BindingResolutionSession) -> T): T {
+    return block(createResolutionSession())
   }
 
   /**
@@ -330,9 +47,15 @@ internal class BindingIndex(
    * the multibinding contributions collected into them.
    */
   fun bindingsFor(consumer: ConsumerEntry): List<KaBinding> {
-    val useSiteModule = moduleFor(consumer.pointer.element)
-    val resolutionScope = useSiteModule?.resolutionScope()
-    return visibleBindingsFor(consumer, useSiteModule, resolutionScope)
+    return withResolutionSession { session -> session.bindingsFor(consumer) }
+  }
+
+  internal fun bindingsFor(
+    session: BindingResolutionSession,
+    consumer: ConsumerEntry,
+  ): List<KaBinding> {
+    val view = session.resolutionViewFor(consumer.sourceIdentity, consumer.pointer)
+    return visibleBindingsFor(consumer, view?.module, view?.resolutionScope)
   }
 
   /**
@@ -344,9 +67,18 @@ internal class BindingIndex(
     consumer: ConsumerEntry,
     queryContext: GraphQueryContext,
   ): List<KaBinding> {
+    return withResolutionSession { session -> session.bindingsFor(consumer, queryContext) }
+  }
+
+  internal fun bindingsFor(
+    session: BindingResolutionSession,
+    consumer: ConsumerEntry,
+    queryContext: GraphQueryContext,
+  ): List<KaBinding> {
+    val plan = editorPlan(session, queryContext)
     val visible =
       visibleBindingsFor(consumer, queryContext.graphModule, queryContext.resolutionScope)
-    return applyReplaces(visible.filter { isBindingInContext(it, queryContext) })
+    return applyReplaces(visible.filter { isBindingInContext(it, plan) })
   }
 
   /**
@@ -354,23 +86,35 @@ internal class BindingIndex(
    * plus the use-site-visible candidates as a fallback for files/projects without graphs.
    */
   fun resolveConsumer(consumer: ConsumerEntry): ConsumerResolution {
-    return consumerResolutions.computeIfAbsent(consumer, ::buildConsumerResolution)
+    return withResolutionSession { session -> session.resolveConsumer(consumer) }
   }
 
-  private fun buildConsumerResolution(consumer: ConsumerEntry): ConsumerResolution {
-    val consumerModule = moduleFor(consumer.pointer.element)
-    val consumerResolutionScope = consumerModule?.resolutionScope()
-    val global = visibleBindingsFor(consumer, consumerModule, consumerResolutionScope)
+  internal fun resolveConsumer(
+    session: BindingResolutionSession,
+    consumer: ConsumerEntry,
+  ): ConsumerResolution {
+    return session.consumerResolution(consumer) {
+      buildConsumerResolution(session, consumer)
+    }
+  }
+
+  private fun buildConsumerResolution(
+    session: BindingResolutionSession,
+    consumer: ConsumerEntry,
+  ): ConsumerResolution {
+    val consumerView = session.resolutionViewFor(consumer.sourceIdentity, consumer.pointer)
+    val global = visibleBindingsFor(consumer, consumerView?.module, consumerView?.resolutionScope)
     if (graphs.isEmpty()) {
       return ConsumerResolution(global, emptyMap(), hasGraphs = false, index = this)
     }
 
     val perContext = LinkedHashMap<GraphContext, List<KaBinding>>()
     val visibleByModule = HashMap<KaModule, List<KaBinding>>()
-    for (context in candidateContextsFor(consumer)) {
+    for (context in candidateContextsFor(session, consumer)) {
       ProgressManager.checkCanceled()
-      val queryContext = queryContext(context) ?: continue
-      if (!isConsumerInContext(consumer, queryContext)) continue
+      val queryContext = queryContext(session, context) ?: continue
+      val plan = editorPlan(session, queryContext)
+      if (!isConsumerInContext(consumer, plan)) continue
       val visible =
         visibleByModule.getOrPut(queryContext.graphModule) {
           visibleBindingsFor(
@@ -379,24 +123,46 @@ internal class BindingIndex(
             queryContext.resolutionScope,
           )
         }
-      perContext[context] = filterBindingsInContext(visible, queryContext)
+      perContext[context] = filterBindingsInContext(visible, plan)
     }
     return ConsumerResolution(global, perContext, hasGraphs = true, index = this)
   }
 
-  private fun candidateContextsFor(consumer: ConsumerEntry): List<GraphContext> {
+  private fun candidateContextsFor(
+    session: BindingResolutionSession,
+    consumer: ConsumerEntry,
+  ): List<GraphContext> {
     val graphId = consumer.graphId
-    if (graphId != null) return contextsByGraphId[graphId].orEmpty()
+    if (graphId != null) {
+      val candidateGraphs = lookups.graphsByReachableAncestor[graphId].orEmpty()
+      return buildList {
+        for ((index, graph) in candidateGraphs.withIndex()) {
+          checkCanceledEvery(index)
+          for (context in session.contextsFor(graph)) {
+            ProgressManager.checkCanceled()
+            // A graph may have several parent paths. Keep only paths containing this consumer's
+            // owner.
+            if (graphId in context.graphIds) add(context)
+          }
+        }
+      }
+    }
 
     if (consumer.contributionScopes.isNotEmpty()) {
+      val candidateGraphs = linkedSetOf<KaGraphDeclaration>()
+      for ((index, scope) in consumer.contributionScopes.withIndex()) {
+        checkCanceledEvery(index)
+        candidateGraphs += lookups.graphsByReachableScope[scope].orEmpty()
+      }
       val contexts = linkedSetOf<GraphContext>()
-      for (scope in consumer.contributionScopes) {
-        contexts += contextsByScope[scope].orEmpty()
+      for ((index, graph) in candidateGraphs.withIndex()) {
+        checkCanceledEvery(index)
+        contexts += session.contextsFor(graph)
       }
       return contexts.toList()
     }
 
-    return allGraphContexts
+    return session.allGraphContexts()
   }
 
   /**
@@ -406,9 +172,9 @@ internal class BindingIndex(
    */
   private fun filterBindingsInContext(
     visible: List<KaBinding>,
-    queryContext: GraphQueryContext,
+    plan: GraphQueryPlan,
   ): List<KaBinding> {
-    return applyReplaces(visible.filter { isBindingInContext(it, queryContext) })
+    return applyReplaces(visible.filter { isBindingInContext(it, plan) })
   }
 
   /**
@@ -419,16 +185,28 @@ internal class BindingIndex(
     key: KaTypeKey,
     queryContext: GraphQueryContext,
   ): List<KaBinding> {
-    // Membership filtering already applies context-wide excludes and replaces via the cached
-    // replacedOrigins set.
-    return bindingsByKey[key].orEmpty().withoutDuplicateAssistedFactories(key).filter {
-      isBindingInContext(it, queryContext, includeIncompatibleScopes = true)
+    return withResolutionSession { session -> session.bindingsForKey(key, queryContext) }
+  }
+
+  internal fun bindingsForKey(
+    session: BindingResolutionSession,
+    key: KaTypeKey,
+    queryContext: GraphQueryContext,
+  ): List<KaBinding> = bindingsForKey(key, validationPlan(session, queryContext))
+
+  internal fun bindingsForKey(
+    key: KaTypeKey,
+    plan: GraphQueryPlan,
+  ): List<KaBinding> {
+    // Membership filtering already applies context-wide excludes and replaces from this plan.
+    return lookups.bindingsByKey[key].orEmpty().withoutDuplicateAssistedFactories(key).filter {
+      isBindingInContext(it, plan)
     }
   }
 
   /** All indexed bindings for the same unqualified type, regardless of graph membership. */
   fun bindingsWithType(key: KaTypeKey): List<KaBinding> {
-    return bindingsByType[key.type].orEmpty().withoutDuplicateAssistedFactories()
+    return lookups.bindingsByType[key.type].orEmpty().withoutDuplicateAssistedFactories()
   }
 
   /** Type-level factory checks use module visibility, not a graph's binding exclusions. */
@@ -446,7 +224,7 @@ internal class BindingIndex(
 
   /** Known assisted factories creating [key], regardless of graph membership. */
   fun assistedFactoriesForTarget(key: KaTypeKey): List<KaBinding.AssistedFactory> {
-    return assistedFactoriesByTarget[key].orEmpty().withoutDuplicateAssistedFactories()
+    return lookups.assistedFactoriesByTarget[key].orEmpty().withoutDuplicateAssistedFactories()
   }
 
   /** Why this exact factory's dependency expansion stopped in the graph's compilation module. */
@@ -462,7 +240,7 @@ internal class BindingIndex(
 
   /** Indexed source sites for [key], used when a graph diagnostic needs its real declaration. */
   fun consumerEntriesForKey(key: KaTypeKey): List<ConsumerEntry> {
-    return consumersByKey[key].orEmpty()
+    return lookups.consumersByKey[key].orEmpty()
   }
 
   /** Contributions collected into [multibindingId] in [queryContext]'s graph. */
@@ -470,8 +248,24 @@ internal class BindingIndex(
     multibindingId: String,
     queryContext: GraphQueryContext,
   ): List<KaBinding> {
-    return contributionsByMultibindingId[multibindingId].orEmpty().filter {
-      isBindingInContext(it, queryContext, includeIncompatibleScopes = true)
+    return withResolutionSession { session ->
+      session.multibindingContributions(multibindingId, queryContext)
+    }
+  }
+
+  internal fun multibindingContributions(
+    session: BindingResolutionSession,
+    multibindingId: String,
+    queryContext: GraphQueryContext,
+  ): List<KaBinding> =
+    multibindingContributions(multibindingId, validationPlan(session, queryContext))
+
+  internal fun multibindingContributions(
+    multibindingId: String,
+    plan: GraphQueryPlan,
+  ): List<KaBinding> {
+    return lookups.contributionsByMultibindingId[multibindingId].orEmpty().filter {
+      isBindingInContext(it, plan)
     }
   }
 
@@ -480,23 +274,42 @@ internal class BindingIndex(
    * demand only.
    */
   fun bindingsInContext(queryContext: GraphQueryContext): List<KaBinding> {
-    return bindings
-      .filter {
-        !it.isValidationOnlyAssistedTarget() && isBindingInContext(it, queryContext)
+    return withResolutionSession { session -> session.bindingsInContext(queryContext) }
+  }
+
+  internal fun bindingsInContext(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+  ): List<KaBinding> {
+    val plan = editorPlan(session, queryContext)
+    val result = buildList {
+      for ((index, binding) in bindings.withIndex()) {
+        checkCanceledEvery(index)
+        if (!binding.isValidationOnlyAssistedTarget() && isBindingInContext(binding, plan)) {
+          add(binding)
+        }
       }
-      .withoutDuplicateAssistedFactories()
+    }
+    return result.withoutDuplicateAssistedFactories()
   }
 
   /** The consumer sites declared on [graph] itself, used as seal roots. */
   fun accessorsFor(graph: KaGraphDeclaration): List<ConsumerEntry> {
-    return accessorsByGraph[graph.declarationId].orEmpty().filter {
+    return lookups.accessorsByGraph[graph.declarationId].orEmpty().filter {
       it.graphContribution == null
     }
   }
 
   /** The actual seal roots after selecting this graph's contributed interface surface. */
   fun accessorsFor(queryContext: GraphQueryContext): List<ConsumerEntry> {
-    return graphComposition(queryContext).accessors
+    return withResolutionSession { session -> session.accessorsFor(queryContext) }
+  }
+
+  internal fun accessorsFor(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+  ): List<ConsumerEntry> {
+    return graphComposition(session, queryContext).accessors
   }
 
   /** The selected surface of [graph] in this exact root module and ancestor suffix. */
@@ -504,40 +317,66 @@ internal class BindingIndex(
     queryContext: GraphQueryContext,
     graph: KaGraphDeclaration = queryContext.graphContext.graph,
   ): GraphComposition {
-    val selected = selectedGraphComposition(queryContext, graph.declarationId)
+    return withResolutionSession { session -> session.graphComposition(queryContext, graph) }
+  }
+
+  internal fun graphComposition(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+    graph: KaGraphDeclaration = queryContext.graphContext.graph,
+  ): GraphComposition {
+    val selected = selectedGraphComposition(session, queryContext, graph.declarationId)
+    requireNotNull(selected) { "Graph is not in the requested parent path" }
+    return selected.composition
+  }
+
+  internal fun graphComposition(
+    plan: GraphQueryPlan,
+    graph: KaGraphDeclaration = plan.structure.queryContext.graphContext.graph,
+  ): GraphComposition {
+    val selected = selectedGraphComposition(plan.structure, graph.declarationId)
     requireNotNull(selected) { "Graph is not in the requested parent path" }
     return selected.composition
   }
 
   private fun selectedGraphComposition(
-    queryContext: GraphQueryContext,
+    structure: GraphQueryStructure,
     ownerId: GraphDeclarationId,
   ): SelectedGraphComposition? {
-    graphCompositionsByOwner[queryContext]?.get(ownerId)?.let {
-      return it
-    }
-    val context = queryContext.graphContext
-    if (ownerId !in context.graphIds) return null
-    val byOwner = graphCompositionsByOwner.computeIfAbsent(queryContext) { ConcurrentHashMap() }
-    return byOwner.computeIfAbsent(ownerId) {
-      val chain = context.chain
-      val graphIndex = chain.indexOfFirst { graph -> graph.declarationId == ownerId }
-      check(graphIndex >= 0) { "Graph is not in the requested parent path" }
-      selectedGraphComposition(
-        chain.subList(graphIndex, chain.size),
-        queryContext.graphModule,
-        queryContext.resolutionScope,
-      )
-    }
+    return structure.compositionsByOwner[ownerId]
   }
 
   private fun selectedGraphComposition(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+    ownerId: GraphDeclarationId,
+  ): SelectedGraphComposition? {
+    val context = queryContext.graphContext
+    if (ownerId !in context.graphIds) return null
+    val graphIndex = context.chain.indexOfFirst { graph -> graph.declarationId == ownerId }
+    check(graphIndex >= 0) { "Graph is not in the requested parent path" }
+    return selectedGraphComposition(
+      session,
+      context.chain.subList(graphIndex, context.chain.size),
+      queryContext.graphModule,
+      queryContext.resolutionScope,
+    )
+  }
+
+  private fun selectedGraphComposition(
+    session: BindingResolutionSession,
     chain: List<KaGraphDeclaration>,
     module: KaModule,
     resolutionScope: DeclarationResolutionScope,
   ): SelectedGraphComposition {
-    val key = GraphCompositionKey(GraphPath(chain.map { it.declarationId }), module)
-    return graphCompositions.computeIfAbsent(key) {
+    val graphPath =
+      GraphPath(
+        chain.mapIndexed { index, graph ->
+          checkCanceledEvery(index)
+          graph.declarationId
+        }
+      )
+    return session.graphComposition(graphPath, module) {
       val graph = chain.first()
       val selection = contributionSelection(chain, module, resolutionScope)
       val typeKeys = LinkedHashSet(graph.supertypeKeys)
@@ -563,20 +402,29 @@ internal class BindingIndex(
             }
         for (implementation in implementations) {
           ProgressManager.checkCanceled()
-          val declaration = implementation.declaration.pointer
-          if (!isVisibleFrom(declaration, null, module, resolutionScope)) continue
+          val declaration = implementation.declaration
+          if (
+            !isVisibleFrom(
+              declaration.pointer,
+              declaration.sourceIdentity,
+              null,
+              module,
+              resolutionScope,
+            )
+          )
+            continue
           // A fake override can still point at the concrete declaration itself. Its optional
           // request, if any, is retained by isImplementedGraphRequest below.
-          pointerIdentity(declaration)?.let(identities::add)
+          declaration.sourceIdentity?.let(identities::add)
           for (overridden in implementation.overriddenDeclarations) {
-            pointerIdentity(overridden.pointer)?.let(identities::add)
+            overridden.sourceIdentity?.let(identities::add)
           }
         }
       }
 
       fun addAccessor(consumer: ConsumerEntry) {
         if (consumer.graphRequestKind == null) return
-        val source = pointerIdentity(consumer.pointer)
+        val source = consumer.sourceIdentity
         val identity =
           if (source == null) consumer
           else
@@ -584,14 +432,16 @@ internal class BindingIndex(
               source,
               consumer.contextKey,
               consumer.graphRequestKind,
-              consumer.injectedMemberPointer?.let(::pointerIdentity),
+              consumer.injectedMemberSourceIdentity,
               consumer.isOptional,
               consumer.isSuspend,
             )
         if (accessorIdentities.add(identity)) accessors += consumer
       }
 
-      for (consumer in accessorsByGraph[graph.declarationId].orEmpty()) {
+      for ((index, consumer) in
+        lookups.accessorsByGraph[graph.declarationId].orEmpty().withIndex()) {
+        checkCanceledEvery(index)
         if (consumer.graphContribution == null) addAccessor(consumer)
       }
       addDefaultImplementations(graph.defaultImplementations)
@@ -610,9 +460,10 @@ internal class BindingIndex(
         factories += candidate.extensionFactories
         memberOwners += candidate.injectedMemberOwnerIds
         addDefaultImplementations(candidate.defaultImplementations)
-        for (binding in candidate.bindings) {
+        for ((bindingIndex, binding) in candidate.bindings.withIndex()) {
+          checkCanceledEvery(bindingIndex)
           if (hasWrittenBinding(binding, graph)) continue
-          val source = pointerIdentity(binding.pointer)
+          val source = bindingSourceIdentity(binding)
           val identity =
             if (source == null) binding
             else
@@ -624,7 +475,10 @@ internal class BindingIndex(
               )
           if (bindingIdentities.add(identity)) selectedBindings += binding
         }
-        candidate.consumers.forEach(::addAccessor)
+        for ((consumerIndex, consumer) in candidate.consumers.withIndex()) {
+          checkCanceledEvery(consumerIndex)
+          addAccessor(consumer)
+        }
       }
       val implementedRequests = implementedDeclarations.orEmpty()
       if (implementedRequests.isNotEmpty()) {
@@ -632,28 +486,29 @@ internal class BindingIndex(
       }
       SelectedGraphComposition(
         GraphComposition(
-          typeKeys,
-          declarations,
-          creations,
-          factories,
-          selectedContributions,
-          accessors,
-          memberOwners,
+          typeKeys.toSet(),
+          declarations.toSet(),
+          creations.toSet(),
+          factories.toList(),
+          selectedContributions.toList(),
+          accessors.toList(),
+          memberOwners.toSet(),
         ),
-        contributionIds,
-        selectedBindings,
-        implementedRequests,
+        selection,
+        contributionIds.toSet(),
+        selectedBindings.toSet(),
+        implementedRequests.toSet(),
       )
     }
   }
 
   private fun hasWrittenBinding(binding: KaBinding, graph: KaGraphDeclaration): Boolean {
-    val source = pointerIdentity(binding.pointer) ?: return false
+    val source = bindingSourceIdentity(binding) ?: return false
     val specialization =
       SpecializedBindingIdentity(graph.declarationId, source, binding.javaClass, binding.typeKey)
-    if (specialization in specializedBindingIdentities) return true
+    if (specialization in lookups.specializedBindingIdentities) return true
     val declaration = BindingDeclarationIdentity(source, binding.javaClass, binding.typeKey)
-    return unownedBindingDeclarations[declaration].orEmpty().any { raw ->
+    return lookups.unownedBindingDeclarations[declaration].orEmpty().any { raw ->
       val owner = raw.containerId ?: return@any false
       val reference = GraphReference(owner, raw.pointer.virtualFile)
       reference in graph.supertypeDeclarations || reference in graph.selfReferences
@@ -665,15 +520,22 @@ internal class BindingIndex(
     module: KaModule,
     resolutionScope: DeclarationResolutionScope,
   ): ContributionSelection {
-    val key = GraphCompositionKey(GraphPath(chain.map { it.declarationId }), module)
-    return contributionSelections.computeIfAbsent(key) {
-      selectContributions(
-        chain.first().scopeKeys,
-        chain.flatMapToSet { it.excludes },
-        module,
-        resolutionScope,
-      )
+    var excludeIndex = 0
+    val excludes = buildSet {
+      for (graph in chain) {
+        checkCanceledEvery(excludeIndex++)
+        for (excluded in graph.excludes) {
+          checkCanceledEvery(excludeIndex++)
+          add(excluded)
+        }
+      }
     }
+    return selectContributions(
+      chain.first().scopeKeys,
+      excludes,
+      module,
+      resolutionScope,
+    )
   }
 
   private fun selectContributions(
@@ -683,13 +545,29 @@ internal class BindingIndex(
     resolutionScope: DeclarationResolutionScope,
   ): ContributionSelection {
     val candidates =
-      contributionsForScopes(scopes).filter { contribution ->
-        isVisibleFrom(contribution.pointer, contribution.hintAvailability, module, resolutionScope)
+      contributionsForScopes(scopes).filterIndexed { index, contribution ->
+        checkCanceledEvery(index)
+        isVisibleFrom(
+          contribution.pointer,
+          contribution.sourceIdentity,
+          contribution.hintAvailability,
+          module,
+          resolutionScope,
+        )
       }
-    val byId = candidates.groupBy { it.classId }
-    val presentIds = byId.keys.filterNotNullTo(mutableSetOf())
+    val byId = linkedMapOf<ClassId?, MutableList<ContributionEntry>>()
+    for ((index, candidate) in candidates.withIndex()) {
+      checkCanceledEvery(index)
+      byId.getOrPut(candidate.classId, ::mutableListOf) += candidate
+    }
+    val presentIds = mutableSetOf<ClassId>()
+    for ((index, classId) in byId.keys.withIndex()) {
+      checkCanceledEvery(index)
+      classId?.let(presentIds::add)
+    }
     val nestedFactories = mutableMapOf<ClassId, MutableSet<ClassId>>()
-    for (contribution in candidates) {
+    for ((index, contribution) in candidates.withIndex()) {
+      checkCanceledEvery(index)
       val child = contribution.graphExtension ?: continue
       val factoryId = contribution.classId ?: continue
       nestedFactories.getOrPut(child.classId, ::mutableSetOf) += factoryId
@@ -700,34 +578,83 @@ internal class BindingIndex(
         excluded = excludes,
         // Compiler exclusions expand ChildGraph to its contributed Factory; replacements do not.
         nestedChildrenOf = { nestedFactories[it].orEmpty() },
-        replacesOf = { id -> byId[id].orEmpty().flatMapToSet { it.replaces } },
+        ensureActive = ProgressManager::checkCanceled,
+        replacesOf = { id ->
+          buildSet {
+            for ((index, contribution) in byId[id].orEmpty().withIndex()) {
+              checkCanceledEvery(index)
+              addAll(contribution.replaces)
+            }
+          }
+        },
       )
-    val selected = candidates.filter { it.classId !in plan.removed }
+    val selected = candidates.filterIndexed { index, contribution ->
+      checkCanceledEvery(index)
+      contribution.classId !in plan.removed
+    }
+    val declarationIds = mutableSetOf<GraphReference>()
+    for ((index, contribution) in selected.withIndex()) {
+      checkCanceledEvery(index)
+      contribution.declarationId?.let(declarationIds::add)
+    }
     return ContributionSelection(
-      selected,
-      selected.mapNotNullTo(mutableSetOf()) { it.declarationId },
-      plan.removed,
+      selected.toList(),
+      declarationIds.toSet(),
+      plan.removed.toSet(),
     )
   }
 
   /** The extension graphs created by [graph]'s accessors. */
   fun extensionsOf(graph: KaGraphDeclaration): List<KaGraphDeclaration> {
     if (graph.extensionCreations.isEmpty()) return emptyList()
-    return graphs.filter { candidate ->
-      candidate.isExtension && candidate.selfReferences.any { it in graph.extensionCreations }
+    return buildList {
+      for ((candidateIndex, candidate) in graphs.withIndex()) {
+        checkCanceledEvery(candidateIndex)
+        if (!candidate.isExtension) continue
+        for ((referenceIndex, reference) in candidate.selfReferences.withIndex()) {
+          checkCanceledEvery(referenceIndex)
+          if (reference in graph.extensionCreations) {
+            add(candidate)
+            break
+          }
+        }
+      }
     }
   }
 
   /** Child declarations created by the selected surface, excluding recursive parent paths. */
   fun extensionsOf(queryContext: GraphQueryContext): List<KaGraphDeclaration> {
+    return withResolutionSession { session -> session.extensionsOf(queryContext) }
+  }
+
+  internal fun extensionsOf(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+  ): List<KaGraphDeclaration> {
+    return extensionsOf(queryContext, graphComposition(session, queryContext))
+  }
+
+  internal fun extensionsOf(plan: GraphQueryPlan): List<KaGraphDeclaration> {
+    val queryContext = plan.structure.queryContext
+    return extensionsOf(queryContext, graphComposition(plan))
+  }
+
+  private fun extensionsOf(
+    queryContext: GraphQueryContext,
+    composition: GraphComposition,
+  ): List<KaGraphDeclaration> {
     val context = queryContext.graphContext
     val result = linkedSetOf<KaGraphDeclaration>()
-    for (reference in graphComposition(queryContext).extensionCreations) {
-      for (candidate in graphsByReference[reference].orEmpty()) {
+    for ((referenceIndex, reference) in composition.extensionCreations.withIndex()) {
+      checkCanceledEvery(referenceIndex)
+      for ((candidateIndex, candidate) in
+        lookups.graphsByReference[reference].orEmpty().withIndex()) {
+        checkCanceledEvery(candidateIndex)
         if (!candidate.isExtension || candidate.declarationId in context.graphIds) continue
         if (
           !isVisibleFrom(
             candidate.pointer,
+            candidate.sourceIdentity,
             null,
             queryContext.graphModule,
             queryContext.resolutionScope,
@@ -742,39 +669,238 @@ internal class BindingIndex(
 
   /** Every valid aggregation context for [graph]. Extensions can have multiple parent paths. */
   fun contextsFor(graph: KaGraphDeclaration): List<GraphContext> {
-    return graphContexts.computeIfAbsent(graph) { buildContexts(it) }
+    return withResolutionSession { session -> session.contextsFor(graph) }
+  }
+
+  internal fun contextsFor(
+    session: BindingResolutionSession,
+    graph: KaGraphDeclaration,
+  ): List<GraphContext> {
+    return session.cachedContextsFor(graph) { buildContexts(session, graph) }
   }
 
   /** Builds the module-aware query view for [context], or null if its graph disappeared. */
   fun queryContext(context: GraphContext): GraphQueryContext? {
-    graphQueryContexts[context]?.let {
+    return withResolutionSession { session -> session.queryContext(context) }
+  }
+
+  internal fun queryContext(
+    session: BindingResolutionSession,
+    context: GraphContext,
+  ): GraphQueryContext? {
+    session.plannedQuery(context)?.let {
+      return it.queryContext
+    }
+    val sourceIdentity = context.dynamicGraph?.sourceIdentity ?: context.rootGraph.sourceIdentity
+    val pointer = context.dynamicGraph?.pointer ?: context.rootGraph.pointer
+    val view = session.resolutionViewFor(sourceIdentity, pointer) ?: return null
+    val aggregateSelection =
+      selectContributions(
+        context.scopes,
+        context.excludes,
+        view.module,
+        view.resolutionScope,
+      )
+    val containers = containersFor(context, view.module, view.resolutionScope, aggregateSelection)
+    val queryContext = GraphQueryContext(context, view.module, view.resolutionScope, containers)
+    val planned = BindingResolutionSession.PlannedGraphQuery(queryContext, aggregateSelection)
+    ProgressManager.checkCanceled()
+    return session.plannedQuery(context) { planned }.queryContext
+  }
+
+  /** Includes bindings with incompatible scopes so validation can report them. */
+  internal fun validationPlan(queryContext: GraphQueryContext): GraphQueryPlan {
+    return withResolutionSession { session -> session.validationPlan(queryContext) }
+  }
+
+  internal fun validationPlan(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+  ): GraphQueryPlan {
+    val published = session.plannedQuery(queryContext.graphContext)
+    if (published == null || published.queryContext !== queryContext) {
+      return createGraphQueryPlan(session, queryContext, includeIncompatibleScopes = true)
+    }
+    val structure = structureFor(session, published)
+    return createGraphQueryPlan(structure, includeIncompatibleScopes = true)
+  }
+
+  private fun editorPlan(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+  ): GraphQueryPlan {
+    val published = session.plannedQuery(queryContext.graphContext)
+    if (published == null || published.queryContext !== queryContext) {
+      return createGraphQueryPlan(session, queryContext, includeIncompatibleScopes = false)
+    }
+    published.editorPlan?.let {
       return it
     }
-    val graphElement =
-      context.dynamicGraph?.pointer?.element ?: context.rootGraph.pointer.element ?: return null
-    val graphModule = moduleFor(graphElement) ?: return null
-    val resolutionScope = graphModule.resolutionScope()
-    val containers = containersFor(context, graphModule, resolutionScope)
-    val queryContext = GraphQueryContext(context, graphModule, resolutionScope, containers)
-    return graphQueryContexts.putIfAbsent(context, queryContext) ?: queryContext
+    val structure = structureFor(session, published)
+    val computed = createGraphQueryPlan(structure, includeIncompatibleScopes = false)
+    ProgressManager.checkCanceled()
+    published.editorPlan = computed
+    return computed
+  }
+
+  private fun structureFor(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+  ): GraphQueryStructure {
+    val published = session.plannedQuery(queryContext.graphContext)
+    if (published?.queryContext === queryContext) return structureFor(session, published)
+    return createGraphQueryStructure(session, queryContext, aggregateSelection(queryContext))
+  }
+
+  private fun structureFor(
+    session: BindingResolutionSession,
+    published: BindingResolutionSession.PlannedGraphQuery,
+  ): GraphQueryStructure {
+    published.structure?.let {
+      return it
+    }
+    val computed =
+      createGraphQueryStructure(session, published.queryContext, published.aggregateSelection)
+    ProgressManager.checkCanceled()
+    published.structure = computed
+    return computed
+  }
+
+  private fun aggregateSelection(queryContext: GraphQueryContext): ContributionSelection {
+    val context = queryContext.graphContext
+    return selectContributions(
+      context.scopes,
+      context.excludes,
+      queryContext.graphModule,
+      queryContext.resolutionScope,
+    )
+  }
+
+  private fun createGraphQueryPlan(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+    includeIncompatibleScopes: Boolean,
+  ): GraphQueryPlan {
+    val aggregateSelection = aggregateSelection(queryContext)
+    return createGraphQueryPlan(
+      session,
+      queryContext,
+      aggregateSelection,
+      includeIncompatibleScopes,
+    )
+  }
+
+  private fun createGraphQueryPlan(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+    aggregateSelection: ContributionSelection,
+    includeIncompatibleScopes: Boolean,
+  ): GraphQueryPlan {
+    val structure = createGraphQueryStructure(session, queryContext, aggregateSelection)
+    return createGraphQueryPlan(structure, includeIncompatibleScopes)
+  }
+
+  private fun createGraphQueryPlan(
+    structure: GraphQueryStructure,
+    includeIncompatibleScopes: Boolean,
+  ): GraphQueryPlan {
+    val pruning = contributionPruning(structure, includeIncompatibleScopes)
+    ProgressManager.checkCanceled()
+    return GraphQueryPlan(structure, pruning, includeIncompatibleScopes)
+  }
+
+  private fun createGraphQueryStructure(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+    aggregateSelection: ContributionSelection,
+  ): GraphQueryStructure {
+    val context = queryContext.graphContext
+    val compositionsByOwner =
+      LinkedHashMap<GraphDeclarationId, SelectedGraphComposition>(context.chain.size)
+    for ((graphIndex, graph) in context.chain.withIndex()) {
+      checkCanceledEvery(graphIndex)
+      compositionsByOwner[graph.declarationId] =
+        selectedGraphComposition(
+          session,
+          context.chain.subList(graphIndex, context.chain.size),
+          queryContext.graphModule,
+          queryContext.resolutionScope,
+        )
+    }
+
+    val currentOwner = context.graph
+    val currentSelection = checkNotNull(compositionsByOwner[currentOwner.declarationId]).selection
+    val ownContainers = buildOwnContainers(queryContext, currentOwner, currentSelection)
+    val nearestInputOwners = buildNearestFactoryInputOwners(context)
+    ProgressManager.checkCanceled()
+    return GraphQueryStructure(
+      queryContext,
+      aggregateSelection,
+      compositionsByOwner.toMap(),
+      ownContainers,
+      nearestInputOwners,
+    )
+  }
+
+  private fun buildNearestFactoryInputOwners(context: GraphContext): NearestFactoryInputOwners {
+    val dependencyOwners = mutableMapOf<KaTypeKey, GraphDeclarationId>()
+    val containerOwners = mutableMapOf<KaTypeKey, GraphDeclarationId>()
+    for ((graphIndex, graph) in context.chain.withIndex()) {
+      checkCanceledEvery(graphIndex)
+      for ((keyIndex, key) in graph.includedDependencies.withIndex()) {
+        checkCanceledEvery(keyIndex)
+        dependencyOwners.putIfAbsent(key, graph.declarationId)
+      }
+      for ((keyIndex, key) in graph.includedBindingContainers.withIndex()) {
+        checkCanceledEvery(keyIndex)
+        containerOwners.putIfAbsent(key, graph.declarationId)
+      }
+    }
+    return NearestFactoryInputOwners(dependencyOwners.toMap(), containerOwners.toMap())
   }
 
   /** Finds the current index's context for a path retained across an index rebuild. */
   fun findContext(path: GraphPath): GraphContext? {
+    return withResolutionSession { session -> session.findContext(path) }
+  }
+
+  internal fun findContext(
+    session: BindingResolutionSession,
+    path: GraphPath,
+  ): GraphContext? {
     val graphSegment = path.segments.firstOrNull() ?: return null
-    return graphs
-      .asSequence()
-      .filter { it.declarationId == graphSegment }
-      .flatMap { contextsFor(it).asSequence() }
-      .firstOrNull { it.path == path }
+    for ((graphIndex, graph) in graphs.withIndex()) {
+      checkCanceledEvery(graphIndex)
+      if (graph.declarationId != graphSegment) continue
+      for ((contextIndex, context) in contextsFor(session, graph).withIndex()) {
+        checkCanceledEvery(contextIndex)
+        if (context.path == path) return context
+      }
+    }
+    return null
   }
 
   /** Concrete child contexts created directly from [parent]'s exact graph path. */
   fun extensionContextsOf(parent: GraphContext): List<GraphContext> {
-    val queryContext = queryContext(parent) ?: return emptyList()
-    return extensionsOf(queryContext).flatMap { extension ->
-      contextsFor(extension).filter { child ->
-        child.chain.drop(1) == parent.chain && child.dynamicGraph?.id == parent.dynamicGraph?.id
+    return withResolutionSession { session -> session.extensionContextsOf(parent) }
+  }
+
+  internal fun extensionContextsOf(
+    session: BindingResolutionSession,
+    parent: GraphContext,
+  ): List<GraphContext> {
+    val queryContext = queryContext(session, parent) ?: return emptyList()
+    return buildList {
+      for ((extensionIndex, extension) in extensionsOf(session, queryContext).withIndex()) {
+        checkCanceledEvery(extensionIndex)
+        for ((contextIndex, child) in contextsFor(session, extension).withIndex()) {
+          checkCanceledEvery(contextIndex)
+          if (
+            child.chain.drop(1) == parent.chain && child.dynamicGraph?.id == parent.dynamicGraph?.id
+          ) {
+            add(child)
+          }
+        }
       }
     }
   }
@@ -785,8 +911,16 @@ internal class BindingIndex(
    * chain are reported separately by [inheritedContributionsFor].
    */
   fun contributionsFor(queryContext: GraphQueryContext): List<ContributionEntry> {
+    return withResolutionSession { session -> session.contributionsFor(queryContext) }
+  }
+
+  internal fun contributionsFor(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+  ): List<ContributionEntry> {
+    val plan = editorPlan(session, queryContext)
     val context = queryContext.graphContext
-    val removedOrigins = removedContributionOrigins(queryContext)
+    val removedOrigins = plan.pruning.removedOrigins
     return contributionsForScopes(context.graph.scopeKeys).filter {
       it.classId !in context.excludes &&
         it.classId !in removedOrigins &&
@@ -799,9 +933,17 @@ internal class BindingIndex(
    * itself: matched against ancestor scopes only, minus excluded. Empty for non-extension graphs.
    */
   fun inheritedContributionsFor(queryContext: GraphQueryContext): List<ContributionEntry> {
+    return withResolutionSession { session -> session.inheritedContributionsFor(queryContext) }
+  }
+
+  internal fun inheritedContributionsFor(
+    session: BindingResolutionSession,
+    queryContext: GraphQueryContext,
+  ): List<ContributionEntry> {
+    val plan = editorPlan(session, queryContext)
     val context = queryContext.graphContext
     val inheritedScopes = context.scopes - context.graph.scopeKeys
-    val removedOrigins = removedContributionOrigins(queryContext)
+    val removedOrigins = plan.pruning.removedOrigins
     return contributionsForScopes(inheritedScopes).filter {
       it.classId !in context.excludes &&
         it.classId !in removedOrigins &&
@@ -810,29 +952,39 @@ internal class BindingIndex(
     }
   }
 
-  private fun buildContexts(graph: KaGraphDeclaration): List<GraphContext> {
-    return buildChains(graph, visited = setOf(graph)).flatMap { chain ->
-      buildList {
-        add(buildContext(chain, dynamicGraph = null))
+  private fun buildContexts(
+    session: BindingResolutionSession,
+    graph: KaGraphDeclaration,
+  ): List<GraphContext> {
+    return buildList {
+      for ((chainIndex, chain) in buildChains(session, graph, visited = setOf(graph)).withIndex()) {
+        checkCanceledEvery(chainIndex)
+        add(buildContext(session, chain, dynamicGraph = null))
         val root = chain.last()
         val rootReference =
           root.classId?.let { classId -> GraphReference(classId, root.pointer.virtualFile) }
-        for (dynamicGraph in rootReference?.let(dynamicGraphsByTarget::get).orEmpty()) {
-          add(buildContext(chain, dynamicGraph))
+        for ((dynamicIndex, dynamicGraph) in
+          rootReference?.let(lookups.dynamicGraphsByTarget::get).orEmpty().withIndex()) {
+          checkCanceledEvery(dynamicIndex)
+          add(buildContext(session, chain, dynamicGraph))
         }
       }
     }
   }
 
   private fun buildChains(
+    session: BindingResolutionSession,
     graph: KaGraphDeclaration,
     visited: Set<KaGraphDeclaration>,
   ): List<List<KaGraphDeclaration>> {
     if (!graph.isExtension) return listOf(listOf(graph))
 
     val parents = linkedSetOf<KaGraphDeclaration>()
-    for (reference in graph.selfReferences) {
-      for (candidate in potentialParentsByReference[reference].orEmpty()) {
+    for ((referenceIndex, reference) in graph.selfReferences.withIndex()) {
+      checkCanceledEvery(referenceIndex)
+      for ((candidateIndex, candidate) in
+        lookups.potentialParentsByReference[reference].orEmpty().withIndex()) {
+        checkCanceledEvery(candidateIndex)
         if (candidate !in visited) parents += candidate
       }
     }
@@ -841,12 +993,29 @@ internal class BindingIndex(
     val chains = mutableListOf<List<KaGraphDeclaration>>()
     for (parent in parents) {
       ProgressManager.checkCanceled()
-      val parentChains = buildChains(parent, visited + parent)
-      for (parentChain in parentChains) {
-        val module = moduleFor(parentChain.last().pointer.element) ?: continue
-        val resolutionScope = module.resolutionScope()
-        if (!isVisibleFrom(graph.pointer, null, module, resolutionScope)) continue
-        val composition = selectedGraphComposition(parentChain, module, resolutionScope).composition
+      val parentChains = buildChains(session, parent, visited + parent)
+      for ((chainIndex, parentChain) in parentChains.withIndex()) {
+        checkCanceledEvery(chainIndex)
+        val root = parentChain.last()
+        val view = session.resolutionViewFor(root.sourceIdentity, root.pointer) ?: continue
+        if (
+          !isVisibleFrom(
+            graph.pointer,
+            graph.sourceIdentity,
+            null,
+            view.module,
+            view.resolutionScope,
+          )
+        )
+          continue
+        val composition =
+          selectedGraphComposition(
+              session,
+              parentChain,
+              view.module,
+              view.resolutionScope,
+            )
+            .composition
         if (composition.extensionCreations.none(graph.selfReferences::contains)) continue
         chains += listOf(graph) + parentChain
       }
@@ -855,34 +1024,64 @@ internal class BindingIndex(
   }
 
   private fun buildContext(
+    session: BindingResolutionSession,
     chain: List<KaGraphDeclaration>,
     dynamicGraph: DynamicGraphCall?,
   ): GraphContext {
-    val scopes = chain.flatMapToSet { it.scopeKeys }
-    val excludes = chain.flatMapToSet { it.excludes }
-    // Supertype members merge into the graph, so their classes gate membership like the graph
-    val graphClassIds = chain.flatMapToSet { it.selfIds + it.supertypeIds }
-    val includedBindingContainers = buildSet {
-      chain.flatMapTo(this) { it.includedBindingContainers }
-      addAll(dynamicGraph?.containerKeys.orEmpty())
+    fun <T> collectFromChain(values: (KaGraphDeclaration) -> Iterable<T>): Set<T> {
+      var workIndex = 0
+      return buildSet {
+        for (graph in chain) {
+          checkCanceledEvery(workIndex++)
+          for (value in values(graph)) {
+            checkCanceledEvery(workIndex++)
+            add(value)
+          }
+        }
+      }
     }
-    val includedDependencies = chain.flatMapToSet { it.includedDependencies }
-    val graphIds = chain.mapTo(mutableSetOf()) { it.declarationId }
-    val dynamicGraphElement = dynamicGraph?.pointer?.element
+
+    val scopes = collectFromChain { it.scopeKeys }
+    val excludes = collectFromChain { it.excludes }
+    // Supertype members merge into the graph, so their classes gate membership like the graph
+    val graphClassIds = collectFromChain { it.selfIds + it.supertypeIds }
+    var containerIndex = 0
+    val includedBindingContainers = buildSet {
+      for (graph in chain) {
+        checkCanceledEvery(containerIndex++)
+        for (container in graph.includedBindingContainers) {
+          checkCanceledEvery(containerIndex++)
+          add(container)
+        }
+      }
+      for (container in dynamicGraph?.containerKeys.orEmpty()) {
+        checkCanceledEvery(containerIndex++)
+        add(container)
+      }
+    }
+    val includedDependencies = collectFromChain { it.includedDependencies }
+    val graphIds = buildSet {
+      for ((index, graph) in chain.withIndex()) {
+        checkCanceledEvery(index)
+        add(graph.declarationId)
+      }
+    }
     val daggerAnvilInteropEnabled =
-      if (dynamicGraphElement == null) {
+      if (dynamicGraph == null) {
         chain.last().daggerAnvilInteropEnabled
       } else {
-        dynamicGraphElement.metroIdeState().options.enableDaggerAnvilInterop
+        session
+          .resolutionViewFor(dynamicGraph.sourceIdentity, dynamicGraph.pointer)
+          ?.daggerAnvilInteropEnabled ?: chain.last().daggerAnvilInteropEnabled
       }
     return GraphContext(
       chain = chain,
       scopes = scopes,
-      scopingAnnotations = chain.flatMapToSet { it.scopingAnnotations },
+      scopingAnnotations = collectFromChain { it.scopingAnnotations },
       excludes = excludes,
       includedBindingContainers = includedBindingContainers,
       includedDependencies = includedDependencies,
-      injectedMemberOwnerIds = chain.flatMapToSet { it.injectedMemberOwnerIds },
+      injectedMemberOwnerIds = collectFromChain { it.injectedMemberOwnerIds },
       daggerAnvilInteropEnabled = daggerAnvilInteropEnabled,
       graphIds = graphIds,
       graphClassIds = graphClassIds,
@@ -894,20 +1093,31 @@ internal class BindingIndex(
     context: GraphContext,
     useSiteModule: KaModule,
     resolutionScope: DeclarationResolutionScope,
+    aggregateSelection: ContributionSelection,
   ): Set<ClassId> {
     // Containers are declared on the graphs, contributed into scope, or transitively included.
-    val containerRoots = context.chain.flatMapTo(hashSetOf()) { it.bindingContainers }
-    for (containerKey in context.includedBindingContainers) {
+    val containerRoots = hashSetOf<ClassId>()
+    for ((graphIndex, graph) in context.chain.withIndex()) {
+      checkCanceledEvery(graphIndex)
+      containerRoots += graph.bindingContainers
+    }
+    for ((containerKeyIndex, containerKey) in context.includedBindingContainers.withIndex()) {
+      checkCanceledEvery(containerKeyIndex)
       val containerId = containerKey.type.classId ?: continue
-      visibleContainers(containerId, useSiteModule, resolutionScope).forEach { container ->
-        container.includes.forEach(containerRoots::add)
+      for ((containerIndex, container) in
+        visibleContainers(containerId, useSiteModule, resolutionScope).withIndex()) {
+        checkCanceledEvery(containerIndex)
+        for ((includeIndex, included) in container.includes.withIndex()) {
+          checkCanceledEvery(includeIndex)
+          containerRoots += included
+        }
       }
     }
-    selectContributions(context.scopes, context.excludes, useSiteModule, resolutionScope)
-      .entries
-      .asSequence()
-      .filter { it.classId != null && it.classId in containersById }
-      .mapTo(containerRoots) { it.classId!! }
+    for ((index, contribution) in aggregateSelection.entries.withIndex()) {
+      checkCanceledEvery(index)
+      val classId = contribution.classId ?: continue
+      if (classId in lookups.containersById) containerRoots += classId
+    }
 
     return resolveContainerClosure(containerRoots, useSiteModule, resolutionScope)
   }
@@ -921,40 +1131,59 @@ internal class BindingIndex(
     graph: KaGraphDeclaration,
     queryContext: GraphQueryContext,
   ): Set<ClassId> {
+    return withResolutionSession { session -> session.graphOwnContainers(graph, queryContext) }
+  }
+
+  internal fun graphOwnContainers(
+    session: BindingResolutionSession,
+    graph: KaGraphDeclaration,
+    queryContext: GraphQueryContext,
+  ): Set<ClassId> = graphOwnContainers(graph, structureFor(session, queryContext))
+
+  internal fun graphOwnContainers(
+    graph: KaGraphDeclaration,
+    plan: GraphQueryPlan,
+  ): Set<ClassId> = graphOwnContainers(graph, plan.structure)
+
+  private fun graphOwnContainers(
+    graph: KaGraphDeclaration,
+    structure: GraphQueryStructure,
+  ): Set<ClassId> {
     val ownerId = graph.declarationId
-    ownContainersByContext[queryContext]?.get(ownerId)?.let {
-      return it
-    }
+    val queryContext = structure.queryContext
     val context = queryContext.graphContext
     require(ownerId in context.graphIds) { "Graph is not in the requested parent path" }
-    val byOwner = ownContainersByContext.computeIfAbsent(queryContext) { ConcurrentHashMap() }
-    return byOwner.computeIfAbsent(ownerId) {
-      val chain = context.chain
-      val graphIndex = chain.indexOfFirst { candidate -> candidate.declarationId == ownerId }
-      check(graphIndex >= 0) { "Graph is not in the requested parent path" }
-      val ownerChain = chain.subList(graphIndex, chain.size)
-      val owner = ownerChain.first()
-      val roots = hashSetOf<ClassId>()
-      roots += owner.bindingContainers
-      for (containerKey in owner.includedBindingContainers) {
+    if (ownerId == context.graph.declarationId) return structure.currentOwnerOwnContainers
+
+    val owner = context.chain.first { candidate -> candidate.declarationId == ownerId }
+    val selection = checkNotNull(structure.compositionsByOwner[ownerId]).selection
+    return buildOwnContainers(queryContext, owner, selection)
+  }
+
+  private fun buildOwnContainers(
+    queryContext: GraphQueryContext,
+    owner: KaGraphDeclaration,
+    selection: ContributionSelection,
+  ): Set<ClassId> {
+    val context = queryContext.graphContext
+    val roots = hashSetOf<ClassId>()
+    roots += owner.bindingContainers
+    for ((index, containerKey) in owner.includedBindingContainers.withIndex()) {
+      checkCanceledEvery(index)
+      containerKey.type.classId?.let(roots::add)
+    }
+    if (owner.declarationId == context.rootGraph.declarationId) {
+      for ((index, containerKey) in context.dynamicGraph?.containerKeys.orEmpty().withIndex()) {
+        checkCanceledEvery(index)
         containerKey.type.classId?.let(roots::add)
       }
-      if (owner.declarationId == context.rootGraph.declarationId) {
-        for (containerKey in context.dynamicGraph?.containerKeys.orEmpty()) {
-          containerKey.type.classId?.let(roots::add)
-        }
-      }
-      contributionSelection(
-          ownerChain,
-          queryContext.graphModule,
-          queryContext.resolutionScope,
-        )
-        .entries
-        .asSequence()
-        .filter { it.classId != null && it.classId in containersById }
-        .mapTo(roots) { it.classId!! }
-      resolveContainerClosure(roots, queryContext.graphModule, queryContext.resolutionScope)
     }
+    for ((index, contribution) in selection.entries.withIndex()) {
+      checkCanceledEvery(index)
+      val classId = contribution.classId ?: continue
+      if (classId in lookups.containersById) roots += classId
+    }
+    return resolveContainerClosure(roots, queryContext.graphModule, queryContext.resolutionScope)
   }
 
   /** Whether [binding] belongs to this graph itself rather than one of its ancestors. */
@@ -962,6 +1191,27 @@ internal class BindingIndex(
     binding: KaBinding,
     queryContext: GraphQueryContext,
   ): Boolean {
+    return withResolutionSession { session ->
+      session.isBindingOwnedByCurrentGraph(binding, queryContext)
+    }
+  }
+
+  internal fun isBindingOwnedByCurrentGraph(
+    session: BindingResolutionSession,
+    binding: KaBinding,
+    queryContext: GraphQueryContext,
+  ): Boolean = isBindingOwnedByCurrentGraph(binding, structureFor(session, queryContext))
+
+  internal fun isBindingOwnedByCurrentGraph(
+    binding: KaBinding,
+    plan: GraphQueryPlan,
+  ): Boolean = isBindingOwnedByCurrentGraph(binding, plan.structure)
+
+  private fun isBindingOwnedByCurrentGraph(
+    binding: KaBinding,
+    structure: GraphQueryStructure,
+  ): Boolean {
+    val queryContext = structure.queryContext
     val context = queryContext.graphContext
     val graph = context.graph
     val ownerGraphId = binding.ownerGraphId
@@ -980,9 +1230,11 @@ internal class BindingIndex(
 
     val containerId = binding.containerId
     if (containerId != null) {
+      val composition =
+        checkNotNull(selectedGraphComposition(structure, graph.declarationId)).composition
       return containerId in graph.selfIds ||
-        graphComposition(queryContext).supertypeDeclarations.any { it.classId == containerId } ||
-        containerId in graphOwnContainers(graph, queryContext)
+        composition.supertypeDeclarations.any { it.classId == containerId } ||
+        containerId in structure.currentOwnerOwnContainers
     }
 
     if (binding.contributionScopes.isNotEmpty()) {
@@ -994,27 +1246,58 @@ internal class BindingIndex(
 
   /** Whether an ancestor can resolve [key] through one of its private bindings. */
   fun hasPrivateAncestorBinding(key: KaTypeKey, queryContext: GraphQueryContext): Boolean {
-    val candidates = bindingsByKey[key].orEmpty()
-    if (candidates.none { it.isGraphPrivate }) {
+    return withResolutionSession { session ->
+      session.hasPrivateAncestorBinding(key, queryContext)
+    }
+  }
+
+  internal fun hasPrivateAncestorBinding(
+    session: BindingResolutionSession,
+    key: KaTypeKey,
+    queryContext: GraphQueryContext,
+  ): Boolean {
+    return hasPrivateAncestorBinding(session, key, structureFor(session, queryContext))
+  }
+
+  private fun hasPrivateAncestorBinding(
+    session: BindingResolutionSession,
+    key: KaTypeKey,
+    structure: GraphQueryStructure,
+  ): Boolean {
+    val candidates = lookups.bindingsByKey[key].orEmpty()
+    val hasPrivateCandidate =
+      candidates.withIndex().any { (index, binding) ->
+        checkCanceledEvery(index)
+        binding.isGraphPrivate
+      }
+    if (!hasPrivateCandidate) {
       return false
     }
 
-    val context = queryContext.graphContext
+    val context = structure.queryContext.graphContext
     val chain = context.chain
     for (ancestorIndex in 1 until chain.size) {
+      checkCanceledEvery(ancestorIndex - 1)
+      val ancestorSegments = ArrayList<GraphDeclarationId>(chain.size - ancestorIndex)
+      for (chainIndex in ancestorIndex until chain.size) {
+        checkCanceledEvery(chainIndex - ancestorIndex)
+        ancestorSegments += chain[chainIndex].declarationId
+      }
       val ancestorPath =
         GraphPath(
-          chain.drop(ancestorIndex).map { it.declarationId },
+          ancestorSegments,
           context.dynamicGraph?.id,
         )
-      val ancestorContext = findContext(ancestorPath) ?: continue
-      val ancestorQueryContext = queryContext(ancestorContext) ?: continue
-      for (binding in candidates) {
+      val ancestorContext = findContext(session, ancestorPath) ?: continue
+      val ancestorQueryContext = queryContext(session, ancestorContext) ?: continue
+      val ancestorStructure = structureFor(session, ancestorQueryContext)
+      for ((candidateIndex, binding) in candidates.withIndex()) {
+        checkCanceledEvery(candidateIndex)
         if (
           binding.isGraphPrivate &&
             isBindingCandidateInContext(
               binding,
-              ancestorQueryContext,
+              ancestorStructure,
               includeIncompatibleScopes = true,
             )
         ) {
@@ -1033,15 +1316,21 @@ internal class BindingIndex(
     val containers = hashSetOf<ClassId>()
     val visitedDeclarations = hashSetOf<GraphReference>()
     val queue = ArrayDeque(containerRoots)
+    var workIndex = 0
     while (queue.isNotEmpty()) {
+      checkCanceledEvery(workIndex++)
       val id = queue.removeFirst()
       containers += id
       for (container in visibleContainers(id, useSiteModule, resolutionScope)) {
+        checkCanceledEvery(workIndex++)
         if (!visitedDeclarations.add(container.declarationId)) continue
-        container.includes.forEach(queue::add)
+        for (included in container.includes) {
+          checkCanceledEvery(workIndex++)
+          queue.add(included)
+        }
       }
     }
-    return containers
+    return containers.toSet()
   }
 
   private fun visibleContainers(
@@ -1049,8 +1338,14 @@ internal class BindingIndex(
     useSiteModule: KaModule,
     resolutionScope: DeclarationResolutionScope,
   ): List<BindingContainerEntry> {
-    return containersById[classId].orEmpty().filter { container ->
-      isVisibleFrom(container.pointer, null, useSiteModule, resolutionScope)
+    return lookups.containersById[classId].orEmpty().filter { container ->
+      isVisibleFrom(
+        container.pointer,
+        container.sourceIdentity,
+        null,
+        useSiteModule,
+        resolutionScope,
+      )
     }
   }
 
@@ -1060,7 +1355,13 @@ internal class BindingIndex(
     resolutionScope: DeclarationResolutionScope?,
   ): List<KaBinding> {
     return candidateBindingsFor(consumer).filter {
-      isVisibleFrom(it.pointer, it.hintAvailability, useSiteModule, resolutionScope)
+      isVisibleFrom(
+        it.pointer,
+        bindingSourceIdentity(it),
+        it.hintAvailability,
+        useSiteModule,
+        resolutionScope,
+      )
     }
   }
 
@@ -1068,13 +1369,14 @@ internal class BindingIndex(
     // Assisted targets are kept in the index for graph diagnostics, but are never ordinary
     // injectable bindings for editor resolution or navigation.
     val direct =
-      bindingsByKey[consumer.key]
+      lookups.bindingsByKey[consumer.key]
         .orEmpty()
         .withoutDuplicateAssistedFactories(consumer.key)
         .filterNot {
           it.isValidationOnlyAssistedTarget()
         }
-    val contributions = consumer.multibindingId?.let { contributionsByMultibindingId[it] }.orEmpty()
+    val contributions =
+      consumer.multibindingId?.let { lookups.contributionsByMultibindingId[it] }.orEmpty()
     return direct + contributions
   }
 
@@ -1082,9 +1384,27 @@ internal class BindingIndex(
     consumer: ConsumerEntry,
     queryContext: GraphQueryContext,
   ): Boolean {
+    return withResolutionSession { session ->
+      session.isConsumerInContext(consumer, queryContext)
+    }
+  }
+
+  internal fun isConsumerInContext(
+    session: BindingResolutionSession,
+    consumer: ConsumerEntry,
+    queryContext: GraphQueryContext,
+  ): Boolean = isConsumerInContext(consumer, editorPlan(session, queryContext))
+
+  private fun isConsumerInContext(
+    consumer: ConsumerEntry,
+    plan: GraphQueryPlan,
+  ): Boolean {
+    val structure = plan.structure
+    val queryContext = structure.queryContext
     if (
       !isVisibleFrom(
         consumer.pointer,
+        consumer.sourceIdentity,
         hintAvailability = null,
         useSiteModule = queryContext.graphModule,
         resolutionScope = queryContext.resolutionScope,
@@ -1093,11 +1413,11 @@ internal class BindingIndex(
       return false
     }
     val context = queryContext.graphContext
-    if (!isContributedConsumerActive(consumer, queryContext)) return false
+    if (!isContributedConsumerActive(consumer, structure)) return false
 
     val isUnspecializedContainerConsumer = consumer.graphId == null && consumer.containerId != null
     if (isUnspecializedContainerConsumer) {
-      if (isSupersededInheritedConsumer(consumer, queryContext)) return false
+      if (isSupersededInheritedConsumer(consumer, structure)) return false
     }
 
     val originClassId = consumer.originClassId
@@ -1105,8 +1425,8 @@ internal class BindingIndex(
       if (originClassId in context.excludes) return false
       // A replaced origin's consumers stay live only while it still has surviving bindings
       if (
-        originClassId in replacedOrigins(queryContext) &&
-          !hasOriginBindingInContext(originClassId, queryContext)
+        originClassId in plan.pruning.replacedOrigins &&
+          !hasOriginBindingInContext(originClassId, plan)
       ) {
         return false
       }
@@ -1116,7 +1436,7 @@ internal class BindingIndex(
     if (graphId != null) {
       if (graphId !in context.graphIds) return false
       if (consumer.graphRequestKind == null || consumer.isOptional) return true
-      val selected = selectedGraphComposition(queryContext, graphId) ?: return false
+      val selected = selectedGraphComposition(structure, graphId) ?: return false
       return !isImplementedGraphRequest(consumer, selected.implementedRequests)
     }
 
@@ -1125,10 +1445,10 @@ internal class BindingIndex(
       if (memberOwnerClassId in context.excludes) return false
       return memberOwnerClassId in context.injectedMemberOwnerIds ||
         context.chain.any { graph ->
-          memberOwnerClassId in graphComposition(queryContext, graph).injectedMemberOwnerIds
+          memberOwnerClassId in graphComposition(plan, graph).injectedMemberOwnerIds
         } ||
-        bindingsByMemberOwner[memberOwnerClassId].orEmpty().any { binding ->
-          isBindingInContext(binding, queryContext)
+        lookups.bindingsByMemberOwner[memberOwnerClassId].orEmpty().any { binding ->
+          isBindingInContext(binding, plan)
         }
     }
 
@@ -1139,7 +1459,7 @@ internal class BindingIndex(
 
     val containerId = consumer.containerId
     if (containerId != null) {
-      return isGraphMemberContainer(containerId, consumer.pointer.virtualFile, queryContext) ||
+      return isGraphMemberContainer(containerId, consumer.pointer.virtualFile, structure) ||
         containerId in queryContext.containers
     }
 
@@ -1148,7 +1468,7 @@ internal class BindingIndex(
     }
 
     if (originClassId != null) {
-      return hasOriginBindingInContext(originClassId, queryContext)
+      return hasOriginBindingInContext(originClassId, plan)
     }
 
     return true
@@ -1156,34 +1476,42 @@ internal class BindingIndex(
 
   private fun hasOriginBindingInContext(
     originClassId: ClassId,
-    queryContext: GraphQueryContext,
+    plan: GraphQueryPlan,
   ): Boolean {
-    return bindingsByOrigin[originClassId].orEmpty().any { binding ->
-      isBindingInContext(binding, queryContext)
+    return lookups.bindingsByOrigin[originClassId].orEmpty().any { binding ->
+      isBindingInContext(binding, plan)
     }
   }
 
   private fun isBindingInContext(
     entry: KaBinding,
-    queryContext: GraphQueryContext,
-    includeIncompatibleScopes: Boolean = false,
+    plan: GraphQueryPlan,
   ): Boolean {
-    if (!isBindingCandidateInContext(entry, queryContext, includeIncompatibleScopes)) return false
+    if (
+      !isBindingCandidateInContext(
+        entry,
+        plan.structure,
+        plan.includeIncompatibleScopes,
+      )
+    ) {
+      return false
+    }
     // Replaces removes the origin's contributions only; its own injectable type stays available
     // (a replacing stub can inject the replaced implementation directly).
     if (entry.contributionScopes.isEmpty()) return true
     val originClassId = entry.originClassId ?: return true
-    if (originClassId in replacedOrigins(queryContext, includeIncompatibleScopes)) return false
-    return entry !in lowerPriorityBindings(queryContext, includeIncompatibleScopes)
+    if (originClassId in plan.pruning.replacedOrigins) return false
+    return entry !in plan.pruning.lowerPriorityBindings
   }
 
   private fun isBindingCandidateInContext(
     entry: KaBinding,
-    queryContext: GraphQueryContext,
-    includeIncompatibleScopes: Boolean = false,
+    structure: GraphQueryStructure,
+    includeIncompatibleScopes: Boolean,
   ): Boolean {
+    val queryContext = structure.queryContext
     if (!isVisibleFrom(entry, queryContext)) return false
-    if (!isContributedBindingActive(entry, queryContext)) return false
+    if (!isContributedBindingActive(entry, structure)) return false
     val isUnspecializedContainerCallable =
       entry.ownerGraphId == null &&
         entry.containerId != null &&
@@ -1195,9 +1523,9 @@ internal class BindingIndex(
           else -> false
         }
     if (isUnspecializedContainerCallable) {
-      if (isSupersededInheritedBinding(entry, queryContext)) return false
+      if (isSupersededInheritedBinding(entry, structure)) return false
     }
-    if (entry.isGraphPrivate && !isBindingOwnedByCurrentGraph(entry, queryContext)) return false
+    if (entry.isGraphPrivate && !isBindingOwnedByCurrentGraph(entry, structure)) return false
     val context = queryContext.graphContext
     if (isSupersededByDynamicBinding(entry, context)) return false
     val ownerGraphId = entry.ownerGraphId
@@ -1207,10 +1535,10 @@ internal class BindingIndex(
           ownerGraphId in context.graphIds ||
             context.graphIds.any { it in entry.additionalOwnerGraphIds }
         if (!ownedByContext) return false
-        if (isSupersededByNearerFactoryInput(entry, context)) return false
+        if (isSupersededByNearerFactoryInput(entry, structure)) return false
       } else {
         if (ownerGraphId !in context.graphIds) return false
-        if (isSupersededByNearerInheritedBinding(entry, queryContext)) return false
+        if (isSupersededByNearerInheritedBinding(entry, structure)) return false
       }
     }
     if (entry.originClassId != null && entry.originClassId in context.excludes) return false
@@ -1243,7 +1571,7 @@ internal class BindingIndex(
         } else {
           entry.contributionScopes.isNotEmpty() ||
             containerId == null ||
-            isGraphMemberContainer(containerId, entry.pointer.virtualFile, queryContext) ||
+            isGraphMemberContainer(containerId, entry.pointer.virtualFile, structure) ||
             containerId in queryContext.containers
         }
       }
@@ -1279,10 +1607,10 @@ internal class BindingIndex(
       return false
     }
     if (binding is KaBinding.BoundInstance && binding.isBindingContainerInput) {
-      val source = pointerIdentity(binding.pointer)
+      val source = bindingSourceIdentity(binding)
       val isDynamicInput =
         dynamicGraph.containerInputs.any { input ->
-          input.typeKey == binding.typeKey && pointerIdentity(input.pointer) == source
+          input.typeKey == binding.typeKey && bindingSourceIdentity(input) == source
         }
       if (isDynamicInput) return false
     }
@@ -1291,21 +1619,21 @@ internal class BindingIndex(
 
   private fun isContributedBindingActive(
     binding: KaBinding,
-    queryContext: GraphQueryContext,
+    structure: GraphQueryStructure,
   ): Boolean {
-    if (binding !in contributedBindingOwners) return true
+    if (binding !in lookups.contributedBindingOwners) return true
     val ownerId = binding.ownerGraphId ?: return false
-    val selected = selectedGraphComposition(queryContext, ownerId) ?: return false
+    val selected = selectedGraphComposition(structure, ownerId) ?: return false
     return binding in selected.bindings
   }
 
   private fun isContributedConsumerActive(
     consumer: ConsumerEntry,
-    queryContext: GraphQueryContext,
+    structure: GraphQueryStructure,
   ): Boolean {
     val contribution = consumer.graphContribution ?: return true
     val ownerId = consumer.graphId ?: return false
-    val selected = selectedGraphComposition(queryContext, ownerId) ?: return false
+    val selected = selectedGraphComposition(structure, ownerId) ?: return false
     return contribution in selected.contributionIds
   }
 
@@ -1316,37 +1644,41 @@ internal class BindingIndex(
   ): Boolean {
     if (consumer.graphRequestKind == null || consumer.isOptional) return false
     if (implementedRequests.isEmpty()) return false
-    val source = pointerIdentity(consumer.pointer) ?: return false
+    val source = consumer.sourceIdentity ?: return false
     return source in implementedRequests
   }
 
   private fun isGraphMemberContainer(
     containerId: ClassId,
     file: VirtualFile?,
-    queryContext: GraphQueryContext,
+    structure: GraphQueryStructure,
   ): Boolean {
+    val queryContext = structure.queryContext
     val context = queryContext.graphContext
     if (containerId in context.graphClassIds) return true
     val reference = GraphReference(containerId, file)
-    return context.chain.any { graph ->
-      reference in graphComposition(queryContext, graph).supertypeDeclarations
+    for ((index, graph) in context.chain.withIndex()) {
+      checkCanceledEvery(index)
+      val composition = selectedGraphComposition(structure, graph.declarationId)?.composition
+      if (composition != null && reference in composition.supertypeDeclarations) return true
     }
+    return false
   }
 
   private fun isSupersededInheritedBinding(
     binding: KaBinding,
-    queryContext: GraphQueryContext,
+    structure: GraphQueryStructure,
   ): Boolean {
-    val pointerIdentity = pointerIdentity(binding.pointer) ?: return false
-    for (graphId in queryContext.graphContext.graphIds) {
+    val pointerIdentity = bindingSourceIdentity(binding) ?: return false
+    for ((graphIndex, graphId) in structure.queryContext.graphContext.graphIds.withIndex()) {
+      checkCanceledEvery(graphIndex)
       val identity = SpecializedDeclarationIdentity(graphId, pointerIdentity, binding.javaClass)
-      if (identity in specializedDeclarationIdentities) return true
-      if (
-        contributedSpecializedDeclarations[identity].orEmpty().any {
-          isContributedBindingActive(it, queryContext)
-        }
-      )
-        return true
+      if (identity in lookups.specializedDeclarationIdentities) return true
+      for ((candidateIndex, candidate) in
+        lookups.contributedSpecializedDeclarations[identity].orEmpty().withIndex()) {
+        checkCanceledEvery(candidateIndex)
+        if (isContributedBindingActive(candidate, structure)) return true
+      }
     }
     return false
   }
@@ -1361,26 +1693,13 @@ internal class BindingIndex(
   /** A child factory input replaces an ancestor's separate parameter of the same type. */
   private fun isSupersededByNearerFactoryInput(
     binding: KaBinding.BoundInstance,
-    context: GraphContext,
+    structure: GraphQueryStructure,
   ): Boolean {
+    val context = structure.queryContext.graphContext
     if (context.chain.size < 2) return false
     if (!binding.isGraphInput && !binding.isBindingContainerInput) return false
 
-    val inputOwners =
-      nearestFactoryInputOwners.computeIfAbsent(context) {
-        val dependencyOwners = mutableMapOf<KaTypeKey, GraphDeclarationId>()
-        val containerOwners = mutableMapOf<KaTypeKey, GraphDeclarationId>()
-        for (graph in context.chain) {
-          ProgressManager.checkCanceled()
-          for (key in graph.includedDependencies) {
-            dependencyOwners.putIfAbsent(key, graph.declarationId)
-          }
-          for (key in graph.includedBindingContainers) {
-            containerOwners.putIfAbsent(key, graph.declarationId)
-          }
-        }
-        NearestFactoryInputOwners(dependencyOwners, containerOwners)
-      }
+    val inputOwners = structure.nearestFactoryInputOwners
     val nearestOwner =
       if (binding.isGraphInput) {
         inputOwners.dependencies[binding.typeKey]
@@ -1393,26 +1712,29 @@ internal class BindingIndex(
   /** The same inherited declaration belongs to the nearest graph that can expose it. */
   private fun isSupersededByNearerInheritedBinding(
     binding: KaBinding,
-    queryContext: GraphQueryContext,
+    structure: GraphQueryStructure,
   ): Boolean {
+    val queryContext = structure.queryContext
     val context = queryContext.graphContext
     if (context.chain.size < 2) return false
     val ownerGraphId = binding.ownerGraphId ?: return false
-    val sourceIdentity = pointerIdentity(binding.pointer) ?: return false
-    for (graph in context.chain) {
-      ProgressManager.checkCanceled()
+    val sourceIdentity = bindingSourceIdentity(binding) ?: return false
+    for ((graphIndex, graph) in context.chain.withIndex()) {
+      checkCanceledEvery(graphIndex)
       val graphId = graph.declarationId
       if (graphId == ownerGraphId) return false
       val identity =
         SpecializedBindingIdentity(graphId, sourceIdentity, binding.javaClass, binding.typeKey)
       // An intermediate graph's private declaration cannot hide a public farther ancestor from a
       // grandchild. A private declaration is only available to the graph that owns it.
-      if (identity in specializedBindingIdentities) {
+      if (identity in lookups.specializedBindingIdentities) {
         if (graphId == context.graph.declarationId) return true
-        if (specializedBindingIdentities[identity] == true) return true
+        if (lookups.specializedBindingIdentities[identity] == true) return true
       }
-      for (candidate in contributedSpecializedBindings[identity].orEmpty()) {
-        if (!isContributedBindingActive(candidate, queryContext)) continue
+      for ((candidateIndex, candidate) in
+        lookups.contributedSpecializedBindings[identity].orEmpty().withIndex()) {
+        checkCanceledEvery(candidateIndex)
+        if (!isContributedBindingActive(candidate, structure)) continue
         if (graphId == context.graph.declarationId || !candidate.isGraphPrivate) return true
       }
     }
@@ -1421,18 +1743,18 @@ internal class BindingIndex(
 
   private fun isSupersededInheritedConsumer(
     consumer: ConsumerEntry,
-    queryContext: GraphQueryContext,
+    structure: GraphQueryStructure,
   ): Boolean {
-    val pointerIdentity = pointerIdentity(consumer.pointer) ?: return false
-    for (graphId in queryContext.graphContext.graphIds) {
+    val pointerIdentity = consumer.sourceIdentity ?: return false
+    for ((graphIndex, graphId) in structure.queryContext.graphContext.graphIds.withIndex()) {
+      checkCanceledEvery(graphIndex)
       val identity = SpecializedConsumerIdentity(graphId, pointerIdentity)
-      if (identity in specializedConsumerIdentities) return true
-      if (
-        contributedSpecializedConsumers[identity].orEmpty().any {
-          isContributedConsumerActive(it, queryContext)
-        }
-      )
-        return true
+      if (identity in lookups.specializedConsumerIdentities) return true
+      for ((candidateIndex, candidate) in
+        lookups.contributedSpecializedConsumers[identity].orEmpty().withIndex()) {
+        checkCanceledEvery(candidateIndex)
+        if (isContributedConsumerActive(candidate, structure)) return true
+      }
     }
     return false
   }
@@ -1441,9 +1763,9 @@ internal class BindingIndex(
     requestedKey: KaTypeKey? = null
   ): List<T> {
     if (size < 2) return this
-    if (requestedKey != null && requestedKey !in duplicatedAssistedFactoryKeys) return this
+    if (requestedKey != null && requestedKey !in lookups.duplicatedAssistedFactoryKeys) return this
     if (requestedKey == null && none { it is KaBinding.AssistedFactory }) return this
-    if (requestedKey == null && duplicatedAssistedFactoryKeys.isEmpty()) return this
+    if (requestedKey == null && lookups.duplicatedAssistedFactoryKeys.isEmpty()) return this
     val seen = HashSet<Triple<ClassId?, VirtualFile?, KaTypeKey>>()
     return filter { binding ->
       binding !is KaBinding.AssistedFactory ||
@@ -1452,9 +1774,41 @@ internal class BindingIndex(
   }
 
   internal fun pointerIdentity(pointer: SmartPsiElementPointer<*>): SourcePointerIdentity? {
-    val file = pointer.virtualFile ?: return null
-    val range = pointer.psiRange ?: return null
-    return SourcePointerIdentity(file, range.startOffset, range.endOffset)
+    return resolutionInputs.sourceIdentity(pointer)
+  }
+
+  private fun bindingSourceIdentity(binding: KaBinding): SourcePointerIdentity? {
+    lookups.bindingSourceIdentities[binding]?.let {
+      return it
+    }
+    return null
+  }
+
+  internal fun sourceIdentityFor(binding: KaBinding): SourcePointerIdentity? {
+    return bindingSourceIdentity(binding)
+  }
+
+  private fun isVisibleFrom(entry: KaBinding, queryContext: GraphQueryContext): Boolean {
+    return isVisibleFrom(
+      entry.pointer,
+      bindingSourceIdentity(entry),
+      entry.hintAvailability,
+      queryContext.graphModule,
+      queryContext.resolutionScope,
+    )
+  }
+
+  private fun isVisibleFrom(
+    entry: ContributionEntry,
+    queryContext: GraphQueryContext,
+  ): Boolean {
+    return isVisibleFrom(
+      entry.pointer,
+      entry.sourceIdentity,
+      entry.hintAvailability,
+      queryContext.graphModule,
+      queryContext.resolutionScope,
+    )
   }
 
   /** The same session-free identity for an enclosing source declaration already under a read. */
@@ -1470,7 +1824,7 @@ internal class BindingIndex(
     val seen = HashSet<BindingDeclarationIdentity>()
     val result = ArrayList<KaBinding>(entries.size)
     for (binding in entries) {
-      val sourceIdentity = pointerIdentity(binding.pointer)
+      val sourceIdentity = bindingSourceIdentity(binding)
       if (sourceIdentity == null) {
         result += binding
         continue
@@ -1486,7 +1840,7 @@ internal class BindingIndex(
     if (entries.isEmpty()) return emptySet()
     val result = HashSet<Any>(entries.size)
     for (binding in entries) {
-      val sourceIdentity = pointerIdentity(binding.pointer)
+      val sourceIdentity = bindingSourceIdentity(binding)
       val identity =
         if (sourceIdentity == null) {
           binding
@@ -1509,12 +1863,6 @@ internal class BindingIndex(
     val endOffset: Int,
   )
 
-  private data class BindingDeclarationIdentity(
-    val pointer: SourcePointerIdentity,
-    val bindingClass: Class<*>,
-    val bindingKey: KaTypeKey,
-  )
-
   private data class BindingResolutionIdentity(
     val pointer: SourcePointerIdentity,
     val bindingClass: Class<*>,
@@ -1522,37 +1870,38 @@ internal class BindingIndex(
     val dependencies: List<KaContextualTypeKey>,
   )
 
-  private data class SpecializedBindingIdentity(
-    val graphId: GraphDeclarationId,
-    val pointer: SourcePointerIdentity,
-    val bindingClass: Class<*>,
-    val bindingKey: KaTypeKey,
-  )
-
-  private data class SpecializedDeclarationIdentity(
-    val graphId: GraphDeclarationId,
-    val pointer: SourcePointerIdentity,
-    val bindingClass: Class<*>,
-  )
-
-  private data class SpecializedConsumerIdentity(
-    val graphId: GraphDeclarationId,
-    val pointer: SourcePointerIdentity,
-  )
-
-  private data class GraphCompositionKey(val path: GraphPath, val module: KaModule)
-
-  private class ContributionSelection(
+  internal class ContributionSelection(
     val entries: List<ContributionEntry>,
     val declarationIds: Set<GraphReference>,
     val removed: Set<ClassId>,
   )
 
-  private class SelectedGraphComposition(
+  internal class SelectedGraphComposition(
     val composition: GraphComposition,
+    val selection: ContributionSelection,
     val contributionIds: Set<GraphReference>,
     val bindings: Set<KaBinding>,
     val implementedRequests: Set<SourcePointerIdentity>,
+  )
+
+  internal class GraphQueryStructure(
+    val queryContext: GraphQueryContext,
+    val aggregateSelection: ContributionSelection,
+    val compositionsByOwner: Map<GraphDeclarationId, SelectedGraphComposition>,
+    val currentOwnerOwnContainers: Set<ClassId>,
+    val nearestFactoryInputOwners: NearestFactoryInputOwners,
+  )
+
+  internal class ContributionPruning(
+    val replacedOrigins: Set<ClassId>,
+    val lowerPriorityBindings: Set<KaBinding>,
+    val removedOrigins: Set<ClassId>,
+  )
+
+  internal class GraphQueryPlan(
+    val structure: GraphQueryStructure,
+    val pruning: ContributionPruning,
+    val includeIncompatibleScopes: Boolean,
   )
 
   private data class GraphAccessorIdentity(
@@ -1564,7 +1913,7 @@ internal class BindingIndex(
     val isSuspend: Boolean,
   )
 
-  private data class NearestFactoryInputOwners(
+  internal data class NearestFactoryInputOwners(
     val dependencies: Map<KaTypeKey, GraphDeclarationId>,
     val containers: Map<KaTypeKey, GraphDeclarationId>,
   )
@@ -1574,129 +1923,115 @@ internal class BindingIndex(
     val mapKeyValue: String,
   )
 
-  private fun replacedOrigins(
-    queryContext: GraphQueryContext,
-    includeIncompatibleScopes: Boolean = false,
-  ): Set<ClassId> {
-    val cache =
-      if (includeIncompatibleScopes) {
-        validationReplacedOriginsByContext
-      } else {
-        replacedOriginsByContext
-      }
-    return cache.computeIfAbsent(queryContext) {
-      val context = queryContext.graphContext
-      val removed =
-        selectContributions(
-            context.scopes,
-            context.excludes,
-            queryContext.graphModule,
-            queryContext.resolutionScope,
-          )
-          .removed
-      // Interface contributions can replace another origin without declaring any binding at all.
-      // Keep their shared merge plan alongside binding-derived replacements (including generated
-      // contribution providers that have no separate source contribution entry).
-      buildSet {
-        addAll(removed)
-        for (binding in bindings) {
-          if (binding.replaces.isEmpty()) continue
-          if (!isBindingCandidateInContext(binding, queryContext, includeIncompatibleScopes))
-            continue
-          addAll(binding.replaces)
-        }
-      }
-    }
+  private fun contributionPruning(
+    structure: GraphQueryStructure,
+    includeIncompatibleScopes: Boolean,
+  ): ContributionPruning {
+    val replaced = replacedOrigins(structure, includeIncompatibleScopes)
+    val lowerPriority = lowerPriorityBindings(structure, includeIncompatibleScopes, replaced)
+    val removed =
+      removedContributionOrigins(
+        structure,
+        includeIncompatibleScopes,
+        replaced,
+        lowerPriority,
+      )
+    return ContributionPruning(replaced, lowerPriority, removed)
   }
 
-  private fun removedContributionOrigins(
-    queryContext: GraphQueryContext,
-    includeIncompatibleScopes: Boolean = false,
+  private fun replacedOrigins(
+    structure: GraphQueryStructure,
+    includeIncompatibleScopes: Boolean,
   ): Set<ClassId> {
-    val cache =
-      if (includeIncompatibleScopes) {
-        validationRemovedOriginsByContext
-      } else {
-        removedOriginsByContext
-      }
-    return cache.computeIfAbsent(queryContext) {
-      val replaced = replacedOrigins(queryContext, includeIncompatibleScopes)
-      val lowerPriority = lowerPriorityBindings(queryContext, includeIncompatibleScopes)
-      if (lowerPriority.isEmpty()) return@computeIfAbsent replaced
-
-      buildSet {
-        addAll(replaced)
-        for (binding in lowerPriority) {
-          val originClassId = binding.originClassId ?: continue
-          if (originClassId in this) continue
-
-          val hasSurvivingBinding =
-            bindingsByOrigin[originClassId].orEmpty().any { candidate ->
-              candidate.contributionScopes.isNotEmpty() &&
-                candidate !in lowerPriority &&
-                isBindingCandidateInContext(candidate, queryContext, includeIncompatibleScopes)
-            }
-          if (hasSurvivingBinding) continue
-
-          val hasNonBindingContribution = contributions.any { contribution ->
-            contribution.classId == originClassId &&
-              contribution.kind != ContributionEntry.Kind.OTHER &&
-              contribution.scopeKeys.any(queryContext.graphContext.scopes::contains) &&
-              isVisibleFrom(contribution, queryContext)
-          }
-          if (!hasNonBindingContribution) add(originClassId)
-        }
+    // Replacements may come from interface contributions with no binding. Start with the shared
+    // merge plan, then add replacements from active bindings.
+    return buildSet {
+      addAll(structure.aggregateSelection.removed)
+      for ((index, binding) in lookups.bindingsWithReplacements.withIndex()) {
+        checkCanceledEvery(index)
+        if (!isBindingCandidateInContext(binding, structure, includeIncompatibleScopes)) continue
+        addAll(binding.replaces)
       }
     }
   }
 
   /** Priority applies to individual surviving contributed bindings after explicit replacements. */
   private fun lowerPriorityBindings(
-    queryContext: GraphQueryContext,
+    structure: GraphQueryStructure,
     includeIncompatibleScopes: Boolean,
+    replaced: Set<ClassId>,
   ): Set<KaBinding> {
-    val cache =
-      if (includeIncompatibleScopes) {
-        validationLowerPriorityBindingsByContext
-      } else {
-        lowerPriorityBindingsByContext
-      }
-    return cache.computeIfAbsent(queryContext) {
-      val replaced = replacedOrigins(queryContext, includeIncompatibleScopes)
-      val prioritized = bindings.filter { binding ->
-        val isClassContribution =
-          when (binding) {
-            is KaBinding.Alias -> binding.isClassContribution
-            is KaBinding.Provided -> binding.isClassContribution
-            else -> false
-          }
-        val isSetContribution = binding.multibindingId != null && binding.mapKeyValue == null
-        isClassContribution &&
-          !isSetContribution &&
-          binding.originClassId != null &&
-          binding.originClassId !in replaced &&
-          isBindingCandidateInContext(binding, queryContext, includeIncompatibleScopes)
-      }
-      if (prioritized.size < 2) return@computeIfAbsent emptySet()
-
-      val lowerPriority = mutableSetOf<KaBinding>()
-      for (graph in queryContext.graphContext.chain) {
-        val levelBindings = prioritized.filter { binding ->
-          binding.contributionScopes.any(graph.scopeKeys::contains)
+    val prioritized = buildList {
+      for ((index, binding) in lookups.priorityEligibleBindings.withIndex()) {
+        checkCanceledEvery(index)
+        val originClassId = binding.originClassId ?: continue
+        if (
+          originClassId !in replaced &&
+            isBindingCandidateInContext(binding, structure, includeIncompatibleScopes)
+        ) {
+          add(binding)
         }
-        lowerPriority += selectLowerPriorityBindings(levelBindings, queryContext)
       }
-      lowerPriority
+    }
+    if (prioritized.size < 2) return emptySet()
+
+    val lowerPriority = mutableSetOf<KaBinding>()
+    for ((graphIndex, graph) in structure.queryContext.graphContext.chain.withIndex()) {
+      checkCanceledEvery(graphIndex)
+      val levelBindings = prioritized.filterIndexed { index, binding ->
+        checkCanceledEvery(index)
+        binding.contributionScopes.any(graph.scopeKeys::contains)
+      }
+      lowerPriority += selectLowerPriorityBindings(levelBindings, structure)
+    }
+    return lowerPriority.toSet()
+  }
+
+  private fun removedContributionOrigins(
+    structure: GraphQueryStructure,
+    includeIncompatibleScopes: Boolean,
+    replaced: Set<ClassId>,
+    lowerPriority: Set<KaBinding>,
+  ): Set<ClassId> {
+    if (lowerPriority.isEmpty()) return replaced
+
+    val queryContext = structure.queryContext
+    return buildSet {
+      addAll(replaced)
+      for ((index, binding) in lowerPriority.withIndex()) {
+        checkCanceledEvery(index)
+        val originClassId = binding.originClassId ?: continue
+        if (originClassId in this) continue
+
+        val hasSurvivingBinding =
+          lookups.bindingsByOrigin[originClassId].orEmpty().any { candidate ->
+            candidate.contributionScopes.isNotEmpty() &&
+              candidate !in lowerPriority &&
+              isBindingCandidateInContext(candidate, structure, includeIncompatibleScopes)
+          }
+        if (hasSurvivingBinding) continue
+
+        val hasNonBindingContribution =
+          lookups.contributionsByOrigin[originClassId].orEmpty().withIndex().any {
+            (contributionIndex, contribution) ->
+            checkCanceledEvery(contributionIndex)
+            contribution.kind != ContributionEntry.Kind.OTHER &&
+              contribution.scopeKeys.any(queryContext.graphContext.scopes::contains) &&
+              isVisibleFrom(contribution, queryContext)
+          }
+        if (!hasNonBindingContribution) add(originClassId)
+      }
     }
   }
 
   private fun selectLowerPriorityBindings(
     candidates: List<KaBinding>,
-    queryContext: GraphQueryContext,
+    structure: GraphQueryStructure,
   ): Set<KaBinding> {
-    val interopEnabled = queryContext.graphContext.daggerAnvilInteropEnabled
+    val interopEnabled = structure.queryContext.graphContext.daggerAnvilInteropEnabled
     return computeLowerPriorityContributions(
       candidates,
+      ensureActive = ProgressManager::checkCanceled,
       conflictKeySelector = { binding ->
         val multibindingId = binding.multibindingId
         if (multibindingId == null) {
@@ -1717,11 +2052,19 @@ internal class BindingIndex(
 
   /** Drops bindings replaced by other surviving contributions, via the shared merge engine. */
   private fun applyReplaces(entries: List<KaBinding>): List<KaBinding> {
-    return applyExcludesAndReplaces(entries)
+    return applyExcludesAndReplaces(entries, ensureActive = ProgressManager::checkCanceled)
   }
 
   /** Sites consuming any of [bindingEntries], joining multibinding contributions by id. */
   fun consumersFor(
+    bindingEntries: Collection<KaBinding>,
+    graphPath: GraphPath? = null,
+  ): List<ConsumerEntry> {
+    return withResolutionSession { session -> session.consumersFor(bindingEntries, graphPath) }
+  }
+
+  internal fun consumersFor(
+    session: BindingResolutionSession,
     bindingEntries: Collection<KaBinding>,
     graphPath: GraphPath? = null,
   ): List<ConsumerEntry> {
@@ -1731,15 +2074,15 @@ internal class BindingIndex(
     for (entry in bindingSet) {
       val multibindingId = entry.multibindingId
       if (multibindingId != null) {
-        candidates += consumersByMultibindingId[multibindingId].orEmpty()
+        candidates += lookups.consumersByMultibindingId[multibindingId].orEmpty()
       } else {
-        candidates += consumersByKey[entry.typeKey].orEmpty()
+        candidates += lookups.consumersByKey[entry.typeKey].orEmpty()
       }
     }
     if (graphs.isEmpty()) return candidates.toList()
 
     for (consumer in candidates) {
-      val resolution = resolveConsumer(consumer)
+      val resolution = resolveConsumer(session, consumer)
       val pinnedBindings = graphPath?.let { resolution.perContext.matchingContextEntry(it)?.value }
       val resolvesToEntry =
         if (pinnedBindings != null) {
@@ -1758,8 +2101,14 @@ internal class BindingIndex(
 
   fun bindingEntriesAt(element: KtElement): List<KaBinding> {
     val file = element.containingFile?.virtualFile ?: return emptyList()
-    return bindingsByFile[file].orEmpty().withoutDuplicateAssistedFactories().filter {
+    return lookups.bindingsByFile[file].orEmpty().withoutDuplicateAssistedFactories().filter {
       !it.isValidationOnlyAssistedTarget() && it.pointer.element === element
+    }
+  }
+
+  internal fun bindingEntriesInFile(file: VirtualFile): List<KaBinding> {
+    return lookups.bindingsByFile[file].orEmpty().withoutDuplicateAssistedFactories().filterNot {
+      it.isValidationOnlyAssistedTarget()
     }
   }
 
@@ -1783,10 +2132,25 @@ internal class BindingIndex(
     return entries.firstOrNull()
   }
 
+  internal fun consumerEntriesInFile(file: VirtualFile): List<ConsumerEntry> {
+    val entries = lookups.consumersByFile[file].orEmpty()
+    val specializedIdentities =
+      entries
+        .asSequence()
+        .filter { it.graphId != null && it.graphRequestKind == null }
+        .mapNotNull { it.sourceIdentity }
+        .toSet()
+    if (specializedIdentities.isEmpty()) return entries
+    return entries.filter { entry ->
+      val identity = entry.sourceIdentity
+      identity == null || identity !in specializedIdentities || entry.graphId != null
+    }
+  }
+
   /** All consumer entries anchored at [element]. Injector members anchor one per injected key. */
   fun consumerEntriesAt(element: KtElement): List<ConsumerEntry> {
     val file = element.containingFile?.virtualFile ?: return emptyList()
-    val entries = consumersByFile[file].orEmpty().filter { it.pointer.element === element }
+    val entries = lookups.consumersByFile[file].orEmpty().filter { it.pointer.element === element }
     val hasSpecializedEntries = entries.any { it.graphId != null && it.graphRequestKind == null }
     if (!hasSpecializedEntries) return entries
     return entries.filter { it.graphId != null }
@@ -1794,7 +2158,11 @@ internal class BindingIndex(
 
   fun graphEntryAt(element: KtElement): KaGraphDeclaration? {
     val file = element.containingFile?.virtualFile ?: return null
-    return graphsByFile[file].orEmpty().firstOrNull { it.pointer.element === element }
+    return lookups.graphsByFile[file].orEmpty().firstOrNull { it.pointer.element === element }
+  }
+
+  internal fun graphEntriesInFile(file: VirtualFile): List<KaGraphDeclaration> {
+    return lookups.graphsByFile[file].orEmpty()
   }
 
   /** Refreshes a retained graph declaration against this index. */
@@ -1804,39 +2172,46 @@ internal class BindingIndex(
 
   fun assistedSiteAt(element: KtElement): AssistedSite? {
     val file = element.containingFile?.virtualFile ?: return null
-    return assistedSitesByFile[file].orEmpty().firstOrNull { it.pointer.element === element }
+    return lookups.assistedSitesByFile[file].orEmpty().firstOrNull {
+      it.pointer.element === element
+    }
+  }
+
+  internal fun assistedSitesInFile(file: VirtualFile): List<AssistedSite> {
+    return lookups.assistedSitesByFile[file].orEmpty()
   }
 
   fun contributionsForScopes(scopeKeys: Set<ClassId>): List<ContributionEntry> {
     if (scopeKeys.isEmpty()) return emptyList()
-    if (scopeKeys.size == 1) return contributionsByScope[scopeKeys.first()].orEmpty()
+    if (scopeKeys.size == 1) return lookups.contributionsByScope[scopeKeys.first()].orEmpty()
     val result = linkedSetOf<ContributionEntry>()
-    for (scope in scopeKeys) result += contributionsByScope[scope].orEmpty()
+    for ((index, scope) in scopeKeys.withIndex()) {
+      checkCanceledEvery(index)
+      result += lookups.contributionsByScope[scope].orEmpty()
+    }
     return result.toList()
   }
 
   fun graphsForScopes(scopeKeys: Set<ClassId>): List<KaGraphDeclaration> {
     if (scopeKeys.isEmpty()) return emptyList()
-    return graphs.filter { graph -> graph.scopeKeys.any(scopeKeys::contains) }
+    return graphs.filterIndexed { index, graph ->
+      checkCanceledEvery(index)
+      graph.scopeKeys.any(scopeKeys::contains)
+    }
   }
 
   companion object {
-    val EMPTY = BindingIndex(emptyList(), emptyList(), emptyList(), emptyList())
-  }
-}
+    internal fun fromBuilder(data: FrozenBindingIndexData): BindingIndex = BindingIndex(data)
 
-/**
- * Groups entries into a memory-compact ScatterMap, skipping entries whose key is null. These maps
- * live for the whole index lifetime, so the per-entry savings over HashMap add up.
- */
-private inline fun <T, K : Any> List<T>.groupToScatter(keyOf: (T) -> K?): ScatterMap<K, List<T>> {
-  val result = MutableScatterMap<K, MutableList<T>>()
-  for (entry in this) {
-    val key = keyOf(entry) ?: continue
-    result.getOrPut(key, ::mutableListOf) += entry
+    val EMPTY =
+      BindingIndexBuilder(IndexGenerationToken.EMPTY)
+        .apply {
+          resolutionInputs =
+            BindingIndexResolutionInputs(FileOrdinalTable.EMPTY, emptyMap(), emptyMap())
+          capturedBindingSourceIdentities = emptyMap()
+        }
+        .build()
   }
-  @Suppress("UNCHECKED_CAST")
-  return result as ScatterMap<K, List<T>>
 }
 
 private fun KaBinding.isValidationOnlyAssistedTarget(): Boolean {
@@ -1892,12 +2267,9 @@ internal class ConsumerResolution(
   }
 }
 
-private fun moduleFor(element: KtElement?): KaModule? {
-  return element?.let { KaModuleProvider.getModule(it.project, it, useSiteModule = null) }
-}
-
 private fun isVisibleFrom(
   pointer: SmartPsiElementPointer<*>,
+  sourceIdentity: BindingIndex.SourcePointerIdentity?,
   hintAvailability: HintAvailability?,
   useSiteModule: KaModule?,
   resolutionScope: DeclarationResolutionScope?,
@@ -1905,31 +2277,10 @@ private fun isVisibleFrom(
   if (hintAvailability != null) {
     if (useSiteModule == null || !hintAvailability.isVisibleFrom(useSiteModule)) return false
   }
+  if (resolutionScope is FrozenDeclarationResolutionScope) {
+    val file = sourceIdentity?.file ?: pointer.virtualFile
+    return resolutionScope.contains(file)
+  }
   val element = pointer.element ?: return false
-  if (resolutionScope == null) return true
-  return resolutionScope.contains(element)
-}
-
-private fun isVisibleFrom(entry: KaBinding, queryContext: GraphQueryContext): Boolean {
-  return isVisibleFrom(
-    entry.pointer,
-    entry.hintAvailability,
-    queryContext.graphModule,
-    queryContext.resolutionScope,
-  )
-}
-
-private fun isVisibleFrom(entry: ContributionEntry, queryContext: GraphQueryContext): Boolean {
-  return isVisibleFrom(
-    entry.pointer,
-    entry.hintAvailability,
-    queryContext.graphModule,
-    queryContext.resolutionScope,
-  )
-}
-
-@OptIn(KaPlatformInterface::class)
-private fun KaModule.resolutionScope(): DeclarationResolutionScope {
-  val resolutionScope = KaResolutionScope.forModule(this)
-  return DeclarationResolutionScope(resolutionScope::contains)
+  return resolutionScope?.contains(element) ?: true
 }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndexBuilder.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndexBuilder.kt
@@ -1,0 +1,223 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea.model
+
+import androidx.collection.MutableScatterMap
+import androidx.collection.ScatterMap
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPsiElementPointer
+import java.util.Collections
+import java.util.IdentityHashMap
+import org.jetbrains.annotations.TestOnly
+import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
+
+/** Identifies one complete index update. Indexes published together share this token. */
+internal class IndexGenerationToken private constructor() {
+  val isEmpty: Boolean
+    get() = this === EMPTY
+
+  companion object {
+    val EMPTY = IndexGenerationToken()
+
+    fun create(): IndexGenerationToken = IndexGenerationToken()
+  }
+}
+
+/** Collects declarations and captured PSI data for an immutable [BindingIndex]. */
+internal class BindingIndexBuilder(
+  val generationToken: IndexGenerationToken = IndexGenerationToken.create()
+) {
+  val bindings = mutableListOf<KaBinding>()
+  val consumers = mutableListOf<ConsumerEntry>()
+  val graphs = mutableListOf<KaGraphDeclaration>()
+  val contributions = mutableListOf<ContributionEntry>()
+  val assistedSites = mutableListOf<AssistedSite>()
+  val bindingContainers = mutableListOf<BindingContainerEntry>()
+  val incompleteAssistedFactories =
+    linkedMapOf<KaModule, Map<SourceAssistedFactoryIdentity, String>>()
+  val dynamicGraphs = mutableListOf<DynamicGraphCall>()
+
+  /** Module ownership and visibility captured under a read action before building the index. */
+  var resolutionInputs: BindingIndexResolutionInputs? = null
+
+  /** Source ranges read with [resolutionInputs]. */
+  var capturedBindingSourceIdentities: Map<KaBinding, BindingIndex.SourcePointerIdentity>? = null
+
+  fun build(): BindingIndex = BindingIndex.fromBuilder(freeze())
+
+  internal fun freeze(): FrozenBindingIndexData {
+    val frozenBindings = bindings.toList()
+    val frozenConsumers = consumers.toList()
+    val frozenGraphs = graphs.toList()
+    val frozenContributions = contributions.toList()
+    val frozenAssistedSites = assistedSites.toList()
+    val frozenBindingContainers = bindingContainers.toList()
+    val frozenIncompleteAssistedFactories =
+      buildMap(incompleteAssistedFactories.size) {
+        for ((module, boundaries) in incompleteAssistedFactories) {
+          put(module, boundaries.toMap())
+        }
+      }
+    val frozenDynamicGraphs = dynamicGraphs.toList()
+    val frozenResolutionInputs =
+      checkNotNull(resolutionInputs) { "Resolution inputs must be captured before finalization" }
+    // Copy once here so lookups can share the map safely after the builder changes.
+    val frozenBindingSourceIdentities =
+      Collections.unmodifiableMap(
+        IdentityHashMap(
+          checkNotNull(capturedBindingSourceIdentities) {
+            "Source identities must be captured before finalization"
+          }
+        )
+      )
+    val lookups =
+      BindingIndexLookups.build(
+        frozenBindings,
+        frozenConsumers,
+        frozenGraphs,
+        frozenContributions,
+        frozenAssistedSites,
+        frozenBindingContainers,
+        frozenDynamicGraphs,
+        frozenBindingSourceIdentities,
+      )
+    return FrozenBindingIndexData(
+      generationToken,
+      frozenBindings,
+      frozenConsumers,
+      frozenGraphs,
+      frozenContributions,
+      frozenAssistedSites,
+      frozenBindingContainers,
+      frozenIncompleteAssistedFactories,
+      frozenDynamicGraphs,
+      frozenResolutionInputs,
+      lookups,
+    )
+  }
+}
+
+internal class FrozenBindingIndexData(
+  val generationToken: IndexGenerationToken,
+  val bindings: List<KaBinding>,
+  val consumers: List<ConsumerEntry>,
+  val graphs: List<KaGraphDeclaration>,
+  val contributions: List<ContributionEntry>,
+  val assistedSites: List<AssistedSite>,
+  val bindingContainers: List<BindingContainerEntry>,
+  val incompleteAssistedFactories: Map<KaModule, Map<SourceAssistedFactoryIdentity, String>>,
+  val dynamicGraphs: List<DynamicGraphCall>,
+  val resolutionInputs: BindingIndexResolutionInputs,
+  val lookups: BindingIndexLookups,
+)
+
+@JvmInline internal value class ModuleViewId(val value: Int)
+
+@JvmInline internal value class FileOrdinal(val value: Int)
+
+/** Immutable file ordinals shared by all module visibility arrays in one index. */
+internal class FileOrdinalTable
+private constructor(private val ordinals: Map<VirtualFile, FileOrdinal>) {
+  val size: Int
+    get() = ordinals.size
+
+  operator fun get(file: VirtualFile?): FileOrdinal? = file?.let(ordinals::get)
+
+  fun getValue(file: VirtualFile): FileOrdinal = ordinals.getValue(file)
+
+  companion object {
+    val EMPTY = FileOrdinalTable(emptyMap())
+
+    /** Copies [ordinals] so later changes to the input map cannot affect module visibility. */
+    fun freeze(ordinals: Map<VirtualFile, FileOrdinal>): FileOrdinalTable {
+      return FileOrdinalTable(ordinals.toMap())
+    }
+  }
+}
+
+/** The files a module can see, captured for one index. */
+internal class BindingIndexModuleView(
+  val id: ModuleViewId,
+  val module: KaModule,
+  visibleFileOrdinals: BooleanArray,
+  internal val fileOrdinalTable: FileOrdinalTable,
+  val daggerAnvilInteropEnabled: Boolean,
+) {
+  private val visibleFileOrdinals = visibleFileOrdinals.copyOf()
+
+  init {
+    require(this.visibleFileOrdinals.size == fileOrdinalTable.size) {
+      "Module visibility must cover the captured file-ordinal table"
+    }
+  }
+
+  val resolutionScope: DeclarationResolutionScope =
+    FrozenFileResolutionScope(this.visibleFileOrdinals, fileOrdinalTable)
+
+  /** Lets tests verify that modules have separate visibility arrays. */
+  @TestOnly
+  internal fun sharesVisibilityArrayWith(other: BindingIndexModuleView): Boolean {
+    return visibleFileOrdinals === other.visibleFileOrdinals
+  }
+}
+
+/** Module ownership, visibility, and source ranges captured under a read action. */
+internal class BindingIndexResolutionInputs(
+  internal val fileOrdinalTable: FileOrdinalTable,
+  moduleByFile: Map<VirtualFile, ModuleViewId>,
+  moduleViews: Map<ModuleViewId, BindingIndexModuleView>,
+  pointerSourceIdentities: Map<SmartPsiElementPointer<*>, BindingIndex.SourcePointerIdentity> =
+    emptyMap(),
+) {
+  private val moduleByFile = moduleByFile.toMap()
+  private val moduleViews = moduleViews.toMap()
+  private val pointerSourceIdentities =
+    Collections.unmodifiableMap(IdentityHashMap(pointerSourceIdentities))
+
+  init {
+    require(this.moduleViews.values.all { it.fileOrdinalTable === fileOrdinalTable }) {
+      "Module views must share the captured file-ordinal table"
+    }
+  }
+
+  fun moduleViewFor(file: VirtualFile?): BindingIndexModuleView? {
+    val id = file?.let(moduleByFile::get) ?: return null
+    return moduleViews[id]
+  }
+
+  fun fileOrdinal(file: VirtualFile?): FileOrdinal? = fileOrdinalTable[file]
+
+  fun sourceIdentity(pointer: SmartPsiElementPointer<*>): BindingIndex.SourcePointerIdentity? =
+    pointerSourceIdentities[pointer]
+}
+
+private class FrozenFileResolutionScope(
+  private val visibleFileOrdinals: BooleanArray,
+  private val fileOrdinalTable: FileOrdinalTable,
+) : FrozenDeclarationResolutionScope {
+
+  override fun contains(element: PsiElement): Boolean {
+    return contains(element.containingFile?.virtualFile)
+  }
+
+  override fun contains(file: VirtualFile?): Boolean {
+    val ordinal = fileOrdinalTable[file]?.value ?: return false
+    return ordinal in visibleFileOrdinals.indices && visibleFileOrdinals[ordinal]
+  }
+}
+
+internal fun sourcePointerIdentity(
+  pointer: SmartPsiElementPointer<*>
+): BindingIndex.SourcePointerIdentity? {
+  val file = pointer.virtualFile ?: return null
+  val range = pointer.psiRange ?: return null
+  return BindingIndex.SourcePointerIdentity(file, range.startOffset, range.endOffset)
+}
+
+internal fun <K : Any, V> MutableScatterMap<K, MutableList<V>>.freezeListLookup():
+  ScatterMap<K, List<V>> {
+  val frozen = MutableScatterMap<K, List<V>>(size)
+  forEach { key, values -> frozen[key] = values.toList() }
+  return frozen
+}

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndexLookups.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndexLookups.kt
@@ -1,0 +1,405 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea.model
+
+import androidx.collection.MutableScatterMap
+import androidx.collection.ScatterMap
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.vfs.VirtualFile
+import dev.zacsweers.metro.idea.checkCanceledEvery
+import java.util.Collections
+import java.util.IdentityHashMap
+import org.jetbrains.kotlin.name.ClassId
+
+/** Lookup tables built before publishing a [BindingIndex]. Lists preserve declaration order. */
+internal class BindingIndexLookups
+private constructor(
+  val containersById: ScatterMap<ClassId, List<BindingContainerEntry>>,
+  val bindingsByOrigin: ScatterMap<ClassId, List<KaBinding>>,
+  /** Contributions grouped by their originating class for replacement checks. */
+  val contributionsByOrigin: ScatterMap<ClassId, List<ContributionEntry>>,
+  /** Bindings whose replacements can remove other contributions from a graph. */
+  val bindingsWithReplacements: List<KaBinding>,
+  /** Class contributions checked for priority conflicts. Set elements are excluded. */
+  val priorityEligibleBindings: List<KaBinding>,
+  val bindingsByMemberOwner: ScatterMap<ClassId, List<KaBinding>>,
+  val contributionsByScope: ScatterMap<ClassId, List<ContributionEntry>>,
+  /** Source ranges copied by the builder and shared with these lookups. */
+  val bindingSourceIdentities: Map<KaBinding, BindingIndex.SourcePointerIdentity>,
+  /** Uses object identity because contributed bindings can share declaration names. */
+  val contributedBindingOwners: Map<KaBinding, GraphInterfaceContribution>,
+  val graphsByReference: Map<GraphReference, List<KaGraphDeclaration>>,
+  /** Graphs that can inherit or declare each contribution scope. */
+  val graphsByReachableScope: ScatterMap<ClassId, List<KaGraphDeclaration>>,
+  /** Graphs whose context paths can contain each declaration. */
+  val graphsByReachableAncestor: Map<GraphDeclarationId, List<KaGraphDeclaration>>,
+  val dynamicGraphsByTarget: Map<GraphReference, List<DynamicGraphCall>>,
+  /** Possible parents of each graph. Contribution selection determines which parents apply. */
+  val potentialParentsByReference: Map<GraphReference, List<KaGraphDeclaration>>,
+  /** Whether an inherited binding is public in its owning graph. */
+  val specializedBindingIdentities: Map<SpecializedBindingIdentity, Boolean>,
+  /** A concrete specialization replaces its raw declaration even when its return key changes. */
+  val specializedDeclarationIdentities: Set<SpecializedDeclarationIdentity>,
+  val contributedSpecializedBindings: Map<SpecializedBindingIdentity, List<KaBinding>>,
+  val contributedSpecializedDeclarations: Map<SpecializedDeclarationIdentity, List<KaBinding>>,
+  /** Raw source callables remain authoritative when their interface was written explicitly. */
+  val unownedBindingDeclarations: Map<BindingDeclarationIdentity, List<KaBinding>>,
+  val bindingsByKey: ScatterMap<KaTypeKey, List<KaBinding>>,
+  val bindingsByType: ScatterMap<KaTypeSnapshot, List<KaBinding>>,
+  val assistedFactoriesByTarget: ScatterMap<KaTypeKey, List<KaBinding.AssistedFactory>>,
+  val consumersByKey: ScatterMap<KaTypeKey, List<ConsumerEntry>>,
+  val contributionsByMultibindingId: ScatterMap<String, List<KaBinding>>,
+  val consumersByMultibindingId: ScatterMap<String, List<ConsumerEntry>>,
+  val accessorsByGraph: ScatterMap<GraphDeclarationId, List<ConsumerEntry>>,
+  /** Groups by file without retaining PSI elements. Resolving pointers needs a read action. */
+  val bindingsByFile: ScatterMap<VirtualFile, List<KaBinding>>,
+  val consumersByFile: ScatterMap<VirtualFile, List<ConsumerEntry>>,
+  val specializedConsumerIdentities: Set<SpecializedConsumerIdentity>,
+  val contributedSpecializedConsumers: Map<SpecializedConsumerIdentity, List<ConsumerEntry>>,
+  /** Keys of assisted factories found in multiple source shards. */
+  val duplicatedAssistedFactoryKeys: Set<KaTypeKey>,
+  val graphsByFile: ScatterMap<VirtualFile, List<KaGraphDeclaration>>,
+  val assistedSitesByFile: ScatterMap<VirtualFile, List<AssistedSite>>,
+) {
+  companion object {
+    /** Builds lookups from the builder's immutable declarations and source ranges. */
+    fun build(
+      bindings: List<KaBinding>,
+      consumers: List<ConsumerEntry>,
+      graphs: List<KaGraphDeclaration>,
+      contributions: List<ContributionEntry>,
+      assistedSites: List<AssistedSite>,
+      bindingContainers: List<BindingContainerEntry>,
+      dynamicGraphs: List<DynamicGraphCall>,
+      bindingSourceIdentities: Map<KaBinding, BindingIndex.SourcePointerIdentity>,
+    ): BindingIndexLookups {
+      val hasDeclarations =
+        bindings.isNotEmpty() ||
+          consumers.isNotEmpty() ||
+          graphs.isNotEmpty() ||
+          contributions.isNotEmpty() ||
+          assistedSites.isNotEmpty() ||
+          bindingContainers.isNotEmpty() ||
+          dynamicGraphs.isNotEmpty()
+      val contributedBindingOwners = IdentityHashMap<KaBinding, GraphInterfaceContribution>()
+      val graphsByReference = linkedMapOf<GraphReference, MutableList<KaGraphDeclaration>>()
+      val potentialParentsByReference =
+        linkedMapOf<GraphReference, MutableList<KaGraphDeclaration>>()
+      val contributedSpecializedBindings =
+        linkedMapOf<SpecializedBindingIdentity, MutableList<KaBinding>>()
+      val contributedSpecializedDeclarations =
+        linkedMapOf<SpecializedDeclarationIdentity, MutableList<KaBinding>>()
+      val graphsByFile = MutableScatterMap<VirtualFile, MutableList<KaGraphDeclaration>>()
+
+      var graphWorkIndex = 0
+      for (graph in graphs) {
+        checkCanceledEvery(graphWorkIndex++)
+        graph.pointer.virtualFile?.let { file ->
+          graphsByFile.getOrPut(file, ::mutableListOf) += graph
+        }
+        for (reference in graph.selfReferences) {
+          checkCanceledEvery(graphWorkIndex++)
+          graphsByReference.getOrPut(reference, ::mutableListOf) += graph
+        }
+
+        val parentReferences = linkedSetOf<GraphReference>()
+        parentReferences += graph.extensionCreations
+        for (contribution in graph.contributedInterfaces) {
+          checkCanceledEvery(graphWorkIndex++)
+          parentReferences += contribution.extensionCreations
+          for (binding in contribution.bindings) {
+            checkCanceledEvery(graphWorkIndex++)
+            val alreadyKnown = contributedBindingOwners.containsKey(binding)
+            contributedBindingOwners[binding] = contribution
+            if (alreadyKnown) continue
+
+            val owner = binding.ownerGraphId ?: continue
+            val source = bindingSourceIdentities[binding] ?: continue
+            val bindingIdentity =
+              SpecializedBindingIdentity(owner, source, binding.javaClass, binding.typeKey)
+            contributedSpecializedBindings.getOrPut(bindingIdentity, ::mutableListOf) += binding
+            val declarationIdentity =
+              SpecializedDeclarationIdentity(owner, source, binding.javaClass)
+            contributedSpecializedDeclarations.getOrPut(
+              declarationIdentity,
+              ::mutableListOf,
+            ) += binding
+          }
+        }
+        for (reference in parentReferences) {
+          checkCanceledEvery(graphWorkIndex++)
+          potentialParentsByReference.getOrPut(reference, ::mutableListOf) += graph
+        }
+      }
+
+      val graphsByReachableScope = MutableScatterMap<ClassId, MutableList<KaGraphDeclaration>>()
+      val graphsByReachableAncestor =
+        linkedMapOf<GraphDeclarationId, MutableList<KaGraphDeclaration>>()
+      var reachabilityWorkIndex = 0
+      for (graph in graphs) {
+        checkCanceledEvery(reachabilityWorkIndex++)
+        val scopes = linkedSetOf<ClassId>()
+        val graphIds = linkedSetOf<GraphDeclarationId>()
+        val visited = linkedSetOf<KaGraphDeclaration>()
+        val remaining = ArrayDeque<KaGraphDeclaration>()
+        remaining += graph
+        while (remaining.isNotEmpty()) {
+          checkCanceledEvery(reachabilityWorkIndex++)
+          val current = remaining.removeFirst()
+          if (!visited.add(current)) continue
+          scopes += current.scopeKeys
+          graphIds += current.declarationId
+          for (reference in current.selfReferences) {
+            checkCanceledEvery(reachabilityWorkIndex++)
+            remaining += potentialParentsByReference[reference].orEmpty()
+          }
+        }
+        for (scope in scopes) {
+          checkCanceledEvery(reachabilityWorkIndex++)
+          graphsByReachableScope.getOrPut(scope, ::mutableListOf) += graph
+        }
+        for (graphId in graphIds) {
+          checkCanceledEvery(reachabilityWorkIndex++)
+          graphsByReachableAncestor.getOrPut(graphId, ::mutableListOf) += graph
+        }
+      }
+
+      val bindingsByOrigin = MutableScatterMap<ClassId, MutableList<KaBinding>>()
+      val bindingsWithReplacements = mutableListOf<KaBinding>()
+      val priorityEligibleBindings = mutableListOf<KaBinding>()
+      val bindingsByMemberOwner = MutableScatterMap<ClassId, MutableList<KaBinding>>()
+      val bindingsByKey = MutableScatterMap<KaTypeKey, MutableList<KaBinding>>()
+      val bindingsByType = MutableScatterMap<KaTypeSnapshot, MutableList<KaBinding>>()
+      val assistedFactoriesByTarget =
+        MutableScatterMap<KaTypeKey, MutableList<KaBinding.AssistedFactory>>()
+      val contributionsByMultibindingId = MutableScatterMap<String, MutableList<KaBinding>>()
+      val bindingsByFile = MutableScatterMap<VirtualFile, MutableList<KaBinding>>()
+      val specializedBindingIdentities = linkedMapOf<SpecializedBindingIdentity, Boolean>()
+      val specializedDeclarationIdentities = linkedSetOf<SpecializedDeclarationIdentity>()
+      val unownedBindingDeclarations =
+        linkedMapOf<BindingDeclarationIdentity, MutableList<KaBinding>>()
+      val assistedFactoryIdentities = HashSet<Triple<ClassId?, VirtualFile?, KaTypeKey>>()
+      val duplicatedAssistedFactoryKeys = linkedSetOf<KaTypeKey>()
+
+      var bindingWorkIndex = 0
+      for (binding in bindings) {
+        checkCanceledEvery(bindingWorkIndex++)
+        if (binding.replaces.isNotEmpty()) bindingsWithReplacements += binding
+        if (binding.isPriorityEligibleContribution()) priorityEligibleBindings += binding
+        val source = bindingSourceIdentities[binding]
+        binding.originClassId?.let { origin ->
+          bindingsByOrigin.getOrPut(origin, ::mutableListOf) += binding
+        }
+        for (owner in binding.memberInjectionOwnerIds) {
+          checkCanceledEvery(bindingWorkIndex++)
+          bindingsByMemberOwner.getOrPut(owner, ::mutableListOf) += binding
+        }
+        val multibindingId = binding.multibindingId
+        if (multibindingId == null) {
+          bindingsByKey.getOrPut(binding.typeKey, ::mutableListOf) += binding
+        } else {
+          contributionsByMultibindingId.getOrPut(
+            multibindingId,
+            ::mutableListOf,
+          ) += binding
+        }
+        bindingsByType.getOrPut(binding.typeKey.type, ::mutableListOf) += binding
+        binding.pointer.virtualFile?.let { file ->
+          bindingsByFile.getOrPut(file, ::mutableListOf) += binding
+        }
+
+        if (binding is KaBinding.AssistedFactory) {
+          binding.targetTypeKey?.let { target ->
+            assistedFactoriesByTarget.getOrPut(target, ::mutableListOf) += binding
+          }
+          val identity = Triple(binding.originClassId, binding.pointer.virtualFile, binding.typeKey)
+          if (!assistedFactoryIdentities.add(identity)) {
+            duplicatedAssistedFactoryKeys += binding.typeKey
+          }
+        }
+
+        if (binding.ownerGraphId == null && binding.containerId != null && source != null) {
+          val identity = BindingDeclarationIdentity(source, binding.javaClass, binding.typeKey)
+          unownedBindingDeclarations.getOrPut(identity, ::mutableListOf) += binding
+        }
+        val ownerGraphId = binding.ownerGraphId
+        if (
+          binding is KaBinding.BoundInstance ||
+            ownerGraphId == null ||
+            contributedBindingOwners.containsKey(binding) ||
+            source == null
+        ) {
+          continue
+        }
+        val specialization =
+          SpecializedBindingIdentity(
+            ownerGraphId,
+            source,
+            binding.javaClass,
+            binding.typeKey,
+          )
+        val alreadyPublic = specializedBindingIdentities[specialization] == true
+        specializedBindingIdentities[specialization] = alreadyPublic || !binding.isGraphPrivate
+        specializedDeclarationIdentities +=
+          SpecializedDeclarationIdentity(
+            specialization.graphId,
+            specialization.pointer,
+            specialization.bindingClass,
+          )
+      }
+
+      val consumersByKey = MutableScatterMap<KaTypeKey, MutableList<ConsumerEntry>>()
+      val consumersByMultibindingId = MutableScatterMap<String, MutableList<ConsumerEntry>>()
+      val accessorsByGraph = MutableScatterMap<GraphDeclarationId, MutableList<ConsumerEntry>>()
+      val consumersByFile = MutableScatterMap<VirtualFile, MutableList<ConsumerEntry>>()
+      val specializedConsumerIdentities = linkedSetOf<SpecializedConsumerIdentity>()
+      val contributedSpecializedConsumers =
+        linkedMapOf<SpecializedConsumerIdentity, MutableList<ConsumerEntry>>()
+
+      for ((index, consumer) in consumers.withIndex()) {
+        checkCanceledEvery(index)
+        consumersByKey.getOrPut(consumer.key, ::mutableListOf) += consumer
+        consumer.multibindingId?.let { multibindingId ->
+          consumersByMultibindingId.getOrPut(multibindingId, ::mutableListOf) += consumer
+        }
+        consumer.graphId?.let { graphId ->
+          accessorsByGraph.getOrPut(graphId, ::mutableListOf) += consumer
+        }
+        consumer.pointer.virtualFile?.let { file ->
+          consumersByFile.getOrPut(file, ::mutableListOf) += consumer
+        }
+
+        val graphId = consumer.graphId ?: continue
+        if (consumer.graphRequestKind != null) continue
+        val source = consumer.sourceIdentity ?: continue
+        val identity = SpecializedConsumerIdentity(graphId, source)
+        if (consumer.graphContribution == null) {
+          specializedConsumerIdentities += identity
+        } else {
+          contributedSpecializedConsumers.getOrPut(identity, ::mutableListOf) += consumer
+        }
+      }
+
+      val contributionsByScope = MutableScatterMap<ClassId, MutableList<ContributionEntry>>()
+      val contributionsByOrigin = MutableScatterMap<ClassId, MutableList<ContributionEntry>>()
+      var contributionWorkIndex = 0
+      for (contribution in contributions) {
+        checkCanceledEvery(contributionWorkIndex++)
+        contribution.classId?.let { origin ->
+          contributionsByOrigin.getOrPut(origin, ::mutableListOf) += contribution
+        }
+        for (scope in contribution.scopeKeys) {
+          checkCanceledEvery(contributionWorkIndex++)
+          contributionsByScope.getOrPut(scope, ::mutableListOf) += contribution
+        }
+      }
+
+      val containersById = MutableScatterMap<ClassId, MutableList<BindingContainerEntry>>()
+      for ((index, container) in bindingContainers.withIndex()) {
+        checkCanceledEvery(index)
+        containersById.getOrPut(container.classId, ::mutableListOf) += container
+      }
+
+      val dynamicGraphsByTarget = linkedMapOf<GraphReference, MutableList<DynamicGraphCall>>()
+      var dynamicGraphWorkIndex = 0
+      for (graph in dynamicGraphs) {
+        checkCanceledEvery(dynamicGraphWorkIndex++)
+        dynamicGraphsByTarget.getOrPut(graph.targetGraph, ::mutableListOf) += graph
+      }
+
+      val assistedSitesByFile = MutableScatterMap<VirtualFile, MutableList<AssistedSite>>()
+      for ((index, site) in assistedSites.withIndex()) {
+        checkCanceledEvery(index)
+        site.pointer.virtualFile?.let { file ->
+          assistedSitesByFile.getOrPut(file, ::mutableListOf) += site
+        }
+      }
+
+      // BindingIndex.EMPTY must initialize even when its first caller is canceled. Builds with
+      // declarations check cancellation before returning.
+      if (hasDeclarations) ProgressManager.checkCanceled()
+      return BindingIndexLookups(
+        containersById.freezeListLookup(),
+        bindingsByOrigin.freezeListLookup(),
+        contributionsByOrigin.freezeListLookup(),
+        bindingsWithReplacements.toList(),
+        priorityEligibleBindings.toList(),
+        bindingsByMemberOwner.freezeListLookup(),
+        contributionsByScope.freezeListLookup(),
+        bindingSourceIdentities,
+        contributedBindingOwners.freezeIdentityMap(),
+        graphsByReference.freezeListMap(),
+        graphsByReachableScope.freezeListLookup(),
+        graphsByReachableAncestor.freezeListMap(),
+        dynamicGraphsByTarget.freezeListMap(),
+        potentialParentsByReference.freezeListMap(),
+        specializedBindingIdentities.toMap(),
+        specializedDeclarationIdentities.toSet(),
+        contributedSpecializedBindings.freezeListMap(),
+        contributedSpecializedDeclarations.freezeListMap(),
+        unownedBindingDeclarations.freezeListMap(),
+        bindingsByKey.freezeListLookup(),
+        bindingsByType.freezeListLookup(),
+        assistedFactoriesByTarget.freezeListLookup(),
+        consumersByKey.freezeListLookup(),
+        contributionsByMultibindingId.freezeListLookup(),
+        consumersByMultibindingId.freezeListLookup(),
+        accessorsByGraph.freezeListLookup(),
+        bindingsByFile.freezeListLookup(),
+        consumersByFile.freezeListLookup(),
+        specializedConsumerIdentities.toSet(),
+        contributedSpecializedConsumers.freezeListMap(),
+        duplicatedAssistedFactoryKeys.toSet(),
+        graphsByFile.freezeListLookup(),
+        assistedSitesByFile.freezeListLookup(),
+      )
+    }
+  }
+}
+
+internal data class BindingDeclarationIdentity(
+  val pointer: BindingIndex.SourcePointerIdentity,
+  val bindingClass: Class<*>,
+  val bindingKey: KaTypeKey,
+)
+
+internal data class SpecializedBindingIdentity(
+  val graphId: GraphDeclarationId,
+  val pointer: BindingIndex.SourcePointerIdentity,
+  val bindingClass: Class<*>,
+  val bindingKey: KaTypeKey,
+)
+
+internal data class SpecializedDeclarationIdentity(
+  val graphId: GraphDeclarationId,
+  val pointer: BindingIndex.SourcePointerIdentity,
+  val bindingClass: Class<*>,
+)
+
+internal data class SpecializedConsumerIdentity(
+  val graphId: GraphDeclarationId,
+  val pointer: BindingIndex.SourcePointerIdentity,
+)
+
+private fun KaBinding.isPriorityEligibleContribution(): Boolean {
+  val isClassContribution =
+    when (this) {
+      is KaBinding.Alias -> isClassContribution
+      is KaBinding.Provided -> isClassContribution
+      else -> false
+    }
+  val isSetContribution = multibindingId != null && mapKeyValue == null
+  return isClassContribution && !isSetContribution && originClassId != null
+}
+
+private fun <K, V> Map<K, MutableList<V>>.freezeListMap(): Map<K, List<V>> {
+  return buildMap(size) {
+    for ((key, values) in this@freezeListMap) {
+      put(key, values.toList())
+    }
+  }
+}
+
+private fun <K : Any, V> IdentityHashMap<K, V>.freezeIdentityMap(): Map<K, V> {
+  return Collections.unmodifiableMap(IdentityHashMap(this))
+}

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingModel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingModel.kt
@@ -53,6 +53,10 @@ internal class ConsumerEntry(
   /** Exact implicit interface contribution that must survive in the owning graph path. */
   val graphContribution: GraphReference? = null,
 ) {
+  val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
+  val injectedMemberSourceIdentity: BindingIndex.SourcePointerIdentity? =
+    injectedMemberPointer?.let(::sourcePointerIdentity)
+
   val key: KaTypeKey
     get() = contextKey.typeKey
 
@@ -98,7 +102,9 @@ internal class AssistedSite(
    * explicit ones don't need a second marker.
    */
   val isImplicit: Boolean,
-)
+) {
+  val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
+}
 
 /** A `@DependencyGraph`/`@GraphExtension`-annotated class and its aggregation metadata. */
 internal class KaGraphDeclaration(
@@ -145,6 +151,7 @@ internal class KaGraphDeclaration(
   /** Concrete members from the written graph hierarchy that satisfy inherited abstract requests. */
   val defaultImplementations: List<GraphDefaultImplementation> = emptyList(),
 ) {
+  val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
   val declarationId: GraphDeclarationId = GraphDeclarationId(classId, pointer.virtualFile)
   val selfReferences: Set<GraphReference> =
     selfIds.mapTo(mutableSetOf()) { GraphReference(it, pointer.virtualFile) }
@@ -193,6 +200,7 @@ internal class BindingContainerEntry(
   val classId: ClassId,
   val includes: Set<ClassId>,
 ) {
+  val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
   /** Separate modules can declare containers with the same fully qualified class name. */
   val declarationId: GraphReference = GraphReference(classId, pointer.virtualFile)
 }
@@ -225,6 +233,7 @@ internal class DynamicGraphCall(
   val containerInputs: List<KaBinding.BoundInstance>,
   val isFactory: Boolean,
 ) {
+  val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
   val containerKeys: Set<KaTypeKey>
     get() = id.containerKeys
 }
@@ -258,7 +267,9 @@ internal data class GraphCallableSignature(
 internal class GraphCallableReference(
   val pointer: SmartPsiElementPointer<out KtElement>,
   val signature: GraphCallableSignature,
-)
+) {
+  val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
+}
 
 /** A concrete graph member and the real declarations that it overrides. */
 internal class GraphDefaultImplementation(
@@ -273,7 +284,9 @@ internal class GraphExtensionFactoryAccessor(
   val factoryKey: KaTypeKey,
   val extensionKey: KaTypeKey,
   val extension: GraphReference,
-)
+) {
+  val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
+}
 
 /** One extracted interface surface, materialized for an exact candidate owning graph. */
 internal class GraphInterfaceContribution(
@@ -369,6 +382,11 @@ internal fun interface DeclarationResolutionScope {
   fun contains(element: PsiElement): Boolean
 }
 
+/** A file visibility snapshot that remains unchanged for the lifetime of an index. */
+internal interface FrozenDeclarationResolutionScope : DeclarationResolutionScope {
+  fun contains(file: VirtualFile?): Boolean
+}
+
 /** Modules from which declarations synthesized from a non-public contribution hint are visible. */
 internal class HintAvailability(modules: Set<KaModule>) {
   private val modules = modules.toSet()
@@ -390,11 +408,12 @@ internal class ContributionEntry(
   /** Excluding this child graph also excludes its contributed nested factory. */
   val graphExtension: GraphReference? = null,
 ) : MergeContribution {
+  val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
+
   override val mergeId: ClassId?
     get() = classId
 
-  val declarationId: GraphReference?
-    get() = classId?.let { GraphReference(it, pointer.virtualFile) }
+  val declarationId: GraphReference? = classId?.let { GraphReference(it, pointer.virtualFile) }
 
   enum class Kind {
     OTHER,

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingResolutionSession.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingResolutionSession.kt
@@ -1,0 +1,186 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea.model
+
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.psi.SmartPsiElementPointer
+import org.jetbrains.annotations.TestOnly
+import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.psi.KtElement
+
+/**
+ * Caches graph queries for one operation against an immutable [BindingIndex].
+ *
+ * The caller must prevent concurrent access and discard the session when the operation finishes.
+ */
+internal class BindingResolutionSession internal constructor(private val index: BindingIndex) {
+  private val graphContexts = HashMap<KaGraphDeclaration, List<GraphContext>>()
+  private val plannedGraphQueries = HashMap<GraphContext, PlannedGraphQuery>()
+  private val consumerResolutions = HashMap<ConsumerEntry, ConsumerResolution>()
+  private val graphCompositions =
+    HashMap<GraphCompositionKey, BindingIndex.SelectedGraphComposition>()
+  private var allGraphContexts: List<GraphContext>? = null
+
+  fun bindingsFor(consumer: ConsumerEntry): List<KaBinding> = index.bindingsFor(this, consumer)
+
+  fun bindingsFor(
+    consumer: ConsumerEntry,
+    queryContext: GraphQueryContext,
+  ): List<KaBinding> = index.bindingsFor(this, consumer, queryContext)
+
+  fun resolveConsumer(consumer: ConsumerEntry): ConsumerResolution {
+    return index.resolveConsumer(this, consumer)
+  }
+
+  fun bindingsForKey(key: KaTypeKey, queryContext: GraphQueryContext): List<KaBinding> {
+    return index.bindingsForKey(this, key, queryContext)
+  }
+
+  fun multibindingContributions(
+    multibindingId: String,
+    queryContext: GraphQueryContext,
+  ): List<KaBinding> = index.multibindingContributions(this, multibindingId, queryContext)
+
+  fun bindingsInContext(queryContext: GraphQueryContext): List<KaBinding> {
+    return index.bindingsInContext(this, queryContext)
+  }
+
+  fun accessorsFor(queryContext: GraphQueryContext): List<ConsumerEntry> {
+    return index.accessorsFor(this, queryContext)
+  }
+
+  fun graphComposition(
+    queryContext: GraphQueryContext,
+    graph: KaGraphDeclaration = queryContext.graphContext.graph,
+  ): GraphComposition = index.graphComposition(this, queryContext, graph)
+
+  fun extensionsOf(queryContext: GraphQueryContext): List<KaGraphDeclaration> {
+    return index.extensionsOf(this, queryContext)
+  }
+
+  fun contextsFor(graph: KaGraphDeclaration): List<GraphContext> {
+    return index.contextsFor(this, graph)
+  }
+
+  fun queryContext(context: GraphContext): GraphQueryContext? {
+    return index.queryContext(this, context)
+  }
+
+  internal fun validationPlan(queryContext: GraphQueryContext): BindingIndex.GraphQueryPlan {
+    return index.validationPlan(this, queryContext)
+  }
+
+  fun findContext(path: GraphPath): GraphContext? = index.findContext(this, path)
+
+  fun extensionContextsOf(parent: GraphContext): List<GraphContext> {
+    return index.extensionContextsOf(this, parent)
+  }
+
+  fun contributionsFor(queryContext: GraphQueryContext): List<ContributionEntry> {
+    return index.contributionsFor(this, queryContext)
+  }
+
+  fun inheritedContributionsFor(queryContext: GraphQueryContext): List<ContributionEntry> {
+    return index.inheritedContributionsFor(this, queryContext)
+  }
+
+  fun graphOwnContainers(
+    graph: KaGraphDeclaration,
+    queryContext: GraphQueryContext,
+  ): Set<ClassId> = index.graphOwnContainers(this, graph, queryContext)
+
+  fun isBindingOwnedByCurrentGraph(
+    binding: KaBinding,
+    queryContext: GraphQueryContext,
+  ): Boolean = index.isBindingOwnedByCurrentGraph(this, binding, queryContext)
+
+  fun hasPrivateAncestorBinding(key: KaTypeKey, queryContext: GraphQueryContext): Boolean {
+    return index.hasPrivateAncestorBinding(this, key, queryContext)
+  }
+
+  fun isConsumerInContext(
+    consumer: ConsumerEntry,
+    queryContext: GraphQueryContext,
+  ): Boolean = index.isConsumerInContext(this, consumer, queryContext)
+
+  fun consumersFor(
+    bindingEntries: Collection<KaBinding>,
+    graphPath: GraphPath? = null,
+  ): List<ConsumerEntry> = index.consumersFor(this, bindingEntries, graphPath)
+
+  internal fun cachedContextsFor(
+    graph: KaGraphDeclaration,
+    build: () -> List<GraphContext>,
+  ): List<GraphContext> = graphContexts.getOrPut(graph, build)
+
+  @TestOnly
+  internal fun hasComputedContextsFor(graph: KaGraphDeclaration): Boolean {
+    return graph in graphContexts
+  }
+
+  internal fun allGraphContexts(): List<GraphContext> {
+    allGraphContexts?.let {
+      return it
+    }
+    val computed =
+      index.graphs.flatMap { graph ->
+        ProgressManager.checkCanceled()
+        contextsFor(graph)
+      }
+    allGraphContexts = computed
+    return computed
+  }
+
+  internal fun plannedQuery(context: GraphContext): PlannedGraphQuery? {
+    return plannedGraphQueries[context]
+  }
+
+  internal fun plannedQuery(
+    context: GraphContext,
+    create: () -> PlannedGraphQuery,
+  ): PlannedGraphQuery = plannedGraphQueries.getOrPut(context, create)
+
+  internal fun consumerResolution(
+    consumer: ConsumerEntry,
+    create: () -> ConsumerResolution,
+  ): ConsumerResolution = consumerResolutions.getOrPut(consumer, create)
+
+  internal fun graphComposition(
+    path: GraphPath,
+    module: KaModule,
+    create: () -> BindingIndex.SelectedGraphComposition,
+  ): BindingIndex.SelectedGraphComposition {
+    return graphCompositions.getOrPut(GraphCompositionKey(path, module), create)
+  }
+
+  internal fun resolutionViewFor(
+    sourceIdentity: BindingIndex.SourcePointerIdentity?,
+    pointer: SmartPsiElementPointer<out KtElement>,
+  ): ResolutionModuleView? {
+    val frozenInputs = index.resolutionInputs
+    val file = sourceIdentity?.file ?: pointer.virtualFile
+    val view = frozenInputs.moduleViewFor(file) ?: return null
+    return ResolutionModuleView(
+      view.module,
+      view.resolutionScope,
+      view.daggerAnvilInteropEnabled,
+    )
+  }
+
+  internal class PlannedGraphQuery(
+    val queryContext: GraphQueryContext,
+    val aggregateSelection: BindingIndex.ContributionSelection,
+  ) {
+    var structure: BindingIndex.GraphQueryStructure? = null
+    var editorPlan: BindingIndex.GraphQueryPlan? = null
+  }
+
+  private data class GraphCompositionKey(val path: GraphPath, val module: KaModule)
+}
+
+internal data class ResolutionModuleView(
+  val module: KaModule,
+  val resolutionScope: DeclarationResolutionScope,
+  val daggerAnvilInteropEnabled: Boolean,
+)

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
@@ -207,7 +207,10 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
       checkNotNull(index.consumerEntryAt(file.declarationsIncludingNested().property("value")))
 
     assertSame(parentContext.dynamicGraph, childContext.dynamicGraph)
-    assertEquals(listOf(childContext), index.extensionContextsOf(parentContext))
+    assertEquals(
+      listOf(childContext.path),
+      index.extensionContextsOf(parentContext).map { it.path },
+    )
     assertEquals(listOf("provideFake"), index.providerNames(childConsumer, childContext))
 
     val results =

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroIndexDependenciesTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroIndexDependenciesTest.kt
@@ -3,12 +3,16 @@
 package dev.zacsweers.metro.idea
 
 import com.intellij.openapi.components.service
+import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import dev.zacsweers.metro.compiler.MetroOptions
 import dev.zacsweers.metro.compiler.graph.WrappedType
 import dev.zacsweers.metro.idea.index.MetroResolutionService
 import dev.zacsweers.metro.idea.model.KaBinding
 import dev.zacsweers.metro.idea.model.multibindingId
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import org.jetbrains.kotlin.psi.KtFile
 
 /**
@@ -239,6 +243,106 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
       setOf("test.Consumer", "kotlin.String", "test.Tracker"),
       accessors.map { it.key.renderedType }.toSet(),
     )
+  }
+
+  fun testParallelSessionsDoNotShareStateOrExpandUnrelatedGraphs() {
+    val file = configure()
+    myFixture.addFileToProject(
+      "test/UnrelatedGraph.kt",
+      """
+      package test
+
+      import dev.zacsweers.metro.DependencyGraph
+
+      interface Missing
+
+      @DependencyGraph
+      interface UnrelatedGraph {
+        val missing: Missing
+      }
+      """
+        .trimIndent(),
+    )
+    val index = project.service<MetroResolutionService>().index(file)
+    val declarations = file.declarationsIncludingNested()
+    val consumer = checkNotNull(index.consumerEntryAt(declarations.property("baseUrl")))
+    assertNotNull(consumer.graphId)
+    val unrelatedGraph = index.graphs.single { it.name == "UnrelatedGraph" }
+    val ready = CountDownLatch(2)
+    val start = CountDownLatch(1)
+
+    fun resolveInNewSession(): CompletableFuture<Triple<List<String?>, List<String>, Boolean>> {
+      return CompletableFuture.supplyAsync {
+        ready.countDown()
+        start.await()
+        index.withResolutionSession { session ->
+          val resolution = session.resolveConsumer(consumer)
+          Triple(
+            resolution.perContext.keys.map { it.graph.name },
+            resolution.perContext.values.flatten().map { it.label },
+            session.hasComputedContextsFor(unrelatedGraph),
+          )
+        }
+      }
+    }
+
+    val first = resolveInNewSession()
+    val second = resolveInNewSession()
+    try {
+      assertTrue(ready.await(30, TimeUnit.SECONDS))
+    } finally {
+      start.countDown()
+    }
+    PlatformTestUtil.waitForFuture(first, 30_000)
+    PlatformTestUtil.waitForFuture(second, 30_000)
+    val firstResult = first.join()
+    val secondResult = second.join()
+
+    assertEquals(firstResult, secondResult)
+    assertEquals(listOf("AppGraph"), firstResult.first)
+    assertEquals(listOf("provides"), firstResult.second)
+    assertFalse(firstResult.third)
+  }
+
+  fun testGraphOwnedConsumerIncludesDescendantContextsWithoutExpandingUnrelatedGraphs() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        @DependencyGraph
+        interface AppGraph {
+          val value: String
+          val child: ChildGraph
+
+          @Provides fun provideValue(): String = "app"
+        }
+
+        @GraphExtension
+        interface ChildGraph
+
+        @DependencyGraph
+        interface UnrelatedGraph {
+          val unrelated: Long
+        }
+        """
+      )
+    val index = project.service<MetroResolutionService>().index(file)
+    val declarations = file.declarationsIncludingNested()
+    val consumer = checkNotNull(index.consumerEntryAt(declarations.property("value")))
+    val unrelatedGraph = index.graphs.single { it.name == "UnrelatedGraph" }
+
+    index.withResolutionSession { session ->
+      val resolution = session.resolveConsumer(consumer)
+
+      assertEquals(
+        listOf("AppGraph", "ChildGraph"),
+        resolution.perContext.keys.map { it.graph.name },
+      )
+      assertEquals(
+        listOf(listOf("provides"), listOf("provides")),
+        resolution.perContext.values.map { bindings -> bindings.map { it.label } },
+      )
+      assertFalse(session.hasComputedContextsFor(unrelatedGraph))
+    }
   }
 
   fun testProvidesReceiverIsADependencyAndConsumer() {

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroIndexDependenciesTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroIndexDependenciesTest.kt
@@ -246,7 +246,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
   }
 
   fun testParallelSessionsDoNotShareStateOrExpandUnrelatedGraphs() {
-    val file = configure()
+    // Configure the editor after adding the second file so both sources are ready for indexing.
     myFixture.addFileToProject(
       "test/UnrelatedGraph.kt",
       """
@@ -263,6 +263,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
       """
         .trimIndent(),
     )
+    val file = configure()
     val index = project.service<MetroResolutionService>().index(file)
     val declarations = file.declarationsIncludingNested()
     val consumer = checkNotNull(index.consumerEntryAt(declarations.property("baseUrl")))

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroMultiModuleResolutionTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroMultiModuleResolutionTest.kt
@@ -19,13 +19,16 @@ import com.intellij.testFramework.runInEdtAndWait
 import dev.zacsweers.metro.compiler.diagnostics.MetroDiagnosticId
 import dev.zacsweers.metro.idea.graph.KaGraphValidationResult
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
-import dev.zacsweers.metro.idea.index.ConsumerGraphContexts
+import dev.zacsweers.metro.idea.index.ConsumerOwnershipBundle
 import dev.zacsweers.metro.idea.index.MetroResolutionService
 import dev.zacsweers.metro.idea.model.BindingIndex
+import dev.zacsweers.metro.idea.model.BindingIndexBuilder
 import dev.zacsweers.metro.idea.model.ContributionEntry
 import dev.zacsweers.metro.idea.model.GraphDeclarationId
 import dev.zacsweers.metro.idea.model.HintAvailability
 import dev.zacsweers.metro.idea.model.KaBinding
+import dev.zacsweers.metro.idea.model.sourcePointerIdentity
+import java.util.IdentityHashMap
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModuleProvider
 import org.jetbrains.kotlin.idea.facet.KotlinFacetType
 import org.jetbrains.kotlin.idea.facet.initializeIfNeeded
@@ -90,6 +93,50 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     } finally {
       super.tearDown()
     }
+  }
+
+  fun testResolutionInputsShareFileOrdinalsAcrossIsolatedModuleViews() {
+    val libraryFile =
+      fixture.addFileToProject(
+        "library/lib/LibraryService.kt",
+        """
+        package lib
+
+        import dev.zacsweers.metro.Inject
+
+        @Inject class LibraryService
+        """
+          .trimIndent(),
+      ) as KtFile
+    val appFile =
+      fixture.addFileToProject(
+        "app/app/AppGraph.kt",
+        """
+        package app
+
+        import dev.zacsweers.metro.DependencyGraph
+        import lib.LibraryService
+
+        @DependencyGraph
+        interface AppGraph {
+          val service: LibraryService
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
+    IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
+
+    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val inputs = index.resolutionInputs
+    val appView = checkNotNull(inputs.moduleViewFor(appFile.virtualFile))
+    val libraryView = checkNotNull(inputs.moduleViewFor(libraryFile.virtualFile))
+
+    assertSame(inputs.fileOrdinalTable, appView.fileOrdinalTable)
+    assertSame(inputs.fileOrdinalTable, libraryView.fileOrdinalTable)
+    assertFalse(appView.sharesVisibilityArrayWith(libraryView))
+    assertTrue(appView.resolutionScope.contains(libraryFile))
+    assertFalse(libraryView.resolutionScope.contains(appFile))
   }
 
   fun testContributedInterfacesProvideInheritedRootsAcrossModules() {
@@ -991,28 +1038,50 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
         isClassContribution = true,
         hintAvailability = availability,
       )
-    val restrictedIndex =
-      BindingIndex(
-        bindings = baseIndex.bindings + hiddenBinding,
-        consumers = baseIndex.consumers,
-        graphs = baseIndex.graphs,
-        contributions =
-          baseIndex.contributions +
-            ContributionEntry(
-              pointerManager.createSmartPsiElementPointer(hiddenService),
-              friendGraph.scopeKeys,
-              hiddenServiceId,
-              availability,
-            ) +
-            ContributionEntry(
-              pointerManager.createSmartPsiElementPointer(hiddenContainer),
-              friendGraph.scopeKeys,
-              hiddenContainerId,
-              availability,
-            ),
-        assistedSites = baseIndex.assistedSites,
-        bindingContainers = baseIndex.bindingContainers,
-      )
+    val restrictedBindings = baseIndex.bindings + hiddenBinding
+    val restrictedContributions =
+      baseIndex.contributions +
+        ContributionEntry(
+          pointerManager.createSmartPsiElementPointer(hiddenService),
+          friendGraph.scopeKeys,
+          hiddenServiceId,
+          availability,
+        ) +
+        ContributionEntry(
+          pointerManager.createSmartPsiElementPointer(hiddenContainer),
+          friendGraph.scopeKeys,
+          hiddenContainerId,
+          availability,
+        )
+    val capturedBindingSourceIdentities =
+      IdentityHashMap<KaBinding, BindingIndex.SourcePointerIdentity>(restrictedBindings.size)
+    val bindingsWithNestedGraphEntries = buildList {
+      addAll(restrictedBindings)
+      for (graph in baseIndex.graphs) {
+        for (contribution in graph.contributedInterfaces) addAll(contribution.bindings)
+      }
+      for (dynamicGraph in baseIndex.dynamicGraphs) addAll(dynamicGraph.containerInputs)
+    }
+    for (binding in bindingsWithNestedGraphEntries) {
+      val sourceIdentity = sourcePointerIdentity(binding.pointer) ?: continue
+      capturedBindingSourceIdentities[binding] = sourceIdentity
+    }
+    val hiddenBindingSourceIdentity = checkNotNull(capturedBindingSourceIdentities[hiddenBinding])
+    val restrictedBuilder =
+      BindingIndexBuilder().apply {
+        bindings += restrictedBindings
+        consumers += baseIndex.consumers
+        graphs += baseIndex.graphs
+        contributions += restrictedContributions
+        assistedSites += baseIndex.assistedSites
+        bindingContainers += baseIndex.bindingContainers
+        dynamicGraphs += baseIndex.dynamicGraphs
+        resolutionInputs = baseIndex.resolutionInputs
+        this.capturedBindingSourceIdentities = capturedBindingSourceIdentities
+      }
+    val restrictedIndex = restrictedBuilder.build()
+    capturedBindingSourceIdentities.clear()
+    assertEquals(hiddenBindingSourceIdentity, restrictedIndex.sourceIdentityFor(hiddenBinding))
 
     val unrelatedGraph = restrictedIndex.graphs.single { it.name == "UnrelatedGraph" }
     val friendContext =
@@ -1405,7 +1474,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
           }
         val owners =
           checkNotNull(
-            ConsumerGraphContexts(index.graphs).includedContainerPointers(includedConsumer)
+            ConsumerOwnershipBundle.build(index).includedContainerPointers(includedConsumer)
           )
         assertEquals(
           setOf(appModule, bridgeModule),
@@ -1674,7 +1743,10 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
           index.consumerEntryAt(ordinaryFile.declarationsIncludingNested().property("factory"))
         )
       val ordinaryResolution = index.resolveConsumer(ordinaryConsumer)
-      assertEquals(setOf(ordinaryContext), ordinaryResolution.perContext.keys)
+      assertEquals(
+        ordinaryContext.path,
+        ordinaryResolution.perContext.keys.single().path,
+      )
       assertTrue(ordinaryResolution.candidateBindings.isEmpty())
 
       val validation = fixture.project.service<MetroGraphValidationService>()
@@ -2021,7 +2093,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
           }
         val owners =
           checkNotNull(
-            ConsumerGraphContexts(index.graphs).includedContainerPointers(includedConsumer)
+            ConsumerOwnershipBundle.build(index).includedContainerPointers(includedConsumer)
           )
         assertEquals("Two graphs in the app module should share one owner", 2, owners.size)
         val ownerModules =

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
@@ -12,6 +12,7 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.ui.UIUtil
 import dev.zacsweers.metro.compiler.graph.WrappedType
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
+import dev.zacsweers.metro.idea.index.ConsumerOwnershipBundle
 import dev.zacsweers.metro.idea.index.IndexBuildPhase
 import dev.zacsweers.metro.idea.index.IndexBuildProgress
 import dev.zacsweers.metro.idea.index.IndexBuildProgressReporter
@@ -2202,7 +2203,12 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       )
 
       val useSites = allowAnalysisOnEdt {
-        sourceAssistedFactoryUseSites(project, index.bindings, index.consumers, index.graphs)
+        sourceAssistedFactoryUseSites(
+          project,
+          index.bindings,
+          index.consumers,
+          ConsumerOwnershipBundle.build(index),
+        )
       }
       val sharedUseSites = checkNotNull(useSites[specializedFactories.first()])
       assertEquals(1, sharedUseSites.size)

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
@@ -260,6 +260,18 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
 
     currentIndex = BindingIndex.EMPTY
     assertTrue(structure.children(root).isEmpty())
+    assertEquals(context.path, pinService.pinnedPath)
+
+    // Clear the pin only after a completed index confirms that its graph disappeared.
+    val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(file))
+    val graphNameStart = document.text.indexOf("interface AppGraph") + "interface ".length
+    WriteCommandAction.runWriteCommandAction(project) {
+      document.replaceString(graphNameStart, graphNameStart + "AppGraph".length, "ReplacementGraph")
+    }
+    PsiDocumentManager.getInstance(project).commitAllDocuments()
+    currentIndex = project.service<MetroResolutionService>().index(file)
+
+    assertEquals(listOf("ReplacementGraph"), structure.children(root).map { it.text })
     assertNull(pinService.pinnedPath)
   }
 

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
@@ -258,7 +258,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
       structure.children(root).map { (it as MetroTreeNode.Graph).context.path },
     )
 
-    currentIndex = BindingIndex(emptyList(), emptyList(), emptyList(), emptyList())
+    currentIndex = BindingIndex.EMPTY
     assertTrue(structure.children(root).isEmpty())
     assertNull(pinService.pinnedPath)
   }


### PR DESCRIPTION
Make each published IDE index immutable so background queries can read it safely while a new index is being built. Capture module visibility and declaration identities with the index so queries use a consistent view of the project.

Give each lookup operation its own session for temporary caches.
