### PR TITLE
Coordinate IDE index and presentation builds in the background

### DIFF
--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/MetroDaemonRestartService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/MetroDaemonRestartService.kt
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Batches Metro highlighting refreshes so the current daemon pass can finish first. */
+@Service(Service.Level.PROJECT)
+internal class MetroDaemonRestartService(private val project: Project) : Disposable {
+  private val restartPending = AtomicBoolean()
+  private val restartCheckScheduled = AtomicBoolean()
+  private val disposed = AtomicBoolean()
+
+  init {
+    project.messageBus
+      .connect(this)
+      .subscribe(
+        DaemonCodeAnalyzer.DAEMON_EVENT_TOPIC,
+        object : DaemonCodeAnalyzer.DaemonListener {
+          override fun daemonFinished() = schedulePendingRestart()
+
+          override fun daemonCancelEventOccurred(reason: String) = schedulePendingRestart()
+        },
+      )
+  }
+
+  fun requestRestart(inUnitTests: Boolean = false) {
+    if (
+      (ApplicationManager.getApplication().isUnitTestMode && !inUnitTests) ||
+        disposed.get() ||
+        project.isDisposed
+    ) {
+      return
+    }
+    restartPending.set(true)
+    schedulePendingRestart()
+  }
+
+  private fun schedulePendingRestart() {
+    if (!restartPending.get() || disposed.get() || project.isDisposed) return
+    val application = ApplicationManager.getApplication()
+    if (!application.isDispatchThread) {
+      if (!restartCheckScheduled.compareAndSet(false, true)) return
+      application.invokeLater {
+        restartCheckScheduled.set(false)
+        if (!disposed.get() && !project.isDisposed) restartIfIdle()
+      }
+      return
+    }
+    restartIfIdle()
+  }
+
+  private fun restartIfIdle() {
+    if (!restartPending.get() || disposed.get() || project.isDisposed) return
+    val daemon = DaemonCodeAnalyzer.getInstance(project)
+    if (daemon.isRunning) return
+    if (restartPending.compareAndSet(true, false)) {
+      daemon.restart("Metro IDE state changed")
+    }
+  }
+
+  override fun dispose() {
+    disposed.set(true)
+    restartPending.set(false)
+    restartCheckScheduled.set(false)
+  }
+}

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/MetroIdeProjectService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/MetroIdeProjectService.kt
@@ -2,16 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea
 
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import dev.zacsweers.metro.compiler.MetroOptions
 import dev.zacsweers.metro.compiler.circuit.CircuitClassIds
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.jetbrains.annotations.TestOnly
 import org.jetbrains.kotlin.idea.compiler.configuration.KotlinCommonCompilerArgumentsHolder
 import org.jetbrains.kotlin.idea.compiler.configuration.KotlinCompilerSettingsTracker
 import org.jetbrains.kotlin.idea.facet.getMergedCompilerArguments
@@ -19,6 +25,13 @@ import org.jetbrains.kotlin.name.ClassId
 
 private const val METRO_PLUGIN_OPTION_PREFIX = "plugin:$PLUGIN_ID:"
 private val DEFAULT_METRO_IDE_STATE = MetroIdeModuleState(MetroOptions())
+private val CURRENT_MODULE_STATE_KEY =
+  Key.create<CurrentModuleState>("dev.zacsweers.metro.idea.currentModuleState")
+
+private data class CurrentModuleState(
+  val compilerSettingsModificationCount: Long,
+  val state: MetroIdeModuleState,
+)
 
 /** Parsed Metro options plus IDE-specific derived caches for one module. */
 internal class MetroIdeModuleState(
@@ -97,19 +110,111 @@ internal class MetroIdeAnnotationClassIds(private val options: MetroOptions) {
  * @see org.jetbrains.kotlin.idea.compiler.configuration.KotlinCompilerSettingsTracker
  */
 @Service(Service.Level.PROJECT)
-class MetroIdeProjectService(private val project: Project) {
+class MetroIdeProjectService(
+  private val project: Project,
+  private val scope: CoroutineScope,
+) {
+  private val stateWarmupLock = Any()
+  private val pendingStateWarmups = mutableMapOf<Module, MutableSet<(Module) -> Unit>>()
+  private val stateWarmupObserver = AtomicReference<(() -> Unit)?>(null)
+
   internal fun state(element: PsiElement): MetroIdeModuleState {
     val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return DEFAULT_METRO_IDE_STATE
     return state(module)
   }
 
   internal fun state(module: Module): MetroIdeModuleState {
-    return CachedValuesManager.getManager(project).getCachedValue(module) {
-      val optionStrings = module.metroPluginOptionStrings()
-      CachedValueProvider.Result.create(
-        MetroIdeModuleState(parseMetroOptions(optionStrings), optionStrings),
-        KotlinCompilerSettingsTracker.getInstance(project),
+    val settingsTracker = KotlinCompilerSettingsTracker.getInstance(project)
+    val modificationCountBefore = settingsTracker.modificationCount
+    val state =
+      CachedValuesManager.getManager(project).getCachedValue(module) {
+        val optionStrings = module.metroPluginOptionStrings()
+        CachedValueProvider.Result.create(
+          MetroIdeModuleState(parseMetroOptions(optionStrings), optionStrings),
+          settingsTracker,
+        )
+      }
+    val modificationCountAfter = settingsTracker.modificationCount
+    if (modificationCountBefore == modificationCountAfter) {
+      module.putUserData(
+        CURRENT_MODULE_STATE_KEY,
+        CurrentModuleState(modificationCountAfter, state),
       )
+    }
+    return state
+  }
+
+  /** Returns cached current options, or schedules a background read and returns null. */
+  internal fun currentStateOrSchedule(element: PsiElement): MetroIdeModuleState? {
+    val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return DEFAULT_METRO_IDE_STATE
+    return currentStateOrSchedule(module)
+  }
+
+  /**
+   * Returns cached current options. A cache miss queues one background read per module and invokes
+   * [onReady] on that worker so callers can retry work that depends on the options.
+   */
+  internal fun currentStateOrSchedule(
+    module: Module,
+    onReady: ((Module) -> Unit)? = null,
+  ): MetroIdeModuleState? {
+    currentStateOrNull(module)?.let {
+      return it
+    }
+    scheduleStateWarmup(module, onReady)
+    return null
+  }
+
+  internal fun currentStateOrNull(module: Module): MetroIdeModuleState? {
+    val settingsTracker = KotlinCompilerSettingsTracker.getInstance(project)
+    val modificationCount = settingsTracker.modificationCount
+    val current = module.getUserData(CURRENT_MODULE_STATE_KEY) ?: return null
+    if (current.compilerSettingsModificationCount != modificationCount) return null
+    return current.state.takeIf { settingsTracker.modificationCount == modificationCount }
+  }
+
+  @TestOnly
+  internal fun setStateWarmupObserver(observer: (() -> Unit)?) {
+    stateWarmupObserver.set(observer)
+  }
+
+  @TestOnly
+  internal fun clearCurrentState(module: Module) {
+    module.putUserData(CURRENT_MODULE_STATE_KEY, null)
+  }
+
+  private fun scheduleStateWarmup(module: Module, onReady: ((Module) -> Unit)?) {
+    if (project.isDisposed || module.isDisposed) return
+    val shouldLaunch =
+      synchronized(stateWarmupLock) {
+        val callbacks = pendingStateWarmups[module]
+        if (callbacks != null) {
+          if (onReady != null) callbacks += onReady
+          false
+        } else {
+          pendingStateWarmups[module] = if (onReady == null) linkedSetOf() else linkedSetOf(onReady)
+          true
+        }
+      }
+    if (!shouldLaunch) return
+    scope.launch {
+      var warmed = false
+      try {
+        readAction {
+          if (!project.isDisposed && !module.isDisposed) {
+            stateWarmupObserver.get()?.invoke()
+            state(module)
+            warmed = true
+          }
+        }
+      } finally {
+        val callbacks =
+          synchronized(stateWarmupLock) { pendingStateWarmups.remove(module).orEmpty() }
+        if (warmed && !project.isDisposed && !module.isDisposed) {
+          callbacks.forEach { it(module) }
+          project.service<MetroDaemonRestartService>().requestRestart()
+        }
+      }
     }
   }
 }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/MetroSettings.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/MetroSettings.kt
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea
 
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.openapi.components.BaseState
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.SimplePersistentStateComponent
@@ -26,6 +25,9 @@ class MetroSettingsState : BaseState() {
 
   /** Shows binding navigation in the editor without disabling graph browsing or validation. */
   var enableBindingResolution by property(true)
+
+  /** Keeps graph and binding data current as project code changes. */
+  var automaticallyRefreshGraphData by property(true)
 
   /** Also resolve bindings from compiled dependencies (inject classes, contribution hints). */
   var resolveFromLibraries by property(true)
@@ -72,6 +74,11 @@ class MetroSettingsConfigurable(private val project: Project) : BoundConfigurabl
         .bindSelected(state::resolveFromLibraries)
         .comment("Includes bindings contributed by compiled project dependencies")
     }
+    row {
+      checkBox("Automatically refresh graphs and bindings after code changes")
+        .bindSelected(state::automaticallyRefreshGraphData)
+        .comment("When disabled, use Refresh in the Metro tool window to update graph data")
+    }
     indent {
       row {
         checkBox("Show \"assisted\" inlay hints")
@@ -86,9 +93,9 @@ class MetroSettingsConfigurable(private val project: Project) : BoundConfigurabl
 
   override fun apply() {
     super.apply()
-    // Refresh cached indexes when binary dependency resolution changes.
+    // Apply changes to library resolution and automatic graph refresh.
     project.service<MetroResolutionService>().settingsChanged()
-    // Re-run highlighting so the gates take effect without further edits
-    DaemonCodeAnalyzer.getInstance(project).restart()
+    // Apply editor display settings without waiting for a source edit.
+    project.service<MetroDaemonRestartService>().requestRestart(inUnitTests = true)
   }
 }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/MetroGraphValidationService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/MetroGraphValidationService.kt
@@ -127,7 +127,7 @@ internal class MetroGraphValidationService(
     val key = cacheKey(context) ?: return null
     val entry = results[key] ?: return null
     val contextElement = context.contextPointer.element ?: element
-    val currentIndex = project.service<MetroResolutionService>().index(contextElement)
+    val currentIndex = project.service<MetroResolutionService>().cachedIndex(contextElement)
     return CachedValidation(entry.result, stale = entry.index !== currentIndex)
   }
 
@@ -243,7 +243,7 @@ internal class MetroGraphValidationService(
     onProgress: (GraphValidationProgress) -> Unit = {},
   ): List<KaGraphValidationResult> {
     val declarationElement = graph.pointer.element ?: element
-    val index = project.service<MetroResolutionService>().index(declarationElement)
+    val index = project.service<MetroResolutionService>().currentIndex(declarationElement)
     val currentGraph =
       index.graphFor(graph)
         ?: throw CancellationException("Metro graph declaration is no longer current")
@@ -335,7 +335,7 @@ internal class MetroGraphValidationService(
     context: GraphContext,
   ): ValidationInput? {
     val contextElement = context.contextPointer.element ?: declarationFallback
-    val index = project.service<MetroResolutionService>().index(contextElement)
+    val index = project.service<MetroResolutionService>().currentIndex(contextElement)
     val currentContext = index.findContext(context.path) ?: return null
     val currentContextElement = currentContext.contextPointer.element ?: return null
     return ValidationInput(currentContextElement, index, currentContext)
@@ -346,7 +346,7 @@ internal class MetroGraphValidationService(
     context: GraphContext,
   ): ValidationInput {
     val contextElement = context.contextPointer.element ?: declarationFallback
-    val index = project.service<MetroResolutionService>().index(contextElement)
+    val index = project.service<MetroResolutionService>().currentIndex(contextElement)
     val currentContext =
       index.findContext(context.path)
         ?: throw CancellationException("Metro graph context is no longer current")

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroCodeVisionProvider.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroCodeVisionProvider.kt
@@ -51,7 +51,7 @@ class MetroCodeVisionProvider : DaemonBoundCodeVisionProvider {
       return emptyList()
     }
     if (!ktFile.metroIdeState().isEnabled) return emptyList()
-    val index = ktFile.project.service<MetroResolutionService>().index(ktFile)
+    val index = ktFile.project.service<MetroResolutionService>().presentationIndex(ktFile)
     val pinService = ktFile.project.service<GraphContextPinService>()
 
     val entries = mutableListOf<Pair<TextRange, CodeVisionEntry>>()

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroInjectedImplementationInlayProvider.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroInjectedImplementationInlayProvider.kt
@@ -52,7 +52,7 @@ class MetroInjectedImplementationInlayProvider : InlayHintsProvider {
     override fun collectFromElement(element: PsiElement, sink: InlayTreeSink) {
       if (element !is KtParameter && element !is KtProperty && element !is KtNamedFunction) return
       element as KtElement
-      val index = element.project.service<MetroResolutionService>().index(element)
+      val index = element.project.service<MetroResolutionService>().presentationIndex(element)
       // Only implicitly assisted parameters get the inlay; explicit @Assisted already reads as
       // assisted in source.
       if (

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroLineMarkerProvider.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroLineMarkerProvider.kt
@@ -87,7 +87,7 @@ class MetroLineMarkerProvider : RelatedItemLineMarkerProvider() {
     if (!MetroSettings.getInstance(element.project).state.enableBindingResolution) return
     if (!declaration.metroIdeState().isEnabled) return
 
-    val index = element.project.service<MetroResolutionService>().index(declaration)
+    val index = element.project.service<MetroResolutionService>().presentationIndex(declaration)
 
     if (GRAPH_OPTION.isEnabled || VALIDATE_OPTION.isEnabled) {
       (declaration as? KtClassOrObject)

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroResolutionService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroResolutionService.kt
@@ -200,6 +200,7 @@ class MetroResolutionService(
   /** Retains requested modules for later automatic rebuilds. */
   private val demandedModules = linkedSetOf<Module>()
   private var pendingPsiChanges = PendingPsiChanges()
+  @Volatile private var psiClassificationObserver: (() -> Unit)? = null
   private var projectInputsPending = false
   private var settingsPending = false
   private var pendingManualRefresh: ManualRefreshRequest? = null
@@ -560,24 +561,35 @@ class MetroResolutionService(
     return satisfied.isNotEmpty()
   }
 
+  /** Retains the batch when classification or its conservative fallback is interrupted. */
   private suspend fun processPendingPsiChanges() {
     val batch = pendingPsiChanges
     pendingPsiChanges = PendingPsiChanges()
+    try {
+      classifyAndApplyPsiChanges(batch)
+    } catch (_: ProcessCanceledException) {
+      mergePendingPsiChanges(batch)
+      yield()
+    } catch (exception: CancellationException) {
+      mergePendingPsiChanges(batch)
+      throw exception
+    }
+  }
+
+  /** Falls back to full invalidation when classification fails without cancellation. */
+  private suspend fun classifyAndApplyPsiChanges(batch: PendingPsiChanges) {
     try {
       val classified =
         smartReadAction(project) {
           checkPsiClassificationActive()
           classifyPsiChanges(batch)
         }
+      psiClassificationObserver?.invoke()
       checkPsiClassificationActive()
       applyClassifiedPsiChanges(classified)
-    } catch (exception: ProcessCanceledException) {
-      mergePendingPsiChanges(batch)
-      yield()
-    } catch (exception: CancellationException) {
-      mergePendingPsiChanges(batch)
-      throw exception
     } catch (failure: Throwable) {
+      if (failure is ProcessCanceledException) throw failure
+      if (failure is CancellationException) throw failure
       checkPsiClassificationActive()
       logger<MetroResolutionService>().warn("Metro PSI invalidation failed", failure)
       val requested = failedClassificationRequests(batch)
@@ -2673,14 +2685,22 @@ class MetroResolutionService(
     return requested
   }
 
-  /** Stops VFS access when JVM shutdown precedes cancellation of the project service scope. */
-  private fun checkPsiClassificationActive() {
-    val ownerDisposed = isDisposed || project.isDisposed
+  /** Keeps captured project unavailability retryable and stops VFS access during shutdown. */
+  internal fun checkPsiClassificationActive(projectDisposed: Boolean = project.isDisposed) {
     val applicationStopping =
       ShutDownTracker.isShutdownStarted() || ApplicationManager.getApplication().isDisposed
-    if (ownerDisposed || applicationStopping) {
+    if (isDisposed || applicationStopping) {
       throw CancellationException("Metro PSI classification stopped during disposal")
     }
+    // Light projects can temporarily close while their service scope stays alive. Preserve the
+    // batch until another event wakes the coordinator after the project becomes available again.
+    if (projectDisposed) throw ProcessCanceledException()
+  }
+
+  /** Lets lifecycle tests interrupt classification after its read and before applying changes. */
+  @TestOnly
+  internal fun setPsiClassificationObserver(observer: (() -> Unit)?) {
+    psiClassificationObserver = observer
   }
 
   /** Called by the coordinator inside a smart read action. */
@@ -2941,6 +2961,7 @@ class MetroResolutionService(
 
   override fun dispose() {
     publishedResolution.value = PublishedResolution.DISPOSED
+    psiClassificationObserver = null
     val abandonedEvents = ingress.close()
     for (event in abandonedEvents) {
       when (event) {

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroResolutionService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/MetroResolutionService.kt
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea.index
 
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.facet.Facet
 import com.intellij.facet.FacetManager
 import com.intellij.facet.FacetManagerListener
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.readAction
 import com.intellij.openapi.application.smartReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -18,6 +18,7 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.runBlockingCancellable
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootEvent
@@ -25,6 +26,7 @@ import com.intellij.openapi.roots.ModuleRootListener
 import com.intellij.openapi.roots.ProjectRootModificationTracker
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.ShutDownTracker
 import com.intellij.openapi.util.SimpleModificationTracker
 import com.intellij.openapi.util.UserDataHolderEx
 import com.intellij.openapi.vfs.VirtualFile
@@ -43,6 +45,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import dev.zacsweers.metro.compiler.MetroOptions
 import dev.zacsweers.metro.compiler.circuit.CircuitClassIds
 import dev.zacsweers.metro.compiler.mapToSet
+import dev.zacsweers.metro.idea.MetroDaemonRestartService
 import dev.zacsweers.metro.idea.MetroIdeModuleState
 import dev.zacsweers.metro.idea.MetroIdeProjectService
 import dev.zacsweers.metro.idea.MetroSettings
@@ -66,6 +69,7 @@ import dev.zacsweers.metro.idea.model.GraphDeclarationId
 import dev.zacsweers.metro.idea.model.GraphDefaultImplementation
 import dev.zacsweers.metro.idea.model.GraphExtensionFactoryAccessor
 import dev.zacsweers.metro.idea.model.GraphReference
+import dev.zacsweers.metro.idea.model.IndexGenerationToken
 import dev.zacsweers.metro.idea.model.KaAnnotationSnapshot
 import dev.zacsweers.metro.idea.model.KaBinding
 import dev.zacsweers.metro.idea.model.KaContextualTypeKey
@@ -78,18 +82,32 @@ import dev.zacsweers.metro.idea.model.sourcePointerIdentity
 import java.util.Collections
 import java.util.IdentityHashMap
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.kotlin.analysis.api.KaPlatformInterface
-import org.jetbrains.kotlin.analysis.api.permissions.allowAnalysisOnEdt
 import org.jetbrains.kotlin.analysis.api.platform.projectStructure.KaResolutionScope
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModuleProvider
@@ -105,96 +123,144 @@ import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtTypeAlias
 
 /**
- * Shared resolution service powering Metro's editor decorations, graph browser, and validation.
+ * Builds and caches the binding data used by editor decorations, the graph browser, and validation.
  *
  * A cold snapshot discovers candidate Kotlin files through stub indexes. Later PSI changes rebuild
  * only the changed file and shards that explicitly depend on it. Binary declarations live in a
- * separate cache so unrelated source edits do not repeat classpath analysis.
+ * separate cache so unrelated source edits do not repeat classpath analysis. One coordinator owns
+ * pending changes and publishes complete immutable generations for concurrent readers. Explicit
+ * queries use the current generation. In manual refresh mode, editor features keep the last
+ * presentation generation until the user refreshes it.
+ *
+ * The supplied scope owns background execution. IntelliJ injects a scope using Dispatchers.Default.
  */
 @Service(Service.Level.PROJECT)
 class MetroResolutionService(
   private val project: Project,
   private val scope: CoroutineScope,
 ) : Disposable {
-  // Project-wide indexes are deduped by options that actually affect IDE extraction. Gradle emits
-  // module-specific report/trace destinations, but those paths do not change declaration semantics.
-  private val snapshots: MutableMap<SnapshotKey, IndexSnapshot> =
-    Collections.synchronizedMap(
-      object : LinkedHashMap<SnapshotKey, IndexSnapshot>(8, 0.75f, true) {
-        override fun removeEldestEntry(
-          eldest: MutableMap.MutableEntry<SnapshotKey, IndexSnapshot>
-        ): Boolean = size > MAX_CACHED_INDEXES
-      }
+  private val libraryShards =
+    object : LinkedHashMap<LibraryCacheKey, LibraryShard>(8, 0.75f, true) {
+      override fun removeEldestEntry(
+        eldest: MutableMap.MutableEntry<LibraryCacheKey, LibraryShard>
+      ): Boolean = size > MAX_CACHED_INDEXES
+    }
+
+  private val mutableIndexBuildProgress = MutableStateFlow<IndexBuildProgress?>(null)
+  /** Latest progress of the coordinator's current index build. */
+  internal val indexBuildProgress: StateFlow<IndexBuildProgress?> =
+    mutableIndexBuildProgress.asStateFlow()
+  /** Broadcasts refresh signals to all active tool-window listeners. */
+  private val indexChanges =
+    MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+  /** Coalesces pending refresh requests until the EDT can notify listeners. */
+  private val notificationRequests = Channel<Unit>(Channel.CONFLATED)
+  /** Cancels EDT delivery and disposable-bound collectors when this service is disposed. */
+  private val notificationScope =
+    CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext[Job]))
+  /** Previous alias and constant contents, used to recognize edits that affect other files. */
+  private val sharedDeclarationFingerprints = mutableMapOf<VirtualFile, String>()
+  /** Remembers irrelevant files so repeated queries leave the current index intact. */
+  private val knownIrrelevantFiles = mutableSetOf<VirtualFile>()
+  /** Readers observe complete generations together with their browser and lifecycle state. */
+  private val publishedResolution = MutableStateFlow(PublishedResolution.EMPTY)
+  private val isDisposed: Boolean
+    get() = publishedResolution.value.isDisposed
+
+  private val retryAutomaticIndexAfterStateWarmup: (Module) -> Unit = { module ->
+    if (automaticallyRefreshGraphData && !isDisposed && !project.isDisposed && !module.isDisposed) {
+      index(module, IndexRequestMode.AUTOMATIC_BACKGROUND)
+    }
+  }
+  private val retryExplicitIndexAfterStateWarmup: (Module) -> Unit = { module ->
+    if (!isDisposed && !project.isDisposed && !module.isDisposed) {
+      index(module, IndexRequestMode.BACKGROUND)
+    }
+  }
+
+  /** Only the resolution coordinator reads or changes this pending source work. */
+  private val pendingDirtyFiles = linkedSetOf<VirtualFile>()
+  private val pendingRequestedFiles = linkedSetOf<VirtualFile>()
+  private var forceAllFiles = false
+  private var semanticRevision = 0L
+  private var sourceSnapshot: SourceSnapshot? = null
+  /** Accepts callbacks from any thread and wakes the coordinator with coalesced requests. */
+  private val ingress =
+    ResolutionIngress(
+      coalescingKey = ResolutionCoordinatorEvent::coalescingKey,
+      merge = ::mergeResolutionCoordinatorEvents,
     )
+  /** Combines requests by module while retaining every caller waiting for the result. */
+  private val pendingBuilds = linkedMapOf<Module, PendingIndexBuild>()
+  /** Retains requested modules for later automatic rebuilds. */
+  private val demandedModules = linkedSetOf<Module>()
+  private var pendingPsiChanges = PendingPsiChanges()
+  private var projectInputsPending = false
+  private var settingsPending = false
+  private var pendingManualRefresh: ManualRefreshRequest? = null
+  /** Clocks captured at the last event drain, used to reject superseded work. */
+  private var coordinatorSnapshot = ingress.snapshot()
+  private val coordinatorJob: Job
+  private val pendingFilePresentationRequests = linkedMapOf<FilePresentationKey, BindingIndex>()
+  private val completedFilePresentationBundles = ArrayDeque<CompletedFilePresentationBundle>()
+  private val pendingFilePresentationAnchorRequests =
+    linkedMapOf<FilePresentationKey, PendingFilePresentationAnchorBuild>()
+  private val completedFilePresentationAnchorBundles =
+    ArrayDeque<CompletedFilePresentationAnchorBundle>()
+  private val pendingCoordinatorBarriers = mutableListOf<CompletableDeferred<Unit>>()
 
-  private val libraryShards: MutableMap<LibraryCacheKey, LibraryShard> =
-    Collections.synchronizedMap(
-      object : LinkedHashMap<LibraryCacheKey, LibraryShard>(8, 0.75f, true) {
-        override fun removeEldestEntry(
-          eldest: MutableMap.MutableEntry<LibraryCacheKey, LibraryShard>
-        ): Boolean = size > MAX_CACHED_INDEXES
-      }
-    )
+  /** The coordinator caps this cache and publishes immutable copies for readers. */
+  private val filePresentationBundles =
+    LinkedHashMap<FilePresentationKey, FilePresentationBundle>(MAX_FILE_PRESENTATION_BUNDLES)
+  /** Active attempts retain their worker slots until completion, including during cancellation. */
+  private val filePresentationBuilds =
+    mutableMapOf<FilePresentationKey, FilePresentationBuildAttempt>()
+  private val filePresentationAnchorBuilds =
+    mutableMapOf<FilePresentationKey, FilePresentationAnchorBuildAttempt>()
 
-  private val listeners = Collections.newSetFromMap(ConcurrentHashMap<() -> Unit, Boolean>())
-  private val indexBuildProgressListeners =
-    Collections.newSetFromMap(ConcurrentHashMap<(IndexBuildProgress?) -> Unit, Boolean>())
-  private val indexBuildProgress = AtomicReference<IndexBuildProgress?>(null)
-  /** Pre-change shared declarations, so broad PSI events do not invalidate unrelated edits. */
-  private val sharedDeclarationFingerprints = ConcurrentHashMap<VirtualFile, String>()
-  private val invalidationPending = AtomicBoolean()
-  /** The first source state in a batch of roots, facet, or compiler-settings callbacks. */
-  private val pendingProjectInputs = AtomicReference<PendingProjectInputs?>(null)
-  private val graphBrowserActivated = AtomicBoolean()
-  private val disposed = AtomicBoolean()
+  /** Declaration identities captured with each index generation's source ranges. */
+  private val declarationAnchorSignatures =
+    ConcurrentHashMap<
+      IndexGenerationToken,
+      Map<BindingIndex.SourcePointerIdentity, DeclarationAnchorSignature>,
+    >()
+  private var nextFilePresentationAttemptId = 0L
 
-  /**
-   * The pending-invalidation ledger. Every mutation replaces the whole immutable value, so a
-   * builder can drain it at the start of a pass and publish results with one compare-and-set. Any
-   * concurrent invalidation changes the reference and fails the publish, forcing a re-drain.
-   * Builders always run inside read actions, so PSI itself cannot change mid-pass. The ledger is
-   * the only state other threads can move underneath a build.
-   */
-  private val invalidations = AtomicReference(Invalidations())
-
-  /** The last fully built source view. Published atomically after a successful drain. */
-  private val sourceSnapshot = AtomicReference<SourceSnapshot?>(null)
-
-  /** Keys whose background builds were requested from the EDT, drained by [buildWorker]. */
-  private val pendingBuilds = ConcurrentHashMap<SnapshotKey, Module>()
-  private val buildSignal = Channel<Unit>(Channel.CONFLATED)
-
-  private val lastResolveFromLibraries =
-    AtomicBoolean(MetroSettings.getInstance(project).state.resolveFromLibraries)
-  private val fingerprintsByModuleState: MutableMap<MetroIdeModuleState, IndexOptionsFingerprint> =
-    Collections.synchronizedMap(
-      object : LinkedHashMap<MetroIdeModuleState, IndexOptionsFingerprint>(16, 0.75f, true) {
-        override fun removeEldestEntry(
-          eldest: MutableMap.MutableEntry<MetroIdeModuleState, IndexOptionsFingerprint>
-        ): Boolean = size > MAX_CACHED_OPTION_FINGERPRINTS
-      }
-    )
+  private var lastResolveFromLibraries =
+    MetroSettings.getInstance(project).state.resolveFromLibraries
+  private var lastAutomaticallyRefreshGraphData = automaticallyRefreshGraphData
 
   init {
     PsiManager.getInstance(project)
       .addPsiTreeChangeListener(
         object : PsiTreeChangeAdapter() {
           override fun beforeChildRemoval(event: PsiTreeChangeEvent) =
-            psiChanged(event, structuralChange = isFileStructureChange(event))
+            psiChanged(
+              event,
+              structuralChange = isFileStructureChange(event),
+              oldTreeMayDisappear = true,
+            )
 
           override fun beforeChildMovement(event: PsiTreeChangeEvent) =
-            psiChanged(event, structuralChange = isFileStructureChange(event))
+            psiChanged(
+              event,
+              structuralChange = isFileStructureChange(event),
+              oldTreeMayDisappear = true,
+            )
 
           override fun beforePropertyChange(event: PsiTreeChangeEvent) =
             psiChanged(event, structuralChange = isFileStructureChange(event))
 
-          override fun beforeChildReplacement(event: PsiTreeChangeEvent) = psiChanged(event)
+          override fun beforeChildReplacement(event: PsiTreeChangeEvent) =
+            psiChanged(event, oldTreeMayDisappear = true)
 
-          override fun beforeChildrenChange(event: PsiTreeChangeEvent) = psiChanged(event)
+          override fun beforeChildrenChange(event: PsiTreeChangeEvent) =
+            psiChanged(event, oldTreeMayDisappear = true)
 
           override fun childAdded(event: PsiTreeChangeEvent) =
             psiChanged(event, structuralChange = isFileStructureChange(event))
@@ -237,58 +303,957 @@ class MetroResolutionService(
         override fun <T> settingsChanged(oldSettings: T?, newSettings: T?) = projectInputsChanged()
       },
     )
-    scope.launch { buildWorker() }
+    coordinatorJob = scope.launch { resolutionCoordinator() }
+    notificationScope.launch(Dispatchers.EDT) { deliverIndexChanges() }
   }
 
-  /** Drains UI-requested background builds one at a time on the service scope. */
-  private suspend fun buildWorker() {
+  /** Processes resolution requests in priority order. */
+  private suspend fun resolutionCoordinator() {
     try {
-      for (unused in buildSignal) {
-        while (true) {
-          val (key, module) = pendingBuilds.entries.firstOrNull() ?: break
-          pendingBuilds.remove(key, module)
-          val progress = IndexBuildProgressReporter(::publishIndexBuildProgress)
-          progress.phase(IndexBuildPhase.QUEUED)
-          val built =
-            try {
-              retryCancelledIndexBuild {
-                smartReadAction(project) { buildCurrentIndex(module, key, progress) }
+      for (unused in ingress.wakeups) {
+        drainCoordinatorEvents()
+        while (!isDisposed && !project.isDisposed && hasRunnableCoordinatorWork()) {
+          val coordinatorMetadataMayHaveChanged =
+            when {
+              !pendingPsiChanges.isEmpty -> {
+                processPendingPsiChanges()
+                true
               }
-            } catch (exception: CancellationException) {
-              throw exception
-            } catch (failure: Throwable) {
-              // The worker must survive analysis failures or every future EDT-scheduled build
-              // would silently stop. Requesters reschedule on their next query.
-              logger<MetroResolutionService>()
-                .warn("Metro index build failed for ${module.name}", failure)
-              continue
+              projectInputsPending -> {
+                processPendingProjectInputs()
+                true
+              }
+              settingsPending -> {
+                processPendingSettings()
+                true
+              }
+              pendingManualRefresh != null -> {
+                processResolutionCandidate(manualRefresh = true)
+                true
+              }
+              completeSatisfiedBuildRequests() -> false
+              pendingBuilds.isNotEmpty() -> {
+                processResolutionCandidate(manualRefresh = false)
+                true
+              }
+              completedFilePresentationBundles.isNotEmpty() -> {
+                publishCompletedFileBundles()
+                false
+              }
+              completedFilePresentationAnchorBundles.isNotEmpty() -> {
+                publishCompletedFilePresentationAnchors()
+                false
+              }
+              else -> {
+                startPendingFileBundles()
+                false
+              }
             }
-          if (built === BindingIndex.EMPTY) {
-            continue
+          if (coordinatorMetadataMayHaveChanged) {
+            publishCoordinatorMetadata()
           }
-          withContext(Dispatchers.EDT) {
-            val current = snapshots[key]
-            if (!project.isDisposed && current?.index === built) {
-              notifyListeners(restartDaemon = true)
-            }
-          }
+          drainCoordinatorEvents()
         }
-        publishIndexBuildProgress(null)
+        completeCoordinatorBarriers()
+        if (pendingBuilds.isEmpty()) publishIndexBuildProgress(null)
       }
     } finally {
+      cancelCoordinatorWork()
       publishIndexBuildProgress(null)
     }
   }
 
-  /** Returns the current index for [element]'s module, or an empty index when Metro is inactive. */
-  internal fun index(element: PsiElement): BindingIndex {
+  private fun drainCoordinatorEvents() {
+    val drained = ingress.drain()
+    coordinatorSnapshot = drained.snapshot
+    for (event in drained.events) {
+      when (event) {
+        is ResolutionCoordinatorEvent.Psi -> mergePendingPsiChanges(event.changes)
+        ResolutionCoordinatorEvent.ProjectInputs -> projectInputsPending = true
+        ResolutionCoordinatorEvent.Settings -> settingsPending = true
+        is ResolutionCoordinatorEvent.PresentationDemand -> demandedModules += event.module
+        is ResolutionCoordinatorEvent.Build -> mergePendingBuild(event)
+        is ResolutionCoordinatorEvent.ManualRefresh -> {
+          pendingManualRefresh = ManualRefreshRequest(event.requestId)
+        }
+        is ResolutionCoordinatorEvent.FilePresentationRequest -> {
+          if (isPresentationIndexPublished(event.index) && !hasFilePresentationWork(event.key)) {
+            pendingFilePresentationRequests.putIfAbsent(event.key, event.index)
+          }
+        }
+        is ResolutionCoordinatorEvent.FilePresentationComplete -> {
+          val activeAttempt = filePresentationBuilds[event.key]
+          val accepted = activeAttempt?.id == event.attemptId && activeAttempt.index === event.index
+          if (!accepted) {
+            continue
+          }
+          filePresentationBuilds.remove(event.key)
+          val bundle =
+            when (val outcome = event.outcome) {
+              FilePresentationBuildOutcome.Canceled,
+              FilePresentationBuildOutcome.Failed -> null
+              is FilePresentationBuildOutcome.Succeeded -> outcome.bundle
+            }
+          if (
+            bundle != null &&
+              isPresentationIndexPublished(event.index) &&
+              event.key !in filePresentationBundles &&
+              completedFilePresentationBundles.none { it.key == event.key }
+          ) {
+            completedFilePresentationBundles +=
+              CompletedFilePresentationBundle(
+                event.index,
+                event.key,
+                bundle,
+              )
+          }
+        }
+        is ResolutionCoordinatorEvent.FilePresentationAnchorRequest -> {
+          val publishedBundle = filePresentationBundles[event.key]
+          if (
+            isPresentationIndexPublished(event.index) &&
+              publishedBundle != null &&
+              publishedBundle === event.baseBundle &&
+              !publishedBundle.anchorsAreCurrent(event.modificationStamp)
+          ) {
+            val active = filePresentationAnchorBuilds[event.key]
+            val sameActiveRequest =
+              active != null &&
+                active.baseBundle === event.baseBundle &&
+                active.modificationStamp == event.modificationStamp
+            if (!sameActiveRequest) {
+              pendingFilePresentationAnchorRequests[event.key] =
+                PendingFilePresentationAnchorBuild(
+                  event.index,
+                  event.key,
+                  event.baseBundle,
+                  event.modificationStamp,
+                )
+              active?.job?.cancel()
+            }
+          }
+        }
+        is ResolutionCoordinatorEvent.FilePresentationAnchorComplete -> {
+          val activeAttempt = filePresentationAnchorBuilds[event.key]
+          val accepted =
+            activeAttempt?.id == event.attemptId &&
+              activeAttempt.index === event.index &&
+              activeAttempt.baseBundle === event.baseBundle &&
+              activeAttempt.modificationStamp == event.modificationStamp
+          if (!accepted) continue
+          filePresentationAnchorBuilds.remove(event.key)
+          val bundle =
+            when (val outcome = event.outcome) {
+              FilePresentationBuildOutcome.Canceled,
+              FilePresentationBuildOutcome.Failed -> null
+              is FilePresentationBuildOutcome.Succeeded -> outcome.bundle
+            }
+          val pending = pendingFilePresentationAnchorRequests[event.key]
+          val superseded =
+            pending != null &&
+              (pending.baseBundle !== event.baseBundle ||
+                pending.modificationStamp != event.modificationStamp)
+          if (
+            bundle != null &&
+              !superseded &&
+              isPresentationBundlePublished(event.index, event.key, event.baseBundle) &&
+              bundle.sharesSemanticData(event.baseBundle) &&
+              bundle.anchorsAreCurrent(event.modificationStamp) &&
+              completedFilePresentationAnchorBundles.none { it.key == event.key }
+          ) {
+            if (
+              pending != null &&
+                pending.baseBundle === event.baseBundle &&
+                pending.modificationStamp == event.modificationStamp
+            ) {
+              pendingFilePresentationAnchorRequests.remove(event.key)
+            }
+            completedFilePresentationAnchorBundles +=
+              CompletedFilePresentationAnchorBundle(
+                event.index,
+                event.key,
+                event.baseBundle,
+                event.modificationStamp,
+                bundle,
+              )
+          }
+        }
+        is ResolutionCoordinatorEvent.TestBarrier -> {
+          pendingCoordinatorBarriers += event.completion
+        }
+      }
+    }
+  }
+
+  /** Returns whether queued work can run before another request or worker completion arrives. */
+  private fun hasRunnableCoordinatorWork(): Boolean {
+    return !pendingPsiChanges.isEmpty ||
+      projectInputsPending ||
+      settingsPending ||
+      pendingManualRefresh != null ||
+      pendingBuilds.isNotEmpty() ||
+      completedFilePresentationBundles.isNotEmpty() ||
+      completedFilePresentationAnchorBundles.isNotEmpty() ||
+      hasStartableFilePresentationWork()
+  }
+
+  private fun mergePendingPsiChanges(added: PendingPsiChanges) {
+    val files = pendingPsiChanges.files.toMutableMap()
+    for ((file, change) in added.files) {
+      files[file] = files[file]?.merge(change) ?: change
+    }
+    pendingPsiChanges =
+      PendingPsiChanges(
+        files = files,
+        directories = pendingPsiChanges.directories + added.directories,
+      )
+  }
+
+  private fun mergePendingBuild(event: ResolutionCoordinatorEvent.Build) {
+    demandedModules += event.module
+    val existing = pendingBuilds[event.module]
+    if (existing == null) {
+      pendingBuilds[event.module] =
+        PendingIndexBuild(
+          module = event.module,
+          intent = event.intent,
+          waiters = event.completions.toMutableList(),
+        )
+    } else {
+      existing.upgrade(event.intent)
+      existing.waiters += event.completions
+    }
+  }
+
+  /** Completes requests when their data is already available to every active reader. */
+  private fun completeSatisfiedBuildRequests(): Boolean {
+    if (
+      pendingBuilds.isEmpty() || pendingManualRefresh != null || isDisposed || project.isDisposed
+    ) {
+      return false
+    }
+    val publication = publishedResolution.value
+    if (publication.isDisposed) return false
+    val current = publication.current
+    if (!generationIsCurrent(current)) return false
+    val presentation = publication.presentation
+    val needsCurrentPresentation = automaticallyRefreshGraphData
+    // Explicit queries can refresh current data while manual mode keeps the old presentation.
+    // Reenabling automatic refresh must update both before queued requests are satisfied.
+    if (needsCurrentPresentation && !generationIsCurrent(presentation)) return false
+    if (isDisposed || project.isDisposed || publishedResolution.value.current !== current) {
+      return false
+    }
+
+    val satisfied = mutableListOf<PendingIndexBuild>()
+    val requests = pendingBuilds.entries.iterator()
+    while (requests.hasNext()) {
+      val request = requests.next().value
+      if (current.index(request.module) === BindingIndex.EMPTY) continue
+      if (needsCurrentPresentation && presentation.index(request.module) === BindingIndex.EMPTY) {
+        continue
+      }
+      requests.remove()
+      satisfied += request
+    }
+    completeBuildRequests(satisfied, IndexBuildOutcome.PUBLISHED)
+    return satisfied.isNotEmpty()
+  }
+
+  private suspend fun processPendingPsiChanges() {
+    val batch = pendingPsiChanges
+    pendingPsiChanges = PendingPsiChanges()
+    try {
+      val classified =
+        smartReadAction(project) {
+          checkPsiClassificationActive()
+          classifyPsiChanges(batch)
+        }
+      checkPsiClassificationActive()
+      applyClassifiedPsiChanges(classified)
+    } catch (exception: ProcessCanceledException) {
+      mergePendingPsiChanges(batch)
+      yield()
+    } catch (exception: CancellationException) {
+      mergePendingPsiChanges(batch)
+      throw exception
+    } catch (failure: Throwable) {
+      checkPsiClassificationActive()
+      logger<MetroResolutionService>().warn("Metro PSI invalidation failed", failure)
+      val requested = failedClassificationRequests(batch)
+      recordForceAllInvalidation()
+      pendingRequestedFiles += requested
+      evictStaleCaches(ProjectRootModificationTracker.getInstance(project).modificationCount)
+      notifyListeners(restartDaemon = true)
+    }
+  }
+
+  private suspend fun processPendingProjectInputs() {
+    projectInputsPending = false
+    try {
+      readAction {
+        reconcileProjectInputs()
+      }
+    } catch (exception: ProcessCanceledException) {
+      projectInputsPending = true
+      yield()
+    } catch (exception: CancellationException) {
+      projectInputsPending = true
+      throw exception
+    } catch (failure: Throwable) {
+      logger<MetroResolutionService>().warn("Metro project input reconciliation failed", failure)
+      semanticRevision++
+      evictStaleCaches(ProjectRootModificationTracker.getInstance(project).modificationCount)
+      notifyListeners(restartDaemon = false)
+    }
+  }
+
+  private fun processPendingSettings() {
+    settingsPending = false
+    val state = MetroSettings.getInstance(project).state
+    val resolveFromLibraries = state.resolveFromLibraries
+    val resolveFromLibrariesChanged = lastResolveFromLibraries != resolveFromLibraries
+    lastResolveFromLibraries = resolveFromLibraries
+    val automaticallyRefresh = state.automaticallyRefreshGraphData
+    val automaticallyRefreshChanged = lastAutomaticallyRefreshGraphData != automaticallyRefresh
+    lastAutomaticallyRefreshGraphData = automaticallyRefresh
+    if (!resolveFromLibrariesChanged && !automaticallyRefreshChanged) return
+    if (automaticallyRefreshChanged) {
+      updatePublishedResolution { it.copy(manualStaleNotificationSent = false) }
+    }
+
+    if (automaticallyRefreshChanged && !automaticallyRefresh) {
+      discardAutomaticPendingBuilds()
+      updatePublishedResolution { publication ->
+        val presentationRevision = publication.presentation.semanticRevision
+        val refreshRevision =
+          if (presentationRevision == ResolutionGeneration.EMPTY_REVISION) semanticRevision
+          else presentationRevision
+        publication.copy(graphBrowserRefreshRevision = refreshRevision)
+      }
+    }
+
+    if (resolveFromLibrariesChanged) {
+      semanticRevision++
+      if (!resolveFromLibraries) libraryShards.clear()
+      evictStaleCaches(ProjectRootModificationTracker.getInstance(project).modificationCount)
+    }
+
+    if (automaticallyRefreshChanged && automaticallyRefresh) {
+      for (module in demandedModules) {
+        if (module.isDisposed || module in pendingBuilds) continue
+        pendingBuilds[module] =
+          PendingIndexBuild(module, IndexBuildIntent.AUTOMATIC, mutableListOf())
+      }
+    }
+    notifyListeners(restartDaemon = automaticallyRefreshChanged && automaticallyRefresh)
+  }
+
+  private fun publishCoordinatorMetadata() {
+    if (!pendingPsiChanges.isEmpty || projectInputsPending || settingsPending) return
+    val publication = publishedResolution.value
+    val currentTrackedFiles = sourceSnapshot?.shardOrder.orEmpty()
+    val trackedFilesUnchanged =
+      publication.trackedSourceFiles.size == currentTrackedFiles.size &&
+        publication.trackedSourceFiles.containsAll(currentTrackedFiles)
+    val irrelevantFilesUnchanged = publication.knownIrrelevantFiles == knownIrrelevantFiles
+    val metadataUnchanged =
+      publication.classifiedSemanticClock == coordinatorSnapshot.semanticClock &&
+        publication.latestSemanticRevision == semanticRevision &&
+        trackedFilesUnchanged &&
+        irrelevantFilesUnchanged
+    if (metadataUnchanged) return
+
+    val trackedSourceFiles =
+      if (trackedFilesUnchanged) publication.trackedSourceFiles else currentTrackedFiles.toSet()
+    val irrelevantFiles =
+      if (irrelevantFilesUnchanged) publication.knownIrrelevantFiles
+      else knownIrrelevantFiles.toSet()
+    updatePublishedResolution { previous ->
+      previous.copy(
+        classifiedSemanticClock = coordinatorSnapshot.semanticClock,
+        latestSemanticRevision = semanticRevision,
+        trackedSourceFiles = trackedSourceFiles,
+        knownIrrelevantFiles = irrelevantFiles,
+      )
+    }
+  }
+
+  private fun hasFilePresentationWork(key: FilePresentationKey): Boolean {
+    return key in filePresentationBuilds ||
+      key in filePresentationAnchorBuilds ||
+      key in filePresentationBundles ||
+      completedFilePresentationBundles.any { it.key == key }
+  }
+
+  /** A worker needs a free slot and exclusive access to its file's presentation. */
+  private fun hasStartableFilePresentationWork(): Boolean {
+    val activeBuilds = filePresentationBuilds.size + filePresentationAnchorBuilds.size
+    if (activeBuilds >= MAX_CONCURRENT_FILE_PRESENTATION_BUILDS) return false
+    val activeKeys = filePresentationBuilds.keys + filePresentationAnchorBuilds.keys
+    return pendingFilePresentationRequests.keys.any { it !in activeKeys } ||
+      pendingFilePresentationAnchorRequests.keys.any { it !in activeKeys }
+  }
+
+  private fun isPresentationBundlePublished(
+    index: BindingIndex,
+    key: FilePresentationKey,
+    bundle: FilePresentationBundle,
+  ): Boolean {
+    if (!isPresentationIndexPublished(index)) return false
+    return publishedResolution.value.filePresentationBundles[key] === bundle
+  }
+
+  private fun completeCoordinatorBarriers() {
+    if (pendingCoordinatorBarriers.isEmpty()) return
+    pendingCoordinatorBarriers.forEach { it.complete(Unit) }
+    pendingCoordinatorBarriers.clear()
+  }
+
+  /** Applies a pure state transformation and preserves disposal as a terminal state. */
+  private fun updatePublishedResolution(
+    update: (PublishedResolution) -> PublishedResolution
+  ): PublishedResolution? {
+    val updated = publishedResolution.updateAndGet { publication ->
+      if (publication.isDisposed || project.isDisposed) publication else update(publication)
+    }
+    return updated.takeUnless { it.isDisposed || project.isDisposed }
+  }
+
+  private fun startPendingFileBundles() {
+    var available =
+      MAX_CONCURRENT_FILE_PRESENTATION_BUILDS -
+        filePresentationBuilds.size -
+        filePresentationAnchorBuilds.size
+    if (available <= 0) return
+    val requests = pendingFilePresentationRequests.entries.iterator()
+    while (requests.hasNext() && available > 0) {
+      val (key, index) = requests.next()
+      if (!isPresentationIndexPublished(index)) {
+        requests.remove()
+        continue
+      }
+      if (hasFilePresentationWork(key)) {
+        requests.remove()
+        continue
+      }
+      requests.remove()
+      val attemptId = ++nextFilePresentationAttemptId
+      val job =
+        scope.async(start = CoroutineStart.LAZY) {
+          try {
+            currentCoroutineContext().ensureActive()
+            if (!isPresentationIndexPublished(index)) {
+              return@async FilePresentationBuildOutcome.Canceled
+            }
+            val semanticBundle = index.withResolutionSession { session ->
+              FilePresentationBundleBuilder(
+                  index = index,
+                  session = session,
+                  file = key.file,
+                  declarationAnchorSignatures =
+                    declarationAnchorSignatures[index.generationToken].orEmpty(),
+                )
+                .build()
+            }
+            val bundle =
+              smartReadAction(project) {
+                val ktFile = PsiManager.getInstance(project).findFile(key.file) as? KtFile
+                ktFile?.let(semanticBundle::rebuildAnchors) ?: semanticBundle
+              }
+            currentCoroutineContext().ensureActive()
+            FilePresentationBuildOutcome.Succeeded(bundle)
+          } catch (exception: CancellationException) {
+            throw exception
+          } catch (_: ProcessCanceledException) {
+            FilePresentationBuildOutcome.Canceled
+          } catch (failure: Throwable) {
+            logger<MetroResolutionService>()
+              .warn("Metro file presentation build failed for ${key.file.name}", failure)
+            FilePresentationBuildOutcome.Failed
+          }
+        }
+      filePresentationBuilds[key] = FilePresentationBuildAttempt(attemptId, index, job)
+      reportFilePresentationCompletion(job) { outcome ->
+        ResolutionCoordinatorEvent.FilePresentationComplete(index, key, attemptId, outcome)
+      }
+      job.start()
+      available--
+    }
+    if (available > 0) startPendingFilePresentationAnchors(available)
+  }
+
+  /** Refreshes declaration locations using slots left after starting new presentation builds. */
+  private fun startPendingFilePresentationAnchors(availableSlots: Int) {
+    var available = availableSlots
+    val requests = pendingFilePresentationAnchorRequests.entries.iterator()
+    while (requests.hasNext() && available > 0) {
+      val (key, request) = requests.next()
+      if (!isPresentationBundlePublished(request.index, key, request.baseBundle)) {
+        requests.remove()
+        continue
+      }
+      if (key in filePresentationBuilds || key in filePresentationAnchorBuilds) continue
+      requests.remove()
+      val attemptId = ++nextFilePresentationAttemptId
+      val job =
+        scope.async(start = CoroutineStart.LAZY) {
+          try {
+            currentCoroutineContext().ensureActive()
+            if (!isPresentationBundlePublished(request.index, key, request.baseBundle)) {
+              return@async FilePresentationBuildOutcome.Canceled
+            }
+            val bundle =
+              smartReadAction(project) {
+                val ktFile = PsiManager.getInstance(project).findFile(key.file) as? KtFile
+                if (ktFile?.modificationStamp != request.modificationStamp) {
+                  null
+                } else {
+                  request.baseBundle.rebuildAnchors(ktFile)
+                }
+              }
+            currentCoroutineContext().ensureActive()
+            if (bundle != null && bundle.anchorsAreCurrent(request.modificationStamp)) {
+              FilePresentationBuildOutcome.Succeeded(bundle)
+            } else {
+              FilePresentationBuildOutcome.Canceled
+            }
+          } catch (exception: CancellationException) {
+            throw exception
+          } catch (_: ProcessCanceledException) {
+            FilePresentationBuildOutcome.Canceled
+          } catch (failure: Throwable) {
+            logger<MetroResolutionService>()
+              .warn("Metro file presentation anchor build failed for ${key.file.name}", failure)
+            FilePresentationBuildOutcome.Failed
+          }
+        }
+      filePresentationAnchorBuilds[key] =
+        FilePresentationAnchorBuildAttempt(
+          attemptId,
+          request.index,
+          request.baseBundle,
+          request.modificationStamp,
+          job,
+        )
+      reportFilePresentationCompletion(job) { outcome ->
+        ResolutionCoordinatorEvent.FilePresentationAnchorComplete(
+          request.index,
+          key,
+          attemptId,
+          request.baseBundle,
+          request.modificationStamp,
+          outcome,
+        )
+      }
+      job.start()
+      available--
+    }
+  }
+
+  /** Awaiting also releases attempts canceled before their lazy worker entered its body. */
+  private fun reportFilePresentationCompletion(
+    worker: Deferred<FilePresentationBuildOutcome>,
+    event: (FilePresentationBuildOutcome) -> ResolutionCoordinatorEvent,
+  ) {
+    scope.launch {
+      val outcome =
+        try {
+          worker.await()
+        } catch (_: CancellationException) {
+          // Service cancellation owns cleanup. An individually canceled worker releases its slot
+          // here.
+          currentCoroutineContext().ensureActive()
+          FilePresentationBuildOutcome.Canceled
+        }
+      ingress.submit { event(outcome) }
+    }
+  }
+
+  private fun publishCompletedFileBundles() {
+    while (completedFilePresentationBundles.isNotEmpty()) {
+      val completed = completedFilePresentationBundles.removeFirst()
+      if (!isPresentationIndexPublished(completed.index)) continue
+      filePresentationBundles[completed.key] = completed.bundle
+      while (filePresentationBundles.size > MAX_FILE_PRESENTATION_BUNDLES) {
+        val eldest = filePresentationBundles.entries.iterator()
+        eldest.next()
+        eldest.remove()
+      }
+      val published = updatePublishedResolution { publication ->
+        publication.copy(filePresentationBundles = filePresentationBundles.toMap())
+      }
+      if (published != null && !isDisposed && !project.isDisposed) {
+        project.service<MetroDaemonRestartService>().requestRestart()
+      }
+    }
+  }
+
+  /** Updates declaration locations while keeping the previously computed binding results. */
+  private fun publishCompletedFilePresentationAnchors() {
+    while (completedFilePresentationAnchorBundles.isNotEmpty()) {
+      val completed = completedFilePresentationAnchorBundles.removeFirst()
+      if (!isPresentationIndexPublished(completed.index)) continue
+      val current = filePresentationBundles[completed.key] ?: continue
+      if (current !== completed.baseBundle) continue
+      if (!completed.bundle.sharesSemanticData(current)) continue
+      if (!completed.bundle.anchorsAreCurrent(completed.modificationStamp)) continue
+      val pending = pendingFilePresentationAnchorRequests[completed.key]
+      if (
+        pending != null &&
+          (pending.baseBundle !== completed.baseBundle ||
+            pending.modificationStamp != completed.modificationStamp)
+      ) {
+        continue
+      }
+      val updatedBundles = LinkedHashMap(filePresentationBundles)
+      updatedBundles[completed.key] = completed.bundle
+      val published = updatePublishedResolution { publication ->
+        if (publication.filePresentationBundles[completed.key] !== completed.baseBundle) {
+          publication
+        } else {
+          publication.copy(filePresentationBundles = updatedBundles.toMap())
+        }
+      }
+      val accepted = published?.filePresentationBundles?.get(completed.key) === completed.bundle
+      if (!accepted) continue
+      filePresentationBundles[completed.key] = completed.bundle
+      if (!isDisposed && !project.isDisposed) {
+        project.service<MetroDaemonRestartService>().requestRestart()
+      }
+    }
+  }
+
+  private fun cancelCoordinatorWork() {
+    completeBuildRequests(pendingBuilds.values, IndexBuildOutcome.CANCELED)
+    pendingBuilds.clear()
+    pendingFilePresentationRequests.clear()
+    completedFilePresentationBundles.clear()
+    pendingFilePresentationAnchorRequests.clear()
+    completedFilePresentationAnchorBundles.clear()
+    filePresentationBuilds.values.forEach { it.job.cancel() }
+    filePresentationBuilds.clear()
+    filePresentationAnchorBuilds.values.forEach { it.job.cancel() }
+    filePresentationAnchorBuilds.clear()
+    filePresentationBundles.clear()
+    completeCoordinatorBarriers()
+  }
+
+  private suspend fun processResolutionCandidate(manualRefresh: Boolean) {
+    val existingPublication = publishedResolution.value
+    val retainedTokens =
+      existingPublication.current.indexGenerationTokens +
+        existingPublication.presentation.indexGenerationTokens
+    declarationAnchorSignatures.keys.removeIf { token -> token !in retainedTokens }
+    val manualRequest =
+      if (manualRefresh) pendingManualRefresh.also { pendingManualRefresh = null } else null
+    val requests = pendingBuilds.toMap()
+    pendingBuilds.clear()
+    val intent =
+      when {
+        manualRequest != null -> IndexBuildIntent.MANUAL_REFRESH
+        requests.values.any { it.intent == IndexBuildIntent.EXPLICIT } -> IndexBuildIntent.EXPLICIT
+        else -> IndexBuildIntent.AUTOMATIC
+      }
+    if (intent == IndexBuildIntent.AUTOMATIC && !automaticallyRefreshGraphData) {
+      completeBuildRequests(requests.values, IndexBuildOutcome.SKIPPED)
+      return
+    }
+
+    val buildSnapshot = coordinatorSnapshot
+    val generationToken = IndexGenerationToken.create()
+    val progress = IndexBuildProgressReporter(::publishIndexBuildProgress)
+    progress.phase(IndexBuildPhase.QUEUED)
+    val candidate =
+      try {
+        val capturedInvalidations = capturePendingInvalidations()
+        smartReadAction(project) {
+          val targets = resolutionTargets(if (manualRequest != null) null else demandedModules)
+          if (manualRequest != null) {
+            for (target in targets) demandedModules += target.modules
+          }
+          if (resolutionCandidateIsSuperseded(buildSnapshot, manualRequest)) {
+            throw ResolutionCandidateSupersededException()
+          }
+          collectResolutionCandidate(
+            targets = targets,
+            progress = progress,
+            generationToken = generationToken,
+            buildSnapshot = buildSnapshot,
+            manualRequest = manualRequest,
+            capturedInvalidations = capturedInvalidations,
+          )
+        }
+      } catch (_: ResolutionCandidateSupersededException) {
+        requeueResolutionCandidate(requests, manualRequest)
+        yield()
+        return
+      } catch (exception: ProcessCanceledException) {
+        requeueResolutionCandidate(requests, manualRequest)
+        yield()
+        return
+      } catch (exception: CancellationException) {
+        requeueResolutionCandidate(requests, manualRequest)
+        throw exception
+      } catch (failure: Throwable) {
+        logger<MetroResolutionService>().warn("Metro resolution preparation failed", failure)
+        completeBuildRequests(requests.values, IndexBuildOutcome.FAILED)
+        return
+      }
+
+    val indexesByKey =
+      try {
+        currentCoroutineContext().ensureActive()
+        val builtIndexes =
+          buildMap<SnapshotKey, BindingIndex>(candidate.buildersByKey.size) {
+            for ((key, builder) in candidate.buildersByKey) {
+              if (
+                resolutionCandidateIsSuperseded(
+                  buildSnapshot,
+                  manualRequest,
+                  candidate.inputs,
+                )
+              ) {
+                throw ResolutionCandidateSupersededException()
+              }
+              put(key, builder.build())
+            }
+          }
+        // Cancellation of the service scope must stop this candidate before publication.
+        currentCoroutineContext().ensureActive()
+        builtIndexes
+      } catch (_: ResolutionCandidateSupersededException) {
+        requeueResolutionCandidate(requests, manualRequest)
+        yield()
+        return
+      } catch (exception: ProcessCanceledException) {
+        requeueResolutionCandidate(requests, manualRequest)
+        yield()
+        return
+      } catch (exception: CancellationException) {
+        requeueResolutionCandidate(requests, manualRequest)
+        throw exception
+      } catch (failure: Throwable) {
+        logger<MetroResolutionService>().warn("Metro resolution build failed", failure)
+        completeBuildRequests(requests.values, IndexBuildOutcome.FAILED)
+        return
+      }
+
+    val completedInputs = currentInputs()
+    val latestIngress = ingress.snapshot()
+    val sameSemanticClock = latestIngress.semanticClock == buildSnapshot.semanticClock
+    val latestManual =
+      manualRequest == null || latestIngress.latestManualRequestId == manualRequest.id
+    val sourceIsCurrent = candidate.source == null || candidate.source.inputs == completedInputs
+    val completeTargetSet = indexesByKey.keys == candidate.buildersByKey.keys
+    val metadataMatches = indexesByKey.values.all { it.generationToken === generationToken }
+    if (
+      !sameSemanticClock ||
+        !latestManual ||
+        completedInputs != candidate.inputs ||
+        !sourceIsCurrent ||
+        !completeTargetSet ||
+        !metadataMatches ||
+        isDisposed ||
+        project.isDisposed
+    ) {
+      requeueResolutionCandidate(requests, manualRequest)
+      yield()
+      return
+    }
+
+    val generation =
+      ResolutionGeneration(
+        token = generationToken,
+        inputs = candidate.inputs,
+        semanticRevision = candidate.semanticRevision,
+        source = candidate.source,
+        indexesByKey = indexesByKey,
+        keysByModule = candidate.keysByModule,
+      )
+    val publishPresentation = manualRequest != null || automaticallyRefreshGraphData
+    val published = updatePublishedResolution { previous ->
+      previous.copy(
+        current = generation,
+        presentation = if (publishPresentation) generation else previous.presentation,
+        classifiedSemanticClock = buildSnapshot.semanticClock,
+        latestSemanticRevision = candidate.semanticRevision,
+        trackedSourceFiles = candidate.source?.shardOrder?.toSet().orEmpty(),
+        knownIrrelevantFiles = knownIrrelevantFiles.toSet(),
+        graphBrowserRefreshRevision =
+          if (manualRequest != null) candidate.semanticRevision
+          else previous.graphBrowserRefreshRevision,
+        manualStaleNotificationSent =
+          if (manualRequest != null) false else previous.manualStaleNotificationSent,
+      )
+    }
+    if (published == null) {
+      completeBuildRequests(requests.values, IndexBuildOutcome.CANCELED)
+      return
+    }
+    sourceSnapshot = candidate.source
+    consumeCapturedInvalidations(candidate.consumedInvalidations)
+    evictStaleCaches(
+      currentRoots = candidate.inputs.roots,
+      activeFingerprints = candidate.source?.moduleFingerprints?.values?.toSet().orEmpty(),
+    )
+    retainPublishedFilePresentationBundles()
+    completeBuildRequests(requests.values, IndexBuildOutcome.PUBLISHED)
+
+    if (manualRequest != null) {
+      notifyListeners(restartDaemon = true, forceDaemonRestart = true)
+    } else {
+      notifyIndexPublished(intent)
+    }
+  }
+
+  private fun resolutionTargets(modules: Set<Module>?): List<ManualRefreshTarget> {
+    demandedModules.removeIf(Module::isDisposed)
+    val resolveFromLibraries = MetroSettings.getInstance(project).state.resolveFromLibraries
+    val projectStateService = project.service<MetroIdeProjectService>()
+    val selectedModules = modules ?: ModuleManager.getInstance(project).modules.toSet()
+    val modulesByKey = linkedMapOf<SnapshotKey, MutableList<Module>>()
+    for (module in selectedModules) {
+      ProgressManager.checkCanceled()
+      if (module.isDisposed) continue
+      val state = projectStateService.state(module)
+      if (!state.isEnabled) continue
+      val key = SnapshotKey(fingerprintFor(state), resolveFromLibraries)
+      modulesByKey.getOrPut(key) { mutableListOf() } += module
+    }
+    return modulesByKey.map { (key, groupedModules) -> ManualRefreshTarget(key, groupedModules) }
+  }
+
+  private fun resolutionCandidateIsSuperseded(
+    buildSnapshot: ResolutionIngressSnapshot,
+    manualRequest: ManualRefreshRequest?,
+    expectedInputs: IndexInputs? = null,
+  ): Boolean {
+    if (isDisposed || project.isDisposed) return true
+    val latest = ingress.snapshot()
+    if (latest.semanticClock != buildSnapshot.semanticClock) return true
+    if (manualRequest != null && latest.latestManualRequestId != manualRequest.id) return true
+    return expectedInputs != null && currentInputs() != expectedInputs
+  }
+
+  private fun requeueResolutionCandidate(
+    requests: Map<Module, PendingIndexBuild>,
+    manualRequest: ManualRefreshRequest?,
+  ) {
+    for ((module, request) in requests) {
+      val existing = pendingBuilds[module]
+      if (existing == null) {
+        pendingBuilds[module] = request
+      } else {
+        existing.upgrade(request.intent)
+        existing.waiters += request.waiters
+      }
+    }
+    if (manualRequest != null && pendingManualRefresh == null) {
+      pendingManualRefresh = manualRequest
+    }
+  }
+
+  private fun completeBuildRequests(
+    requests: Collection<PendingIndexBuild>,
+    outcome: IndexBuildOutcome,
+  ) {
+    for (request in requests) {
+      request.waiters.forEach { waiter -> waiter.complete(outcome) }
+    }
+  }
+
+  private fun notifyIndexPublished(intent: IndexBuildIntent) {
+    val restartDaemon = intent == IndexBuildIntent.EXPLICIT || automaticallyRefreshGraphData
+    notifyListeners(
+      restartDaemon = restartDaemon,
+      forceDaemonRestart = intent == IndexBuildIntent.EXPLICIT,
+    )
+  }
+
+  /** Returns current graph data after applying pending invalidations. */
+  internal fun currentIndex(element: PsiElement): BindingIndex {
     val file = element as? KtFile ?: element.containingFile as? KtFile
     val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return BindingIndex.EMPTY
     if (file != null) enrollRequestedFile(file)
-    return index(module)
+    return currentIndex(module)
   }
 
-  /** Returns a current cached index without scheduling or performing analysis. */
+  /** Returns the published presentation generation without scheduling analysis in manual mode. */
+  internal fun presentationIndex(element: PsiElement): BindingIndex {
+    val file = element as? KtFile ?: element.containingFile as? KtFile
+    val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return BindingIndex.EMPTY
+    if (file != null) enrollRequestedFile(file)
+    ingress.submit { ResolutionCoordinatorEvent.PresentationDemand(module) }
+    return index(module, automaticPresentationRequestMode())
+  }
+
+  /** Returns a cached presentation bundle or schedules its background construction. */
+  internal fun presentationBundle(element: KtElement): FilePresentationBundle? {
+    val ktFile = element.containingFile as? KtFile ?: return null
+    val file = ktFile.virtualFile
+    val index = presentationIndex(element)
+    if (index === BindingIndex.EMPTY) return null
+    val key = FilePresentationKey(index.generationToken, file)
+    publishedResolution.value.filePresentationBundles[key]?.let { bundle ->
+      val modificationStamp = ktFile.modificationStamp
+      if (!bundle.anchorsAreCurrent(modificationStamp)) {
+        ingress.submit {
+          ResolutionCoordinatorEvent.FilePresentationAnchorRequest(
+            index,
+            key,
+            bundle,
+            modificationStamp,
+          )
+        }
+      }
+      return bundle
+    }
+    ingress.submit { ResolutionCoordinatorEvent.FilePresentationRequest(index, key) }
+    return null
+  }
+
+  private fun isPresentationIndexPublished(index: BindingIndex): Boolean {
+    if (index === BindingIndex.EMPTY || isDisposed || project.isDisposed) return false
+    return publishedResolution.value.presentation.contains(index)
+  }
+
+  private fun retainPublishedFilePresentationBundles() {
+    val activeTokens = publishedResolution.value.presentation.indexGenerationTokens
+    declarationAnchorSignatures.keys.removeIf { token -> token !in activeTokens }
+    pendingFilePresentationRequests.keys.removeIf { key ->
+      key.generationToken !in activeTokens
+    }
+    completedFilePresentationBundles.removeAll { completed ->
+      completed.key.generationToken !in activeTokens
+    }
+    pendingFilePresentationAnchorRequests.keys.removeIf { key ->
+      key.generationToken !in activeTokens
+    }
+    completedFilePresentationAnchorBundles.removeAll { completed ->
+      completed.key.generationToken !in activeTokens
+    }
+    filePresentationBundles.keys.removeIf { key -> key.generationToken !in activeTokens }
+    val builds = filePresentationBuilds.entries.iterator()
+    while (builds.hasNext()) {
+      val (key, attempt) = builds.next()
+      if (key.generationToken in activeTokens) continue
+      attempt.job.cancel()
+    }
+    val anchorBuilds = filePresentationAnchorBuilds.entries.iterator()
+    while (anchorBuilds.hasNext()) {
+      val (key, attempt) = anchorBuilds.next()
+      if (key.generationToken in activeTokens) continue
+      attempt.job.cancel()
+    }
+    updatePublishedResolution { publication ->
+      publication.copy(filePresentationBundles = filePresentationBundles.toMap())
+    }
+  }
+
+  @TestOnly internal fun index(element: PsiElement): BindingIndex = currentIndex(element)
+
+  /** Returns a current cached index and schedules missing settings work in the background. */
   internal fun cachedIndex(element: PsiElement): BindingIndex {
     val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return BindingIndex.EMPTY
     return index(module, IndexRequestMode.CACHE_ONLY)
@@ -297,8 +1262,8 @@ class MetroResolutionService(
   /** Returns the distinct current indexes that can contain an exact Find Usages target. */
   internal fun usageIndexes(element: PsiElement): List<BindingIndex> {
     val module = ModuleUtilCore.findModuleForPsiElement(element)
-    if (module != null) return index(element).asUsageIndexList()
-    return distinctUsageIndexes { index(it) }
+    if (module != null) return currentIndex(element).asUsageIndexList()
+    return distinctUsageIndexes { currentIndex(it) }
   }
 
   /**
@@ -325,133 +1290,330 @@ class MetroResolutionService(
   }
 
   /**
-   * Returns a current project snapshot for [module]. Production EDT callers never perform Kotlin
-   * analysis: they trigger a coalesced smart-mode build and receive an empty index until it lands.
-   * Background highlighting and the platform's synchronous unit-test fixtures build immediately.
+   * Returns current binding data for [module]. Production EDT callers schedule a background build
+   * and receive an empty index until it finishes. Other callers wait for the coordinator. Callers
+   * in a read action use [retryCancelledIndexBuild] to release the read lock before waiting.
    */
-  internal fun index(module: Module): BindingIndex {
-    val application = ApplicationManager.getApplication()
-    val requestMode =
-      if (application.isDispatchThread && !application.isUnitTestMode) {
-        IndexRequestMode.BACKGROUND
-      } else {
-        IndexRequestMode.SYNCHRONOUS
-      }
-    return index(module, requestMode)
+  internal fun currentIndex(module: Module): BindingIndex {
+    return index(module, currentRequestMode())
   }
+
+  @TestOnly internal fun index(module: Module): BindingIndex = currentIndex(module)
 
   /** Returns a cached graph-browser index, building in the background only after first use. */
   internal fun indexForToolWindow(module: Module): BindingIndex {
     val requestMode =
-      if (graphBrowserActivated.get()) {
-        IndexRequestMode.BACKGROUND
+      if (!isGraphBrowserActivated) {
+        if (automaticallyRefreshGraphData) IndexRequestMode.CACHE_ONLY
+        else IndexRequestMode.STALE_CACHE_ONLY
       } else {
-        IndexRequestMode.CACHE_ONLY
+        automaticToolWindowRequestMode()
       }
+    ingress.submit { ResolutionCoordinatorEvent.PresentationDemand(module) }
     val index = index(module, requestMode)
-    if (index !== BindingIndex.EMPTY && graphBrowserActivated.compareAndSet(false, true)) {
-      // currentIndexes() may have skipped earlier modules while the browser was inactive. Ask the
-      // tree to make one active pass so those modules can schedule their own snapshots.
-      scheduleInvalidationNotification()
+    if (index !== BindingIndex.EMPTY) {
+      val indexIsCurrent = isCurrent(index)
+      val previous = publishedResolution.getAndUpdate { publication ->
+        if (publication.isDisposed || publication.graphBrowserActivated) {
+          publication
+        } else {
+          val refreshRevision =
+            if (indexIsCurrent && publication.current.contains(index))
+              publication.latestSemanticRevision
+            else publication.graphBrowserRefreshRevision
+          publication.copy(
+            graphBrowserActivated = true,
+            graphBrowserRefreshRevision = refreshRevision,
+          )
+        }
+      }
+      if (!previous.isDisposed && !previous.graphBrowserActivated) {
+        // currentIndexes() may have skipped earlier modules while the browser was inactive. Ask the
+        // tree to make one active pass so those modules can schedule their own snapshots.
+        scheduleInvalidationNotification()
+      }
     }
     return index
   }
 
   internal val isGraphBrowserActivated: Boolean
-    get() = graphBrowserActivated.get()
+    get() = publishedResolution.value.graphBrowserActivated
 
   internal fun activateGraphBrowser() {
-    graphBrowserActivated.set(true)
+    updatePublishedResolution { it.copy(graphBrowserActivated = true) }
   }
+
+  /** Builds and publishes a generation containing every pending change. */
+  internal fun refreshGraphData() {
+    activateGraphBrowser()
+    ingress.submit(manualRefresh = true) { ticket ->
+      ResolutionCoordinatorEvent.ManualRefresh(ticket.eventClock)
+    }
+  }
+
+  internal val isManualGraphDataRefreshRequired: Boolean
+    get() {
+      val publication = publishedResolution.value
+      if (automaticallyRefreshGraphData || !publication.graphBrowserActivated) return false
+      val ingressSnapshot = ingress.snapshot()
+      val classificationPending =
+        publication.classifiedSemanticClock < ingressSnapshot.semanticClock
+      return classificationPending ||
+        publication.latestSemanticRevision > publication.graphBrowserRefreshRevision
+    }
 
   @TestOnly
   internal fun resetGraphBrowserActivation() {
-    graphBrowserActivated.set(false)
+    updatePublishedResolution {
+      it.copy(graphBrowserActivated = false, manualStaleNotificationSent = false)
+    }
+  }
+
+  /** Resolves a graph in a cancellable smart read and invokes [onResult] on the EDT. */
+  internal fun findGraphAsync(
+    classId: ClassId,
+    file: VirtualFile?,
+    onResult: (KaGraphDeclaration?) -> Unit,
+  ): Job {
+    return scope.launch {
+      if (project.isDisposed) return@launch
+      val graph = retryCancelledIndexBuild {
+        smartReadAction(project) {
+          val psiFile = file?.let { PsiManager.getInstance(project).findFile(it) } as? KtFile
+          psiFile?.let { sourceFile ->
+            val module = ModuleUtilCore.findModuleForPsiElement(sourceFile)
+            if (module == null) {
+              null
+            } else {
+              enrollRequestedFile(sourceFile)
+              index(module, IndexRequestMode.BACKGROUND).graphs.firstOrNull {
+                ProgressManager.checkCanceled()
+                it.classId == classId && it.pointer.virtualFile == file
+              }
+            }
+          }
+        }
+      }
+      withContext(Dispatchers.EDT) {
+        if (!project.isDisposed) onResult(graph)
+      }
+    }
+  }
+
+  /** Waits until the coordinator has drained every event submitted before this call. */
+  @TestOnly
+  internal suspend fun awaitCoordinatorBarrier() {
+    val completion = CompletableDeferred<Unit>()
+    if (ingress.submit { ResolutionCoordinatorEvent.TestBarrier(completion) } != null) {
+      completion.await()
+    }
+  }
+
+  private val automaticallyRefreshGraphData: Boolean
+    get() = MetroSettings.getInstance(project).state.automaticallyRefreshGraphData
+
+  private fun currentRequestMode(): IndexRequestMode {
+    val application = ApplicationManager.getApplication()
+    return if (application.isDispatchThread && !application.isUnitTestMode) {
+      IndexRequestMode.BACKGROUND
+    } else {
+      IndexRequestMode.SYNCHRONOUS
+    }
+  }
+
+  private fun automaticPresentationRequestMode(): IndexRequestMode {
+    if (!automaticallyRefreshGraphData) return IndexRequestMode.STALE_CACHE_ONLY
+    val application = ApplicationManager.getApplication()
+    return if (application.isUnitTestMode) IndexRequestMode.SYNCHRONOUS
+    else IndexRequestMode.AUTOMATIC_BACKGROUND
+  }
+
+  private fun automaticToolWindowRequestMode(): IndexRequestMode {
+    return if (automaticallyRefreshGraphData) {
+      IndexRequestMode.AUTOMATIC_BACKGROUND
+    } else {
+      IndexRequestMode.STALE_CACHE_ONLY
+    }
   }
 
   private fun index(module: Module, requestMode: IndexRequestMode): BindingIndex {
-    val moduleState = project.service<MetroIdeProjectService>().state(module)
-    if (!moduleState.isEnabled) return BindingIndex.EMPTY
-
-    val fingerprint = fingerprintFor(moduleState)
-    val key =
-      SnapshotKey(fingerprint, MetroSettings.getInstance(project).state.resolveFromLibraries)
-    val inputs = currentInputs()
-    val sourceInputs = sourceSnapshot.get()?.inputs
-    val compilerSettingsChanged = sourceInputs?.compilerSettings != inputs.compilerSettings
-    if (!compilerSettingsChanged && sourceInputs?.roots == inputs.roots) {
-      snapshots[key]
-        ?.takeIf { it.matches(invalidations.get().generation, inputs.roots) }
-        ?.let {
-          return it.index
+    val publication = publishedResolution.value
+    when (requestMode) {
+      IndexRequestMode.STALE_CACHE_ONLY -> return publication.presentation.index(module)
+      IndexRequestMode.CACHE_ONLY -> {
+        val current = publication.current
+        if (generationIsCurrent(current)) {
+          current
+            .index(module)
+            .takeUnless { it === BindingIndex.EMPTY }
+            ?.let {
+              return it
+            }
         }
+      }
+      IndexRequestMode.AUTOMATIC_BACKGROUND -> {
+        val presentation = publication.presentation
+        if (generationIsCurrent(presentation)) {
+          presentation
+            .index(module)
+            .takeUnless { it === BindingIndex.EMPTY }
+            ?.let {
+              return it
+            }
+        }
+      }
+      IndexRequestMode.BACKGROUND,
+      IndexRequestMode.SYNCHRONOUS -> {
+        val current = publication.current
+        if (generationIsCurrent(current)) {
+          current
+            .index(module)
+            .takeUnless { it === BindingIndex.EMPTY }
+            ?.let {
+              return it
+            }
+        }
+      }
     }
+
+    val projectStateService = project.service<MetroIdeProjectService>()
+    val moduleState =
+      when (requestMode) {
+        IndexRequestMode.STALE_CACHE_ONLY -> return publication.presentation.index(module)
+        IndexRequestMode.CACHE_ONLY -> projectStateService.currentStateOrSchedule(module)
+        IndexRequestMode.AUTOMATIC_BACKGROUND ->
+          projectStateService.currentStateOrSchedule(
+            module,
+            retryAutomaticIndexAfterStateWarmup,
+          )
+        IndexRequestMode.BACKGROUND ->
+          projectStateService.currentStateOrSchedule(
+            module,
+            retryExplicitIndexAfterStateWarmup,
+          )
+        IndexRequestMode.SYNCHRONOUS -> projectStateService.state(module)
+      } ?: return BindingIndex.EMPTY
+    if (!moduleState.isEnabled) return BindingIndex.EMPTY
+    if (requestMode == IndexRequestMode.CACHE_ONLY) return BindingIndex.EMPTY
 
     return when (requestMode) {
-      IndexRequestMode.CACHE_ONLY -> BindingIndex.EMPTY
-      IndexRequestMode.BACKGROUND -> {
-        scheduleBuild(module, key)
+      IndexRequestMode.CACHE_ONLY,
+      IndexRequestMode.STALE_CACHE_ONLY -> BindingIndex.EMPTY
+      IndexRequestMode.AUTOMATIC_BACKGROUND -> {
+        scheduleBuild(module, IndexBuildIntent.AUTOMATIC)
         BindingIndex.EMPTY
       }
-      IndexRequestMode.SYNCHRONOUS ->
-        if (ApplicationManager.getApplication().isDispatchThread) {
-          // BasePlatformTestCase performs existing marker/index assertions synchronously on the
-          // EDT. Production callers take the background path and never reach this exception.
-          allowAnalysisOnEdt { buildCurrentIndex(module, key) }
-        } else {
-          buildCurrentIndex(module, key)
+      IndexRequestMode.BACKGROUND -> {
+        scheduleBuild(module, IndexBuildIntent.EXPLICIT)
+        BindingIndex.EMPTY
+      }
+      IndexRequestMode.SYNCHRONOUS -> {
+        val application = ApplicationManager.getApplication()
+        val staleIndex = publication.current.index(module)
+        val classificationPending =
+          publication.classifiedSemanticClock < ingress.snapshot().semanticClock
+        if (
+          application.isUnitTestMode &&
+            application.isDispatchThread &&
+            classificationPending &&
+            staleIndex !== BindingIndex.EMPTY
+        ) {
+          scheduleBuild(module, IndexBuildIntent.EXPLICIT)
+          return staleIndex
         }
+        if (application.isReadAccessAllowed) {
+          // Release this read action before waiting for the coordinator's smart read.
+          val completion = CompletableDeferred<IndexBuildOutcome>()
+          scheduleBuild(module, IndexBuildIntent.EXPLICIT, completion)
+          throw ResolutionBuildPendingException(completion)
+        }
+        val completion = CompletableDeferred<IndexBuildOutcome>()
+        scheduleBuild(module, IndexBuildIntent.EXPLICIT, completion)
+        val outcome = runBlockingCancellable { completion.await() }
+        if (outcome != IndexBuildOutcome.PUBLISHED) return BindingIndex.EMPTY
+        val current = publishedResolution.value.current
+        if (!generationIsCurrent(current)) return BindingIndex.EMPTY
+        current.index(module)
+      }
     }
+  }
+
+  private fun generationIsCurrent(generation: ResolutionGeneration): Boolean {
+    if (generation === ResolutionGeneration.EMPTY) return false
+    val publication = publishedResolution.value
+    val ingressSnapshot = ingress.snapshot()
+    return generation.semanticRevision == publication.latestSemanticRevision &&
+      publication.classifiedSemanticClock == ingressSnapshot.semanticClock &&
+      generation.inputs == currentInputs()
+  }
+
+  /** Returns true when [index] matches the current project state. */
+  internal fun isCurrent(index: BindingIndex): Boolean {
+    if (index === BindingIndex.EMPTY) return false
+    val current = publishedResolution.value.current
+    return current.contains(index) && generationIsCurrent(current)
   }
 
   /** Notifies a tool window when a fresh background index is ready; callbacks run on the EDT. */
   internal fun addIndexListener(parentDisposable: Disposable, listener: () -> Unit) {
-    listeners += listener
-    Disposer.register(parentDisposable) { listeners -= listener }
+    collectForDisposable(indexChanges, parentDisposable) { listener() }
   }
 
-  /** Reports serialized tool-window index builds on the EDT. */
+  /** Reports index-build progress to tool-window listeners on the EDT. */
   internal fun addIndexBuildProgressListener(
     parentDisposable: Disposable,
     listener: (IndexBuildProgress?) -> Unit,
   ) {
-    indexBuildProgressListeners += listener
-    Disposer.register(parentDisposable) { indexBuildProgressListeners -= listener }
-    notifyIndexBuildProgressListener(listener, indexBuildProgress.get())
+    collectForDisposable(indexBuildProgress, parentDisposable, listener)
   }
 
   /**
-   * Invalidates snapshots after an index-relevant setting changes without discarding source shards.
+   * Subscribes immediately and marshals each Swing callback to the EDT for its owner's lifetime.
    */
+  private fun <T> collectForDisposable(
+    events: Flow<T>,
+    parentDisposable: Disposable,
+    listener: (T) -> Unit,
+  ) {
+    val job =
+      notificationScope.launch(Dispatchers.EDT, start = CoroutineStart.UNDISPATCHED) {
+        events.collect { value ->
+          withContext(Dispatchers.EDT) {
+            if (!isDisposed && !project.isDisposed) listener(value)
+          }
+        }
+      }
+    Disposer.register(parentDisposable) { job.cancel() }
+  }
+
+  /** Queues settings reconciliation and resumes automatic presentation builds. */
   internal fun settingsChanged() {
-    val resolveFromLibraries = MetroSettings.getInstance(project).state.resolveFromLibraries
-    if (lastResolveFromLibraries.getAndSet(resolveFromLibraries) == resolveFromLibraries) {
-      return
+    ingress.submit(semanticChange = true) { ResolutionCoordinatorEvent.Settings }
+  }
+
+  private fun discardAutomaticPendingBuilds() {
+    val iterator = pendingBuilds.entries.iterator()
+    while (iterator.hasNext()) {
+      val request = iterator.next().value
+      if (request.intent != IndexBuildIntent.AUTOMATIC) continue
+      iterator.remove()
+      request.waiters.forEach { it.complete(IndexBuildOutcome.SKIPPED) }
     }
-    val bumped = invalidations.updateAndGet { it.bumpGeneration() }
-    if (!resolveFromLibraries) {
-      synchronized(libraryShards) { libraryShards.clear() }
-    }
-    evictStaleCaches(
-      bumped.generation,
-      ProjectRootModificationTracker.getInstance(project).modificationCount,
-    )
-    notifyListeners(restartDaemon = false)
   }
 
   /** Roots/facet changes should refresh open windows even when no editor asks for the index. */
   private fun projectInputsChanged() {
-    val pending = PendingProjectInputs(sourceSnapshot.get())
-    if (!pendingProjectInputs.compareAndSet(null, pending)) return
     ApplicationManager.getApplication().invokeLater {
-      val scheduled = pendingProjectInputs.getAndSet(null) ?: return@invokeLater
-      if (disposed.get() || project.isDisposed) return@invokeLater
-      reconcileProjectInputs(scheduled.snapshot)
+      if (!isDisposed && !project.isDisposed) {
+        ingress.submit(semanticChange = true) { ResolutionCoordinatorEvent.ProjectInputs }
+      }
     }
   }
 
   /** A sync can change many modules together; compare their semantic options once per batch. */
-  private fun reconcileProjectInputs(snapshot: SourceSnapshot?) {
+  private fun reconcileProjectInputs() {
+    knownIrrelevantFiles.clear()
+    val snapshot = sourceSnapshot
     if (snapshot == null) {
       // An already-open window may be waiting for Metro to be configured for the first time.
       scheduleInvalidationNotification()
@@ -466,130 +1628,157 @@ class MetroResolutionService(
     val semanticSettingsChanged =
       compilerSettingsChanged && snapshot.moduleFingerprints != currentFingerprints
     if (!rootsChanged && !semanticSettingsChanged) {
-      // Reenabling Metro can match the last built options after disabling evicted every index.
-      if (snapshots.isEmpty()) scheduleInvalidationNotification()
+      if (snapshot.inputs != inputs) updatePublishedInputs(snapshot, inputs)
+      // Reenabling Metro can restore the last built options while its retained data is stale.
+      val current = publishedResolution.value.current
+      val needsBuild =
+        current.indexesByKey.isEmpty() || current.semanticRevision != semanticRevision
+      if (needsBuild) {
+        scheduleInvalidationNotification()
+      }
       return
     }
 
-    val latest = sourceSnapshot.get()
-    val currentSourceAlreadyPublished =
-      latest != null &&
-        latest.inputs == inputs &&
-        (!semanticSettingsChanged || latest.moduleFingerprints == currentFingerprints)
-    if (!currentSourceAlreadyPublished) {
-      val bumped = invalidations.updateAndGet { it.bumpGeneration() }
-      evictStaleCaches(bumped.generation, inputs.roots)
-    }
+    semanticRevision++
+    evictStaleCaches(inputs.roots)
     scheduleInvalidationNotification()
   }
 
-  /** Entries stranded by generation or root changes can never be served again, so drop them. */
-  private fun evictStaleCaches(currentGeneration: Long, currentRoots: Long) {
-    synchronized(snapshots) {
-      snapshots.values.removeIf { !it.matches(currentGeneration, currentRoots) }
-    }
-    synchronized(libraryShards) {
-      libraryShards.keys.removeIf { it.rootsGeneration != currentRoots }
-    }
-  }
-
-  private fun scheduleBuild(module: Module, key: SnapshotKey) {
-    if (pendingBuilds.putIfAbsent(key, module) != null) return
-    val queued = IndexBuildProgress(IndexBuildPhase.QUEUED)
-    if (indexBuildProgress.compareAndSet(null, queued)) {
-      notifyIndexBuildProgress(queued)
-    }
-    buildSignal.trySend(Unit)
-  }
-
-  /**
-   * Builds (or reuses) the index for [key] with an optimistic drain/compute/publish loop:
-   * 1. Drain the invalidation ledger and read the last published source snapshot.
-   * 2. Compute a new immutable snapshot outside any lock. Analysis is allowed here, and the
-   *    caller's read action keeps PSI stable for the whole pass.
-   * 3. Publish with a single compare-and-set against the drained ledger. A concurrent invalidation
-   *    fails the publish and the loop re-drains. Unchanged shards replay from their per-file cached
-   *    values, so retries are cheap.
-   */
-  private fun buildCurrentIndex(
-    module: Module,
-    key: SnapshotKey,
-    progress: IndexBuildProgressReporter? = null,
-  ): BindingIndex {
-    if (DumbService.isDumb(project)) return BindingIndex.EMPTY
-    val moduleState = project.service<MetroIdeProjectService>().state(module)
-    if (!moduleState.isEnabled) return BindingIndex.EMPTY
-    val currentKey =
-      SnapshotKey(
-        fingerprintFor(moduleState),
-        MetroSettings.getInstance(project).state.resolveFromLibraries,
-      )
-    if (currentKey != key) return BindingIndex.EMPTY
-
-    while (true) {
-      ProgressManager.checkCanceled()
-      var start = invalidations.get()
-      val inputs = currentInputs()
-      val prev = sourceSnapshot.get()
-
-      if (prev != null && prev.inputs == inputs) {
-        snapshots[key]
-          ?.takeIf { it.matches(start.generation, inputs.roots) }
-          ?.let {
-            return it.index
-          }
-      }
-
-      val compilerSettingsChanged =
-        prev != null && prev.inputs.compilerSettings != inputs.compilerSettings
-      val fingerprintChanged =
-        compilerSettingsChanged && prev!!.moduleFingerprints != moduleFingerprints()
-      if (fingerprintChanged) {
-        // A semantic option change makes everything keyed by the old generation stale. Bump once
-        // and
-        // adopt the bumped ledger as this pass's drain point so the loop cannot spin.
-        start = invalidations.updateAndGet { it.bumpGeneration() }
-      }
-
-      val coldSweep = prev == null || prev.inputs.roots != inputs.roots || fingerprintChanged
-      val next =
-        if (coldSweep) {
-          coldSweep(moduleState.options, inputs, start, progress)
+  /** Updates project-input versions when changed settings leave the binding data unchanged. */
+  private fun updatePublishedInputs(snapshot: SourceSnapshot, inputs: IndexInputs) {
+    val updatedSource = snapshot.withInputs(inputs)
+    sourceSnapshot = updatedSource
+    updatePublishedResolution { publication ->
+      val current = publication.current.withUpdatedInputs(snapshot, updatedSource, inputs)
+      val presentation =
+        if (publication.presentation === publication.current) {
+          current
         } else {
-          incremental(prev!!, inputs, start, progress)
+          publication.presentation.withUpdatedInputs(snapshot, updatedSource, inputs)
         }
+      if (current === publication.current && presentation === publication.presentation) {
+        publication
+      } else {
+        publication.copy(current = current, presentation = presentation)
+      }
+    }
+  }
 
-      // Publish the snapshot before draining the ledger. A builder that observes the drained
-      // ledger then also observes this snapshot, so no builder can pair a drained ledger with
-      // the previous snapshot and re-publish or cache stale state. If the drain CAS below fails,
-      // the early publish is harmless because the files it incorporated are still marked dirty
-      // and simply replay from their per-file cached values on the retry.
-      sourceSnapshot.set(next)
-      val drained = start.drainAll()
-      if (!invalidations.compareAndSet(start, drained)) {
-        continue
+  /** Drops stale library data without changing the published presentation generation. */
+  private fun evictStaleCaches(
+    currentRoots: Long,
+    activeFingerprints: Set<IndexOptionsFingerprint>? = null,
+  ) {
+    libraryShards.keys.removeIf { key ->
+      key.rootsGeneration != currentRoots ||
+        (activeFingerprints != null && key.fingerprint !in activeFingerprints)
+    }
+  }
+
+  private fun scheduleBuild(
+    module: Module,
+    intent: IndexBuildIntent,
+    completion: CompletableDeferred<IndexBuildOutcome>? = null,
+  ) {
+    if (isDisposed || project.isDisposed || module.isDisposed) {
+      completion?.complete(IndexBuildOutcome.CANCELED)
+      return
+    }
+    if (intent == IndexBuildIntent.AUTOMATIC && !automaticallyRefreshGraphData) {
+      completion?.complete(IndexBuildOutcome.SKIPPED)
+      return
+    }
+    val accepted = ingress.submit {
+      val completions = mutableListOf<CompletableDeferred<IndexBuildOutcome>>()
+      if (completion != null) completions += completion
+      ResolutionCoordinatorEvent.Build(module, intent, completions)
+    }
+    if (accepted == null) {
+      completion?.complete(IndexBuildOutcome.CANCELED)
+    }
+  }
+
+  private fun collectResolutionCandidate(
+    targets: List<ManualRefreshTarget>,
+    progress: IndexBuildProgressReporter,
+    generationToken: IndexGenerationToken,
+    buildSnapshot: ResolutionIngressSnapshot,
+    manualRequest: ManualRefreshRequest?,
+    capturedInvalidations: CapturedInvalidations,
+  ): CollectedResolutionCandidate {
+    check(!DumbService.isDumb(project))
+    ProgressManager.checkCanceled()
+    val inputs = currentInputs()
+    val previous = sourceSnapshot
+    val compilerSettingsChanged =
+      previous != null && previous.inputs.compilerSettings != inputs.compilerSettings
+    val fingerprintChanged =
+      compilerSettingsChanged && previous!!.moduleFingerprints != moduleFingerprints()
+    val candidateInvalidations =
+      if (fingerprintChanged) {
+        capturedInvalidations.copy(semanticRevision = capturedInvalidations.semanticRevision + 1)
+      } else {
+        capturedInvalidations
       }
 
-      snapshots[key]
-        ?.takeIf { it.matches(start.generation, inputs.roots) }
-        ?.let {
-          return it.index
-        }
-      progress?.phase(IndexBuildPhase.COMBINING_DECLARATIONS)
-      val rawSource = aggregateSource(next, progress)
-      progress?.phase(IndexBuildPhase.RESOLVING_ASSISTED_FACTORIES)
-      val summary = next.librarySummary.getOrCreate(project, rawSource)
-      val source = rawSource.withAddedFactories(summary.sourceFactories.addedBindings)
+    if (targets.isEmpty()) {
+      return CollectedResolutionCandidate(
+        source = null,
+        consumedInvalidations = candidateInvalidations,
+        semanticRevision = candidateInvalidations.semanticRevision,
+        inputs = inputs,
+        buildersByKey = emptyMap(),
+        keysByModule = emptyMap(),
+      )
+    }
+
+    val coldSweep = previous == null || previous.inputs.roots != inputs.roots || fingerprintChanged
+    val collectedSource =
+      if (coldSweep) {
+        coldSweep(
+          targets.first().key.fingerprint.options,
+          inputs,
+          candidateInvalidations,
+          progress,
+        )
+      } else {
+        incremental(previous!!, inputs, candidateInvalidations, progress)
+      }
+    if (resolutionCandidateIsSuperseded(buildSnapshot, manualRequest, inputs)) {
+      throw ResolutionCandidateSupersededException()
+    }
+
+    progress.phase(IndexBuildPhase.COMBINING_DECLARATIONS)
+    val rawSource = aggregateSource(collectedSource, progress)
+    progress.phase(IndexBuildPhase.RESOLVING_ASSISTED_FACTORIES)
+    val summary =
+      collectedSource.librarySummary
+        ?: buildFinalizedSourceLibrarySummary(
+          project,
+          rawSource,
+          buildSourceOwnershipIndex(rawSource),
+        )
+    val finalizedSource = collectedSource.withLibrarySummary(summary)
+    val source = rawSource.withAddedFactories(summary.sourceFactories.addedBindings)
+    val buildersByKey = linkedMapOf<SnapshotKey, BindingIndexBuilder>()
+    val keysByModule = linkedMapOf<Module, SnapshotKey>()
+    val declarationSignatureFiles = finalizedSource.shardOrder.toSet()
+    for (target in targets) {
+      ProgressManager.checkCanceled()
+      if (resolutionCandidateIsSuperseded(buildSnapshot, manualRequest, inputs)) {
+        throw ResolutionCandidateSupersededException()
+      }
+      val key = target.key
       val library =
         if (key.resolveFromLibraries) {
-          progress?.phase(IndexBuildPhase.READING_DEPENDENCY_METADATA)
+          progress.phase(IndexBuildPhase.READING_DEPENDENCY_METADATA)
           libraryShardFor(key.fingerprint, inputs.roots, source, summary)
         } else {
           LibraryShard.EMPTY
         }
-      progress?.phase(IndexBuildPhase.BUILDING_GRAPH_INDEX)
+      progress.phase(IndexBuildPhase.BUILDING_GRAPH_INDEX)
       val indexBuilder =
-        BindingIndexBuilder().apply {
+        BindingIndexBuilder(generationToken).apply {
           bindings += source.bindings + library.bindings
           consumers += source.consumers
           graphs += source.graphs
@@ -601,22 +1790,191 @@ class MetroResolutionService(
             else summary.sourceFactories.incompleteFactories
           dynamicGraphs += source.dynamicGraphs
         }
-      indexBuilder.captureResolutionInputs(project)
-      val index = indexBuilder.build()
-      // Only cache when nothing invalidated the pass semantically. A plain re-drain of new dirty
-      // files under the same generation still describes this exact source snapshot.
-      if (invalidations.get().generation == start.generation) {
-        snapshots[key] = IndexSnapshot(index, start.generation, inputs.roots)
-        evictStaleCaches(start.generation, inputs.roots)
+      indexBuilder.captureResolutionInputs(declarationSignatureFiles)
+      buildersByKey[key] = indexBuilder
+      for (module in target.modules) {
+        keysByModule[module] = key
       }
-      return index
     }
+    return CollectedResolutionCandidate(
+      source = finalizedSource,
+      consumedInvalidations = candidateInvalidations,
+      semanticRevision = candidateInvalidations.semanticRevision,
+      inputs = inputs,
+      buildersByKey = buildersByKey,
+      keysByModule = keysByModule,
+    )
+  }
+
+  private fun buildSourceOwnershipIndex(source: SourceAggregate): BindingIndex {
+    val builder =
+      BindingIndexBuilder().apply {
+        bindings += source.bindings
+        consumers += source.consumers
+        graphs += source.graphs
+        contributions += source.contributions
+        assistedSites += source.assistedSites
+        bindingContainers += source.bindingContainers
+        dynamicGraphs += source.dynamicGraphs
+      }
+    builder.captureResolutionInputs(emptySet())
+    return builder.build()
+  }
+
+  /** Captures module visibility and source declaration identities inside the generation read. */
+  @OptIn(KaPlatformInterface::class)
+  private fun BindingIndexBuilder.captureResolutionInputs(
+    declarationSignatureFiles: Set<VirtualFile>
+  ) {
+    val representatives = linkedMapOf<VirtualFile, PsiElement>()
+    val pointerSourceIdentities =
+      IdentityHashMap<SmartPsiElementPointer<*>, BindingIndex.SourcePointerIdentity>()
+    val capturedDeclarationSignatures =
+      linkedMapOf<BindingIndex.SourcePointerIdentity, DeclarationAnchorSignature>()
+    val ambiguousDeclarationSignatures = mutableSetOf<BindingIndex.SourcePointerIdentity>()
+    val capturedBindings = Collections.newSetFromMap(IdentityHashMap<KaBinding, Boolean>())
+    var pointerCaptureWorkIndex = 0
+
+    fun capture(
+      pointer: SmartPsiElementPointer<*>,
+      captureAnchorSignature: Boolean = false,
+    ) {
+      checkCanceledEvery(pointerCaptureWorkIndex++)
+      val identity = sourcePointerIdentity(pointer)
+      if (identity != null) pointerSourceIdentities[pointer] = identity
+      val file = pointer.virtualFile ?: return
+      val needsAnchorSignature = captureAnchorSignature && file in declarationSignatureFiles
+      if (!needsAnchorSignature && file in representatives) return
+      val element = pointer.element ?: return
+      representatives.putIfAbsent(file, element)
+      if (!needsAnchorSignature || identity == null) return
+      val ktElement = element as? KtElement ?: return
+      val currentIdentity =
+        BindingIndex.SourcePointerIdentity(
+          file,
+          ktElement.textRange.startOffset,
+          ktElement.textRange.endOffset,
+        )
+      if (currentIdentity != identity) return
+      val signature = DeclarationAnchorSignature.capture(ktElement)
+      val existing = capturedDeclarationSignatures.putIfAbsent(identity, signature)
+      if (existing != null && existing != signature) {
+        ambiguousDeclarationSignatures += identity
+      }
+    }
+
+    fun captureBinding(binding: KaBinding) {
+      capturedBindings += binding
+      capture(binding.pointer, captureAnchorSignature = true)
+    }
+
+    for (binding in bindings) captureBinding(binding)
+    for (consumer in consumers) {
+      capture(consumer.pointer, captureAnchorSignature = true)
+      consumer.injectedMemberPointer?.let { pointer -> capture(pointer) }
+    }
+    for (graph in graphs) {
+      capture(graph.pointer, captureAnchorSignature = true)
+      for (factory in graph.extensionFactories) capture(factory.pointer)
+      for (implementation in graph.defaultImplementations) {
+        capture(implementation.declaration.pointer)
+        for (overridden in implementation.overriddenDeclarations) capture(overridden.pointer)
+      }
+      for (contribution in graph.contributedInterfaces) {
+        capture(contribution.contribution.pointer)
+        for (binding in contribution.bindings) captureBinding(binding)
+        for (consumer in contribution.consumers) {
+          capture(consumer.pointer, captureAnchorSignature = true)
+        }
+        for (factory in contribution.extensionFactories) capture(factory.pointer)
+        for (implementation in contribution.defaultImplementations) {
+          capture(implementation.declaration.pointer)
+          for (overridden in implementation.overriddenDeclarations) capture(overridden.pointer)
+        }
+      }
+    }
+    for (contribution in contributions) capture(contribution.pointer)
+    for (site in assistedSites) {
+      capture(site.pointer, captureAnchorSignature = true)
+    }
+    for (container in bindingContainers) capture(container.pointer)
+    for (dynamicGraph in dynamicGraphs) {
+      capture(dynamicGraph.pointer)
+      for (input in dynamicGraph.containerInputs) captureBinding(input)
+    }
+    capturedBindingSourceIdentities =
+      IdentityHashMap<KaBinding, BindingIndex.SourcePointerIdentity>().apply {
+        for (binding in capturedBindings) {
+          checkCanceledEvery(pointerCaptureWorkIndex++)
+          pointerSourceIdentities[binding.pointer]?.let { identity -> put(binding, identity) }
+        }
+      }
+    if (declarationSignatureFiles.isNotEmpty()) {
+      ambiguousDeclarationSignatures.forEach(capturedDeclarationSignatures::remove)
+      declarationAnchorSignatures.compute(generationToken) { _, existing ->
+        val merged = existing.orEmpty().toMutableMap()
+        val conflicts = mutableSetOf<BindingIndex.SourcePointerIdentity>()
+        for ((identity, signature) in capturedDeclarationSignatures) {
+          val previous = merged.putIfAbsent(identity, signature)
+          if (previous != null && previous != signature) conflicts += identity
+        }
+        conflicts.forEach(merged::remove)
+        merged.toMap()
+      }
+    }
+
+    val fileOrdinalTable =
+      FileOrdinalTable.freeze(
+        representatives.keys.withIndex().associate { (ordinal, file) ->
+          file to FileOrdinal(ordinal)
+        }
+      )
+    val moduleByFile = linkedMapOf<VirtualFile, ModuleViewId>()
+    val moduleIds = linkedMapOf<KaModule, ModuleViewId>()
+    val moduleRepresentatives = linkedMapOf<KaModule, PsiElement>()
+    for ((file, element) in representatives) {
+      ProgressManager.checkCanceled()
+      val module = KaModuleProvider.getModule(project, element, useSiteModule = null)
+      val moduleId = moduleIds.getOrPut(module) { ModuleViewId(moduleIds.size) }
+      moduleByFile[file] = moduleId
+      moduleRepresentatives.putIfAbsent(module, element)
+    }
+
+    val moduleViews = linkedMapOf<ModuleViewId, BindingIndexModuleView>()
+    for ((module, moduleId) in moduleIds) {
+      ProgressManager.checkCanceled()
+      val scope = KaResolutionScope.forModule(module)
+      val visibleFiles = BooleanArray(fileOrdinalTable.size)
+      for ((file, element) in representatives) {
+        ProgressManager.checkCanceled()
+        if (scope.contains(element)) {
+          visibleFiles[fileOrdinalTable.getValue(file).value] = true
+        }
+      }
+      val moduleElement = checkNotNull(moduleRepresentatives[module])
+      moduleViews[moduleId] =
+        BindingIndexModuleView(
+          id = moduleId,
+          module = module,
+          visibleFileOrdinals = visibleFiles,
+          fileOrdinalTable = fileOrdinalTable,
+          daggerAnvilInteropEnabled =
+            moduleElement.metroIdeState().options.enableDaggerAnvilInterop,
+        )
+    }
+    resolutionInputs =
+      BindingIndexResolutionInputs(
+        fileOrdinalTable,
+        moduleByFile,
+        moduleViews,
+        pointerSourceIdentities,
+      )
   }
 
   private fun coldSweep(
     options: MetroOptions,
     inputs: IndexInputs,
-    start: Invalidations,
+    pending: CapturedInvalidations,
     progress: IndexBuildProgressReporter?,
   ): SourceSnapshot {
     progress?.phase(IndexBuildPhase.DISCOVERING_SOURCE_FILES)
@@ -624,7 +1982,7 @@ class MetroResolutionService(
     val shortNames = annotationIds.mapToSet { it.shortClassName.asString() }
     val transaction = SourceSnapshotTransaction()
     val candidates = candidateFiles(annotationIds, shortNames)
-    val total = candidates.size + start.requested.size
+    val total = candidates.size + pending.requested.size
     var completed = 0
     progress?.counted(IndexBuildPhase.ANALYZING_DECLARATIONS, completed, total)
     for (file in candidates) {
@@ -638,7 +1996,7 @@ class MetroResolutionService(
       }
     }
     // Stub loading can surface requested files before their annotations reach the stub index.
-    for (virtualFile in start.requested) {
+    for (virtualFile in pending.requested) {
       ProgressManager.checkCanceled()
       try {
         if (!virtualFile.isValid || transaction.containsShard(virtualFile)) {
@@ -659,24 +2017,24 @@ class MetroResolutionService(
   private fun incremental(
     prev: SourceSnapshot,
     inputs: IndexInputs,
-    start: Invalidations,
+    pending: CapturedInvalidations,
     progress: IndexBuildProgressReporter?,
   ): SourceSnapshot {
     val dirty =
-      if (start.forceAll) {
+      if (pending.forceAll) {
         buildSet {
           addAll(prev.shardOrder)
-          addAll(start.dirty)
+          addAll(pending.dirty)
         }
       } else {
-        start.dirty
+        pending.dirty
       }
-    if (dirty.isEmpty() && start.requested.isEmpty()) {
+    if (dirty.isEmpty() && pending.requested.isEmpty()) {
       // Output-only compiler-option changes update inputs without touching any shard.
       return if (prev.inputs == inputs) prev else prev.withInputs(inputs)
     }
     val transaction = SourceSnapshotTransaction(prev)
-    val total = dirty.size + start.requested.size
+    val total = dirty.size + pending.requested.size
     var completed = 0
     progress?.counted(IndexBuildPhase.ANALYZING_DECLARATIONS, completed, total)
     for (virtualFile in dirty) {
@@ -691,16 +2049,18 @@ class MetroResolutionService(
           transaction.removeShard(virtualFile)
           continue
         }
-        val forced = start.forceAll || virtualFile in start.forced
-        transaction.applyShard(virtualFile, shardFor(file, forced))
+        transaction.applyShard(
+          virtualFile,
+          shardFor(file, forceRebuild = pending.forceAll),
+        )
       } finally {
         completed++
         progress?.counted(IndexBuildPhase.ANALYZING_DECLARATIONS, completed, total)
       }
     }
     // Requested files were enqueued before their stubs or directory events settled. Draining
-    // them here keeps them from lingering in the ledger until a cold sweep.
-    for (virtualFile in start.requested) {
+    // them here keeps them from lingering until a cold sweep.
+    for (virtualFile in pending.requested) {
       ProgressManager.checkCanceled()
       try {
         if (!virtualFile.isValid || transaction.containsShard(virtualFile)) {
@@ -801,7 +2161,7 @@ class MetroResolutionService(
     )
   }
 
-  /** Materialize each scope-matched candidate once; BindingIndex owns path-specific selection. */
+  /** Attaches interfaces with matching scopes. BindingIndex selects them for each graph path. */
   private fun attachGraphInterfaces(
     surfaces: List<GraphInterfaceSurface>,
     graphs: MutableList<KaGraphDeclaration>,
@@ -838,7 +2198,7 @@ class MetroResolutionService(
     fingerprint: IndexOptionsFingerprint,
     rootsGeneration: Long,
     source: SourceAggregate,
-    summary: SourceLibrarySummary,
+    summary: FinalizedSourceLibrarySummary,
   ): LibraryShard {
     val key = LibraryCacheKey(fingerprint, rootsGeneration, summary.inputs)
     libraryShards[key]?.let {
@@ -855,7 +2215,7 @@ class MetroResolutionService(
           source.consumers,
           source.graphs,
           contributions,
-          summary.factoryUseSites,
+          summary.sourceFactories.factoryUseSites,
           summary.consumerOwnership,
           summary.sourceFactories,
         )
@@ -899,7 +2259,7 @@ class MetroResolutionService(
   }
 
   private fun fingerprintFor(state: MetroIdeModuleState): IndexOptionsFingerprint {
-    return fingerprintsByModuleState.computeIfAbsent(state) { IndexOptionsFingerprint(it.options) }
+    return IndexOptionsFingerprint(state.options)
   }
 
   /** Files containing any Metro-relevant annotation or an exact aliased import, via indexes. */
@@ -914,8 +2274,7 @@ class MetroResolutionService(
       }
     }
 
-    // Search a distinctive package component rather than common names like Inject/Provides.
-    // This visits import/package occurrences, not every annotation usage in the whole project.
+    // Searching a distinctive package component limits this pass to import and package occurrences.
     val idsBySearchWord = annotationIds.groupBy { annotationId ->
       annotationId.packageFqName.pathSegments().maxByOrNull { it.asString().length }?.asString()
         ?: annotationId.shortClassName.asString()
@@ -961,8 +2320,16 @@ class MetroResolutionService(
   }
 
   private fun containsRelevantAnnotation(file: KtFile, shortNames: Set<String>): Boolean {
+    var hasAliasedImport = false
+    for (directive in file.importDirectives) {
+      ProgressManager.checkCanceled()
+      if (directive.aliasName != null) {
+        hasAliasedImport = true
+        break
+      }
+    }
     val names =
-      if (file.importDirectives.any { it.aliasName != null }) {
+      if (hasAliasedImport) {
         shortNames +
           file.annotationShortNamesIncludingAliases(
             sweepAnnotationIds(file.metroIdeState().options)
@@ -970,25 +2337,41 @@ class MetroResolutionService(
       } else {
         shortNames
       }
-    val hasRelevantAnnotation =
-      PsiTreeUtil.collectElementsOfType(file, KtAnnotationEntry::class.java).any { entry ->
-        entry.shortName?.asString() in names
+    var hasRelevantAnnotation = false
+    PsiTreeUtil.processElements(file) { element ->
+      ProgressManager.checkCanceled()
+      if (element is KtAnnotationEntry && element.shortName?.asString() in names) {
+        hasRelevantAnnotation = true
+        false
+      } else {
+        true
       }
+    }
     if (hasRelevantAnnotation) return true
 
     val dynamicGraphNames = buildSet {
       for (callableId in DYNAMIC_GRAPH_CALLABLES.keys) {
+        ProgressManager.checkCanceled()
         add(callableId.callableName.asString())
         for (directive in file.importDirectives) {
+          ProgressManager.checkCanceled()
           if (directive.importedFqName == callableId.asSingleFqName()) {
             directive.aliasName?.let(::add)
           }
         }
       }
     }
-    return PsiTreeUtil.collectElementsOfType(file, KtCallExpression::class.java).any { call ->
-      call.calleeExpression?.text in dynamicGraphNames
+    var hasDynamicGraphCall = false
+    PsiTreeUtil.processElements(file) { element ->
+      ProgressManager.checkCanceled()
+      if (element is KtCallExpression && element.calleeExpression?.text in dynamicGraphNames) {
+        hasDynamicGraphCall = true
+        false
+      } else {
+        true
+      }
     }
+    return hasDynamicGraphCall
   }
 
   private fun shardFor(file: KtFile, forceRebuild: Boolean = false): FileShard {
@@ -1005,8 +2388,8 @@ class MetroResolutionService(
         val state = file.metroIdeState()
         val builder = if (state.isEnabled) FileShardBuilder(file.project, state.options) else null
         val shard = builder?.buildShard(file) ?: FileShard.EMPTY
-        // Dependency PSI is only handed to the platform's cache registration here. The shard
-        // model and the service retain virtual files instead of pinning PSI.
+        // Register dependency PSI with the platform cache. The shard and service store virtual
+        // files so they do not keep those PSI trees alive.
         CachedValueProvider.Result.create(
           shard,
           file,
@@ -1025,7 +2408,28 @@ class MetroResolutionService(
         return shardFor(file, forceRebuild = true)
       }
     }
+    seedSharedDeclarationFingerprints(file, cached)
     return cached
+  }
+
+  /** Records shared declaration fingerprints during the shard's background read. */
+  private fun seedSharedDeclarationFingerprints(file: KtFile, shard: FileShard) {
+    seedSharedDeclarationFingerprint(file)
+    val psiManager = PsiManager.getInstance(project)
+    for (dependencyFile in shard.dependencyFiles + shard.sharedDeclarationFiles) {
+      ProgressManager.checkCanceled()
+      if (sharedDeclarationFingerprints.containsKey(dependencyFile)) continue
+      val dependency = psiManager.findFile(dependencyFile) as? KtFile ?: continue
+      seedSharedDeclarationFingerprint(dependency)
+    }
+  }
+
+  private fun seedSharedDeclarationFingerprint(file: KtFile) {
+    ProgressManager.checkCanceled()
+    val virtualFile = file.virtualFile ?: return
+    if (sharedDeclarationFingerprints.containsKey(virtualFile)) return
+    if (!fileHasSharedDeclarationsCached(file)) return
+    sharedDeclarationFingerprints.putIfAbsent(virtualFile, sharedDeclarationFingerprint(file))
   }
 
   /** Stored on the file so the tracker and the cached value share one lifetime. */
@@ -1055,26 +2459,22 @@ class MetroResolutionService(
   /** An opened file may be available before its stub index or directory-creation event settles. */
   private fun enrollRequestedFile(file: KtFile) {
     val virtualFile = file.virtualFile ?: return
-    val state = sourceSnapshot.get()
-    if (state == null) {
-      invalidations.updateAndGet { it.withRequested(virtualFile) }
+    val publication = publishedResolution.value
+    if (
+      virtualFile in publication.trackedSourceFiles ||
+        virtualFile in publication.knownIrrelevantFiles
+    ) {
       return
     }
-    if (virtualFile in state.shards || virtualFile in invalidations.get().dirty) {
-      return
-    }
-    // Editor features call index() once per declaration. A cached negative keeps files without
-    // Metro annotations from paying a full PSI walk on every call.
-    if (!isRelevantFileCached(file)) {
-      return
-    }
-    invalidations.updateAndGet { it.withDirty(setOf(virtualFile)) }
+    enqueuePsiChange(
+      PendingPsiChanges(files = mapOf(virtualFile to PendingFileChange(requestedByQuery = true)))
+    )
   }
 
   private fun isRelevantFileCached(file: KtFile): Boolean {
     return CachedValuesManager.getCachedValue(file) {
       val shortNames =
-        sourceSnapshot.get()?.shortNames ?: projectSweepShortNames(file.metroIdeState().options)
+        sourceSnapshot?.shortNames ?: projectSweepShortNames(file.metroIdeState().options)
       CachedValueProvider.Result.create(
         containsRelevantAnnotation(file, shortNames),
         file,
@@ -1083,92 +2483,50 @@ class MetroResolutionService(
     }
   }
 
-  private fun psiChanged(event: PsiTreeChangeEvent, structuralChange: Boolean = false) {
-    val file = changedFile(event)
-    val directory = event.child as? PsiDirectory ?: event.element as? PsiDirectory
-    if (file == null && directory != null && structuralChange) {
-      directoryChanged(directory)
-      return
-    }
-    if (file == null || !file.isValid) return
-    val virtualFile = file.virtualFile ?: return
-    val state = sourceSnapshot.get()
-    if (state == null) {
-      if (structuralChange) {
-        invalidations.updateAndGet { it.withRequested(virtualFile) }
-      }
-      return
-    }
-    val requestFile = structuralChange && virtualFile !in state.shards
-    val ownerFiles = state.dependencyOwners[virtualFile]
-    val alreadyIndexed = virtualFile in state.shards
-    val newlyRelevant = !alreadyIndexed && isRelevantFileCached(file)
-    // A file can mix indexed declarations with constants or aliases that unrelated shards
-    // reference. Only a change to those declarations needs the whole-project fallback.
-    val globalSemanticChange = sharedDeclarationChanged(event, file, structuralChange)
-    val affectsIndexedDeclarations =
-      alreadyIndexed ||
-        !ownerFiles.isNullOrEmpty() ||
-        newlyRelevant ||
-        structuralChange ||
-        globalSemanticChange
-    if (!affectsIndexedDeclarations) {
-      if (requestFile) {
-        invalidations.updateAndGet { it.withRequested(virtualFile) }
+  private fun psiChanged(
+    event: PsiTreeChangeEvent,
+    structuralChange: Boolean = false,
+    oldTreeMayDisappear: Boolean = false,
+  ) {
+    val virtualFile = changedVirtualFile(event)
+    if (virtualFile == null) {
+      val directory = changedDirectoryVirtualFile(event)
+      if (directory != null && structuralChange) {
+        enqueuePsiChange(PendingPsiChanges(directories = setOf(directory)))
       }
       return
     }
 
-    val dirty = mutableSetOf(virtualFile)
-    if (ownerFiles != null) {
-      dirty += ownerFiles
-    }
-    invalidations.updateAndGet { ledger ->
-      var updated = ledger.withDirty(dirty)
-      if (globalSemanticChange) {
-        updated = updated.withForceAll()
-      }
-      if (requestFile) {
-        updated = updated.withRequested(virtualFile)
-      }
-      updated
-    }
-    scheduleInvalidationNotification()
+    val sharedChange = sharedDeclarationChange(event, oldTreeMayDisappear)
+    val mayHaveRemovedSharedDeclaration =
+      mayHaveRemovedSharedDeclaration(event, oldTreeMayDisappear)
+
+    enqueuePsiChange(
+      PendingPsiChanges(
+        files =
+          mapOf(
+            virtualFile to
+              PendingFileChange(
+                structuralChange = structuralChange,
+                sharedDeclarationChanges =
+                  if (sharedChange == SharedDeclarationChange.NONE) emptySet()
+                  else setOf(sharedChange),
+                removedTrackedSharedDeclaration = mayHaveRemovedSharedDeclaration,
+              )
+          )
+      )
+    )
   }
 
   /**
-   * Unannotated aliases/constants can change keys across unrelated files without PSI pointers.
-   * Edits to such files force a whole-project re-shard because dependency tracking only records
-   * annotation and factory declaration files. Narrowing this needs referenced-declaration files
-   * recorded during type-key snapshotting.
+   * Aliases and constants can change binding keys in other files. Their dependencies are only
+   * partially tracked, so edits to these declarations rebuild all source shards. Tracking every
+   * referenced declaration during type-key capture would allow narrower invalidation.
    */
   private fun fileHasSharedDeclarationsCached(file: KtFile): Boolean {
     return CachedValuesManager.getCachedValue(file) {
       CachedValueProvider.Result.create(hasSharedSemanticDeclarations(file), file)
     }
-  }
-
-  private fun sharedDeclarationChanged(
-    event: PsiTreeChangeEvent,
-    file: KtFile,
-    structuralChange: Boolean,
-  ): Boolean {
-    val virtualFile = file.virtualFile ?: return false
-    val hasSharedDeclarations = fileHasSharedDeclarationsCached(file)
-    val previous = sharedDeclarationFingerprints[virtualFile]
-    if (!hasSharedDeclarations) {
-      if (previous != null) {
-        sharedDeclarationFingerprints.remove(virtualFile)
-        return true
-      }
-      return changedSharedElement(event)
-    }
-
-    val current = sharedDeclarationFingerprint(file)
-    sharedDeclarationFingerprints[virtualFile] = current
-    if (previous != null && previous != current) return true
-    if (structuralChange) return true
-    return changedSharedElement(event)
   }
 
   /** Names and declaration text catch value, alias, containing-object, and import changes. */
@@ -1180,6 +2538,7 @@ class MetroResolutionService(
 
       fun appendDeclarations(declarations: List<KtDeclaration>, owner: String) {
         for (declaration in declarations) {
+          ProgressManager.checkCanceled()
           when {
             declaration is KtTypeAlias -> {
               append('\n')
@@ -1202,22 +2561,57 @@ class MetroResolutionService(
     }
   }
 
-  private fun changedSharedElement(event: PsiTreeChangeEvent): Boolean {
-    val candidate = event.child ?: event.element ?: event.parent ?: return false
-    if (candidate is KtFile || candidate is PsiDirectory) return false
-    if (candidate is KtClassOrObject && hasSharedSemanticDeclarations(candidate)) return true
+  /** Records the change type before removed PSI becomes unavailable. */
+  private fun sharedDeclarationChange(
+    event: PsiTreeChangeEvent,
+    oldTreeMayDisappear: Boolean,
+  ): SharedDeclarationChange {
+    val candidate =
+      event.child ?: event.element ?: event.parent ?: return SharedDeclarationChange.NONE
+    if (candidate is KtFile) {
+      // Bulk reparses may omit individual removal events, so record a possible file-wide change.
+      return if (oldTreeMayDisappear) SharedDeclarationChange.FILE_CONTENTS
+      else SharedDeclarationChange.NONE
+    }
+    if (candidate is PsiDirectory) return SharedDeclarationChange.NONE
+    if (candidate is KtClassOrObject) return SharedDeclarationChange.DECLARATION_CONTAINER
 
     var current: PsiElement? = candidate
     while (current != null && current !is KtFile) {
-      if (current is KtTypeAlias) return true
-      if (current is KtProperty && current.hasModifier(KtTokens.CONST_KEYWORD)) return true
+      if (current is KtTypeAlias) return SharedDeclarationChange.DECLARATION
+      if (current is KtProperty && current.hasModifier(KtTokens.CONST_KEYWORD)) {
+        return SharedDeclarationChange.DECLARATION
+      }
+      if (current is KtImportDirective || current is KtPackageDirective) {
+        return SharedDeclarationChange.FILE_METADATA
+      }
       current = current.parent
     }
-    return false
+    return SharedDeclarationChange.NONE
+  }
+
+  /** Detects removed type aliases and const properties before their PSI is discarded. */
+  private fun mayHaveRemovedSharedDeclaration(
+    event: PsiTreeChangeEvent,
+    oldTreeMayDisappear: Boolean,
+  ): Boolean {
+    if (!oldTreeMayDisappear) return false
+    return when (val removed = event.oldChild ?: event.child) {
+      // The background classifier checks files and declaration containers.
+      is KtFile,
+      is KtClassOrObject -> false
+      is KtTypeAlias -> true
+      is KtProperty -> removed.hasModifier(KtTokens.CONST_KEYWORD)
+      else -> false
+    }
   }
 
   private fun hasSharedSemanticDeclarations(file: KtFile): Boolean {
-    return file.declarations.any(::hasSharedSemanticDeclarations)
+    for (declaration in file.declarations) {
+      ProgressManager.checkCanceled()
+      if (hasSharedSemanticDeclarations(declaration)) return true
+    }
+    return false
   }
 
   private fun hasSharedSemanticDeclarations(declaration: KtDeclaration): Boolean {
@@ -1225,288 +2619,571 @@ class MetroResolutionService(
     return when {
       declaration is KtTypeAlias -> true
       declaration is KtProperty && declaration.hasModifier(KtTokens.CONST_KEYWORD) -> true
-      declaration is KtClassOrObject ->
-        declaration.declarations.any(::hasSharedSemanticDeclarations)
+      declaration is KtClassOrObject -> {
+        for (nested in declaration.declarations) {
+          ProgressManager.checkCanceled()
+          if (hasSharedSemanticDeclarations(nested)) return true
+        }
+        false
+      }
       else -> false
     }
   }
 
+  private fun changedVirtualFile(event: PsiTreeChangeEvent): VirtualFile? {
+    event.file?.virtualFile?.let {
+      return it
+    }
+    (event.element as? KtFile)?.virtualFile?.let {
+      return it
+    }
+    return (event.child as? KtFile)?.virtualFile
+  }
+
+  private fun changedDirectoryVirtualFile(event: PsiTreeChangeEvent): VirtualFile? {
+    val directory =
+      event.child as? PsiDirectory
+        ?: event.element as? PsiDirectory
+        ?: event.parent as? PsiDirectory
+    return directory?.virtualFile
+  }
+
+  private fun enqueuePsiChange(change: PendingPsiChanges) {
+    if (change.isEmpty || isDisposed) return
+    ingress.submit(semanticChange = true) { ResolutionCoordinatorEvent.Psi(change) }
+  }
+
+  /** Collects Kotlin files from failed classification requests without reading PSI. */
+  private suspend fun failedClassificationRequests(batch: PendingPsiChanges): Set<VirtualFile> {
+    val requested = linkedSetOf<VirtualFile>()
+    requested += batch.files.keys
+    val remaining = ArrayDeque(batch.directories)
+    var visited = 0
+    while (remaining.isNotEmpty()) {
+      if (visited++ % 64 == 0) yield()
+      checkPsiClassificationActive()
+      val file = remaining.removeFirst()
+      if (!file.isValid) continue
+      if (file.isDirectory) {
+        remaining += file.children
+      } else if (file.extension == "kt" || file.extension == "kts") {
+        requested += file
+      }
+    }
+    return requested
+  }
+
+  /** Stops VFS access when JVM shutdown precedes cancellation of the project service scope. */
+  private fun checkPsiClassificationActive() {
+    val ownerDisposed = isDisposed || project.isDisposed
+    val applicationStopping =
+      ShutDownTracker.isShutdownStarted() || ApplicationManager.getApplication().isDisposed
+    if (ownerDisposed || applicationStopping) {
+      throw CancellationException("Metro PSI classification stopped during disposal")
+    }
+  }
+
+  /** Called by the coordinator inside a smart read action. */
+  private fun classifyPsiChanges(batch: PendingPsiChanges): ClassifiedPsiChanges {
+    val result = ClassifiedPsiChanges.Builder()
+    val state = sourceSnapshot
+    for (directory in batch.directories) {
+      ProgressManager.checkCanceled()
+      classifyDirectoryChange(directory, state, result)
+    }
+    for ((virtualFile, change) in batch.files) {
+      ProgressManager.checkCanceled()
+      classifyFileChange(virtualFile, change, state, result)
+    }
+    return result.build()
+  }
+
   /** Directory moves can replace several Kotlin files without reporting individual PSI children. */
-  private fun directoryChanged(directory: PsiDirectory) {
-    if (!directory.isValid || !directory.virtualFile.isValid) return
-    val files = mutableListOf<KtFile>()
+  private fun classifyDirectoryChange(
+    virtualFile: VirtualFile,
+    state: SourceSnapshot?,
+    result: ClassifiedPsiChanges.Builder,
+  ) {
+    checkPsiClassificationActive()
+    if (!virtualFile.isValid) {
+      // The removed directory cannot be traversed. Rebuild all published shards.
+      if (state != null) result.forceAll = true
+      return
+    }
+    val directory = PsiManager.getInstance(project).findDirectory(virtualFile) ?: return
     val remaining = ArrayDeque<PsiDirectory>()
     remaining += directory
     while (remaining.isNotEmpty()) {
       ProgressManager.checkCanceled()
+      checkPsiClassificationActive()
       val current = remaining.removeFirst()
       if (!current.isValid || !current.virtualFile.isValid) continue
-      files += current.files.filterIsInstance<KtFile>()
+      for (file in current.files.filterIsInstance<KtFile>()) {
+        ProgressManager.checkCanceled()
+        checkPsiClassificationActive()
+        val fileVirtualFile = file.virtualFile ?: continue
+        val alreadyTracked =
+          state != null &&
+            (fileVirtualFile in state.shards ||
+              !state.dependencyOwners[fileVirtualFile].isNullOrEmpty() ||
+              !state.sharedDeclarationOwners[fileVirtualFile].isNullOrEmpty())
+        if (alreadyTracked) continue
+        classifyFileChange(
+          fileVirtualFile,
+          PendingFileChange(structuralChange = true),
+          state,
+          result,
+          file,
+        )
+      }
       remaining += current.subdirectories
     }
-    if (files.isEmpty()) return
+  }
 
-    val state = sourceSnapshot.get() ?: return
-    val requested = mutableSetOf<VirtualFile>()
-    val dirty = mutableSetOf<VirtualFile>()
-    var sharedDeclarationsChanged = false
-    for (file in files) {
-      ProgressManager.checkCanceled()
-      val virtualFile = file.virtualFile ?: continue
-      if (fileHasSharedDeclarationsCached(file)) {
-        sharedDeclarationsChanged = true
+  /** Reads PSI and fingerprints shared declarations inside the coordinator's smart read. */
+  private fun classifyFileChange(
+    virtualFile: VirtualFile,
+    change: PendingFileChange,
+    state: SourceSnapshot?,
+    result: ClassifiedPsiChanges.Builder,
+    knownFile: KtFile? = null,
+  ) {
+    checkPsiClassificationActive()
+    val ownerFiles = state?.dependencyOwners?.get(virtualFile)
+    val alreadyIndexed = state != null && virtualFile in state.shards
+    val file =
+      knownFile
+        ?: virtualFile
+          .takeIf { it.isValid }
+          ?.let {
+            PsiManager.getInstance(project).findFile(it) as? KtFile
+          }
+    if (file == null || !file.isValid) {
+      result.fingerprints[virtualFile] = null
+      result.irrelevantFilesToRemove += virtualFile
+      if (change.structuralChange) result.requestedToRemove += virtualFile
+      result.dirty += ownerFiles.orEmpty()
+      if (alreadyIndexed || !ownerFiles.isNullOrEmpty()) result.dirty += virtualFile
+      val lostFingerprint = sharedDeclarationFingerprints.containsKey(virtualFile)
+      val directlyChangesSharedDeclaration =
+        change.sharedDeclarationChanges.any { it.forcesGlobalInvalidation }
+      val lostSharedDeclaration =
+        lostFingerprint ||
+          change.removedTrackedSharedDeclaration ||
+          directlyChangesSharedDeclaration
+      if (lostSharedDeclaration) {
+        result.forceAll = true
       }
-      if (virtualFile !in state.shards) {
-        requested += virtualFile
-      }
-      val owners = state.dependencyOwners[virtualFile]
-      val relevant = virtualFile in state.shards || !owners.isNullOrEmpty()
-      val newlyRelevant = containsRelevantAnnotation(file, state.shortNames)
-      if (!relevant && !newlyRelevant) {
-        continue
-      }
-      dirty += virtualFile
-      if (owners != null) {
-        dirty += owners
-      }
-    }
-    if (requested.isEmpty() && dirty.isEmpty() && !sharedDeclarationsChanged) {
       return
     }
-    invalidations.updateAndGet { ledger ->
-      var updated = ledger.withRequested(requested)
-      if (dirty.isNotEmpty()) {
-        updated = updated.withDirty(dirty)
+
+    val hasSharedDeclarations = fileHasSharedDeclarationsCached(file)
+    val previousFingerprint = sharedDeclarationFingerprints[virtualFile]
+    val currentFingerprint = if (hasSharedDeclarations) sharedDeclarationFingerprint(file) else null
+    result.fingerprints[virtualFile] = currentFingerprint
+    val fingerprintChanged =
+      previousFingerprint != null && previousFingerprint != currentFingerprint
+    val metadataAffectsSharedDeclarations =
+      SharedDeclarationChange.FILE_METADATA in change.sharedDeclarationChanges &&
+        (hasSharedDeclarations || previousFingerprint != null)
+    val removedSharedDeclarationWithoutFingerprint =
+      change.removedTrackedSharedDeclaration &&
+        previousFingerprint == null &&
+        !hasSharedDeclarations
+    val directlyChangesSharedDeclaration =
+      change.sharedDeclarationChanges.any { it.forcesGlobalInvalidation }
+    val asynchronouslyDiscoveredGlobalChange =
+      metadataAffectsSharedDeclarations ||
+        fingerprintChanged ||
+        removedSharedDeclarationWithoutFingerprint
+    val globalSemanticChange =
+      directlyChangesSharedDeclaration || asynchronouslyDiscoveredGlobalChange
+
+    val relevant =
+      if (state == null) {
+        isRelevantFileCached(file)
+      } else {
+        containsRelevantAnnotation(file, state.shortNames)
       }
-      if (sharedDeclarationsChanged) {
-        updated = updated.withForceAll()
-      }
-      updated
+    if (relevant) {
+      result.irrelevantFilesToRemove += virtualFile
+    } else {
+      result.irrelevantFiles += virtualFile
     }
-    if (dirty.isNotEmpty() || sharedDeclarationsChanged) {
+
+    if (state == null) {
+      if (change.structuralChange || change.requestedByQuery) {
+        if (relevant) {
+          result.requested += virtualFile
+        } else {
+          result.requestedToRemove += virtualFile
+        }
+      }
+      if (globalSemanticChange) result.forceAll = true
+      return
+    }
+
+    val newlyRelevant = !alreadyIndexed && ownerFiles.isNullOrEmpty() && relevant
+    val needsRebuild =
+      alreadyIndexed || !ownerFiles.isNullOrEmpty() || relevant || globalSemanticChange
+    if (needsRebuild) {
+      result.dirty += virtualFile
+      result.dirty += ownerFiles.orEmpty()
+    }
+    if (change.structuralChange && !alreadyIndexed) {
+      if (relevant) {
+        result.requested += virtualFile
+      } else {
+        result.requestedToRemove += virtualFile
+      }
+    }
+    if (globalSemanticChange) result.forceAll = true
+    if (newlyRelevant) result.restartDaemon = true
+  }
+
+  private fun applyClassifiedPsiChanges(classified: ClassifiedPsiChanges) {
+    for ((file, fingerprint) in classified.fingerprints) {
+      if (fingerprint == null) {
+        sharedDeclarationFingerprints.remove(file)
+      } else {
+        sharedDeclarationFingerprints[file] = fingerprint
+      }
+    }
+    knownIrrelevantFiles.removeAll(classified.irrelevantFilesToRemove)
+    knownIrrelevantFiles.addAll(classified.irrelevantFiles)
+
+    val dirtyInvalidationAdded = recordDirtyInvalidations(classified.dirty)
+    val forceAllInvalidationAdded = classified.forceAll && recordForceAllInvalidation()
+    pendingRequestedFiles += classified.requested
+    pendingRequestedFiles.removeAll(classified.requestedToRemove)
+    val semanticInvalidationAdded = dirtyInvalidationAdded || forceAllInvalidationAdded
+    if (classified.restartDaemon || semanticInvalidationAdded) {
+      // The edit-triggered daemon pass may have finished before background classification landed.
+      notifyListeners(restartDaemon = true)
+    } else if (classified.dirty.isNotEmpty() || classified.forceAll) {
       scheduleInvalidationNotification()
     }
   }
 
-  private fun changedFile(event: PsiTreeChangeEvent): KtFile? {
-    val file = event.file as? KtFile
-    if (file != null) return file
-
-    val elementFile = event.element as? KtFile
-    if (elementFile != null) return elementFile
-
-    val childFile = event.child as? KtFile
-    if (childFile != null) return childFile
-
-    val parentFile = event.parent?.containingFile as? KtFile
-    if (parentFile != null) return parentFile
-
-    return event.child?.containingFile as? KtFile
+  private fun recordDirtyInvalidations(files: Set<VirtualFile>): Boolean {
+    if (files.isEmpty()) return false
+    pendingDirtyFiles += files
+    semanticRevision++
+    return true
   }
 
-  private fun notifyListeners(restartDaemon: Boolean) {
-    val application = ApplicationManager.getApplication()
-    if (!application.isDispatchThread) {
-      application.invokeLater {
-        if (!project.isDisposed) notifyListeners(restartDaemon)
-      }
-      return
-    }
-    if (restartDaemon) DaemonCodeAnalyzer.getInstance(project).restart()
-    for (listener in listeners.toList()) listener()
+  private fun recordForceAllInvalidation(): Boolean {
+    if (forceAllFiles) return false
+    forceAllFiles = true
+    semanticRevision++
+    return true
   }
 
-  private fun publishIndexBuildProgress(progress: IndexBuildProgress?) {
-    indexBuildProgress.set(progress)
-    notifyIndexBuildProgress(progress)
+  /** Copies the pending source changes for one build attempt. */
+  private fun capturePendingInvalidations(): CapturedInvalidations {
+    return CapturedInvalidations(
+      dirty = pendingDirtyFiles.toSet(),
+      requested = pendingRequestedFiles.toSet(),
+      forceAll = forceAllFiles,
+      semanticRevision = semanticRevision,
+    )
   }
 
-  private fun notifyIndexBuildProgress(progress: IndexBuildProgress?) {
-    for (listener in indexBuildProgressListeners.toList()) {
-      notifyIndexBuildProgressListener(listener, progress)
-    }
+  /** Removes captured work only after its complete generation has published. */
+  private fun consumeCapturedInvalidations(captured: CapturedInvalidations) {
+    if (semanticRevision > captured.semanticRevision) return
+    pendingDirtyFiles.removeAll(captured.dirty)
+    pendingRequestedFiles.removeAll(captured.requested)
+    if (captured.forceAll) forceAllFiles = false
+    semanticRevision = captured.semanticRevision
   }
 
-  private fun notifyIndexBuildProgressListener(
-    listener: (IndexBuildProgress?) -> Unit,
-    progress: IndexBuildProgress?,
+  /** Daemon restart intent is recorded before conflating UI refresh requests. */
+  private fun notifyListeners(
+    restartDaemon: Boolean,
+    forceDaemonRestart: Boolean = false,
   ) {
-    val application = ApplicationManager.getApplication()
-    if (!application.isDispatchThread) {
-      application.invokeLater {
-        if (progress == null && indexBuildProgress.get() != null) return@invokeLater
-        if (!disposed.get() && !project.isDisposed && listener in indexBuildProgressListeners) {
-          listener(progress)
-        }
-      }
-      return
+    if (isDisposed || project.isDisposed) return
+    if (restartDaemon && (forceDaemonRestart || automaticallyRefreshGraphData)) {
+      project.service<MetroDaemonRestartService>().requestRestart()
     }
-    if (progress == null && indexBuildProgress.get() != null) return
-    if (!disposed.get() && !project.isDisposed && listener in indexBuildProgressListeners) {
-      listener(progress)
+    scheduleInvalidationNotification()
+  }
+
+  /** Serial EDT delivery preserves the manual browser's single stale notification per refresh. */
+  private suspend fun deliverIndexChanges() {
+    for (unused in notificationRequests) {
+      if (isDisposed) return
+      // Service disposal and scope cancellation own the consumer's lifetime.
+      if (project.isDisposed) continue
+      if (indexChanges.subscriptionCount.value == 0) continue
+      if (isManualGraphDataRefreshRequired) {
+        val previous = publishedResolution.getAndUpdate { publication ->
+          if (publication.isDisposed) publication
+          else publication.copy(manualStaleNotificationSent = true)
+        }
+        if (previous.isDisposed || previous.manualStaleNotificationSent) continue
+      }
+      indexChanges.emit(Unit)
     }
   }
 
-  /** Coalesces write-action events so an open graph window requests a fresh background snapshot. */
+  /** Publishes the current build progress for UI collectors. */
+  private fun publishIndexBuildProgress(progress: IndexBuildProgress?) {
+    if (isDisposed || project.isDisposed) return
+    mutableIndexBuildProgress.value = progress
+  }
+
+  /** Coalesces write-action events so an open graph window can refresh or show stale status. */
   private fun scheduleInvalidationNotification() {
-    if (listeners.isEmpty()) return
-    if (!invalidationPending.compareAndSet(false, true)) return
-    ApplicationManager.getApplication().invokeLater {
-      invalidationPending.set(false)
-      if (!disposed.get() && !project.isDisposed) notifyListeners(restartDaemon = false)
-    }
+    if (!isDisposed && !project.isDisposed) notificationRequests.trySend(Unit)
   }
 
   override fun dispose() {
-    disposed.set(true)
-    pendingProjectInputs.set(null)
-    buildSignal.close()
-    pendingBuilds.clear()
-    graphBrowserActivated.set(false)
-    listeners.clear()
-    indexBuildProgressListeners.clear()
-    indexBuildProgress.set(null)
-    sharedDeclarationFingerprints.clear()
-    snapshots.clear()
-    libraryShards.clear()
-    fingerprintsByModuleState.clear()
+    publishedResolution.value = PublishedResolution.DISPOSED
+    val abandonedEvents = ingress.close()
+    for (event in abandonedEvents) {
+      when (event) {
+        is ResolutionCoordinatorEvent.Build -> {
+          event.completions.forEach { it.complete(IndexBuildOutcome.CANCELED) }
+        }
+        is ResolutionCoordinatorEvent.TestBarrier -> event.completion.complete(Unit)
+        else -> Unit
+      }
+    }
+    coordinatorJob.cancel()
+    notificationRequests.close()
+    notificationScope.cancel()
+    declarationAnchorSignatures.clear()
+    mutableIndexBuildProgress.value = null
   }
 
   private companion object {
     const val MAX_CACHED_INDEXES = 8
-    const val MAX_CACHED_OPTION_FINGERPRINTS = 64
+    const val MAX_CONCURRENT_FILE_PRESENTATION_BUILDS = 2
+    const val MAX_FILE_PRESENTATION_BUNDLES = 64
   }
-}
-
-/** Builds the immutable source index used to capture dependency ownership. */
-private fun buildSourceOwnershipIndex(project: Project, source: SourceAggregate): BindingIndex {
-  val builder =
-    BindingIndexBuilder().apply {
-      bindings += source.bindings
-      consumers += source.consumers
-      graphs += source.graphs
-      contributions += source.contributions
-      assistedSites += source.assistedSites
-      bindingContainers += source.bindingContainers
-      dynamicGraphs += source.dynamicGraphs
-    }
-  builder.captureResolutionInputs(project)
-  return builder.build()
-}
-
-/** Captures module visibility and source declaration identities during the index read. */
-@OptIn(KaPlatformInterface::class)
-private fun BindingIndexBuilder.captureResolutionInputs(project: Project) {
-  val representatives = linkedMapOf<VirtualFile, PsiElement>()
-  val pointerSourceIdentities =
-    IdentityHashMap<SmartPsiElementPointer<*>, BindingIndex.SourcePointerIdentity>()
-  val capturedBindings = Collections.newSetFromMap(IdentityHashMap<KaBinding, Boolean>())
-  var pointerCaptureWorkIndex = 0
-
-  fun capture(pointer: SmartPsiElementPointer<*>) {
-    checkCanceledEvery(pointerCaptureWorkIndex++)
-    val identity = sourcePointerIdentity(pointer)
-    if (identity != null) pointerSourceIdentities[pointer] = identity
-    val file = pointer.virtualFile ?: return
-    if (file in representatives) return
-    val element = pointer.element ?: return
-    representatives.putIfAbsent(file, element)
-  }
-
-  fun captureBinding(binding: KaBinding) {
-    capturedBindings += binding
-    capture(binding.pointer)
-  }
-
-  for (binding in bindings) captureBinding(binding)
-  for (consumer in consumers) {
-    capture(consumer.pointer)
-    consumer.injectedMemberPointer?.let { pointer -> capture(pointer) }
-  }
-  for (graph in graphs) {
-    capture(graph.pointer)
-    for (factory in graph.extensionFactories) capture(factory.pointer)
-    for (implementation in graph.defaultImplementations) {
-      capture(implementation.declaration.pointer)
-      for (overridden in implementation.overriddenDeclarations) capture(overridden.pointer)
-    }
-    for (contribution in graph.contributedInterfaces) {
-      capture(contribution.contribution.pointer)
-      for (binding in contribution.bindings) captureBinding(binding)
-      for (consumer in contribution.consumers) capture(consumer.pointer)
-      for (factory in contribution.extensionFactories) capture(factory.pointer)
-      for (implementation in contribution.defaultImplementations) {
-        capture(implementation.declaration.pointer)
-        for (overridden in implementation.overriddenDeclarations) capture(overridden.pointer)
-      }
-    }
-  }
-  for (contribution in contributions) capture(contribution.pointer)
-  for (site in assistedSites) capture(site.pointer)
-  for (container in bindingContainers) capture(container.pointer)
-  for (dynamicGraph in dynamicGraphs) {
-    capture(dynamicGraph.pointer)
-    for (input in dynamicGraph.containerInputs) captureBinding(input)
-  }
-  capturedBindingSourceIdentities =
-    IdentityHashMap<KaBinding, BindingIndex.SourcePointerIdentity>().apply {
-      for (binding in capturedBindings) {
-        checkCanceledEvery(pointerCaptureWorkIndex++)
-        pointerSourceIdentities[binding.pointer]?.let { identity -> put(binding, identity) }
-      }
-    }
-
-  val fileOrdinalTable =
-    FileOrdinalTable.freeze(
-      representatives.keys.withIndex().associate { (ordinal, file) ->
-        file to FileOrdinal(ordinal)
-      }
-    )
-  val moduleByFile = linkedMapOf<VirtualFile, ModuleViewId>()
-  val moduleIds = linkedMapOf<KaModule, ModuleViewId>()
-  val moduleRepresentatives = linkedMapOf<KaModule, PsiElement>()
-  for ((file, element) in representatives) {
-    ProgressManager.checkCanceled()
-    val module = KaModuleProvider.getModule(project, element, useSiteModule = null)
-    val moduleId = moduleIds.getOrPut(module) { ModuleViewId(moduleIds.size) }
-    moduleByFile[file] = moduleId
-    moduleRepresentatives.putIfAbsent(module, element)
-  }
-
-  val moduleViews = linkedMapOf<ModuleViewId, BindingIndexModuleView>()
-  for ((module, moduleId) in moduleIds) {
-    ProgressManager.checkCanceled()
-    val scope = KaResolutionScope.forModule(module)
-    val visibleFiles = BooleanArray(fileOrdinalTable.size)
-    for ((file, element) in representatives) {
-      ProgressManager.checkCanceled()
-      if (scope.contains(element)) {
-        visibleFiles[fileOrdinalTable.getValue(file).value] = true
-      }
-    }
-    val moduleElement = checkNotNull(moduleRepresentatives[module])
-    moduleViews[moduleId] =
-      BindingIndexModuleView(
-        id = moduleId,
-        module = module,
-        visibleFileOrdinals = visibleFiles,
-        fileOrdinalTable = fileOrdinalTable,
-        daggerAnvilInteropEnabled = moduleElement.metroIdeState().options.enableDaggerAnvilInterop,
-      )
-  }
-  resolutionInputs =
-    BindingIndexResolutionInputs(
-      fileOrdinalTable,
-      moduleByFile,
-      moduleViews,
-      pointerSourceIdentities,
-    )
 }
 
 private enum class IndexRequestMode {
   CACHE_ONLY,
+  STALE_CACHE_ONLY,
+  AUTOMATIC_BACKGROUND,
   BACKGROUND,
   SYNCHRONOUS,
+}
+
+private enum class IndexBuildIntent {
+  AUTOMATIC,
+  EXPLICIT,
+  MANUAL_REFRESH,
+}
+
+private enum class IndexBuildOutcome {
+  PUBLISHED,
+  SKIPPED,
+  FAILED,
+  CANCELED,
+}
+
+private class PendingIndexBuild(
+  val module: Module,
+  var intent: IndexBuildIntent,
+  val waiters: MutableList<CompletableDeferred<IndexBuildOutcome>>,
+) {
+  fun upgrade(addedIntent: IndexBuildIntent) {
+    if (intent == IndexBuildIntent.AUTOMATIC && addedIntent == IndexBuildIntent.EXPLICIT) {
+      intent = IndexBuildIntent.EXPLICIT
+    }
+  }
+}
+
+private data class ManualRefreshRequest(val id: Long)
+
+private data class ManualRefreshTarget(
+  val key: SnapshotKey,
+  val modules: List<Module>,
+)
+
+private data class CollectedResolutionCandidate(
+  val source: SourceSnapshot?,
+  val consumedInvalidations: CapturedInvalidations,
+  val semanticRevision: Long,
+  val inputs: IndexInputs,
+  val buildersByKey: Map<SnapshotKey, BindingIndexBuilder>,
+  val keysByModule: Map<Module, SnapshotKey>,
+)
+
+private class ResolutionCandidateSupersededException : RuntimeException() {
+  override fun fillInStackTrace(): Throwable = this
+}
+
+private data class CompletedFilePresentationBundle(
+  val index: BindingIndex,
+  val key: FilePresentationKey,
+  val bundle: FilePresentationBundle,
+)
+
+/** Requests updated declaration locations for one published bundle and file version. */
+private data class PendingFilePresentationAnchorBuild(
+  val index: BindingIndex,
+  val key: FilePresentationKey,
+  val baseBundle: FilePresentationBundle,
+  val modificationStamp: Long,
+)
+
+/** Updated declaration locations waiting for the coordinator to check and publish them. */
+private data class CompletedFilePresentationAnchorBundle(
+  val index: BindingIndex,
+  val key: FilePresentationKey,
+  val baseBundle: FilePresentationBundle,
+  val modificationStamp: Long,
+  val bundle: FilePresentationBundle,
+)
+
+/** Tracks one worker so only its matching terminal event can release the slot. */
+private data class FilePresentationBuildAttempt(
+  val id: Long,
+  val index: BindingIndex,
+  val job: Job,
+)
+
+/** Tracks the original bundle and file version used by one declaration-location worker. */
+private data class FilePresentationAnchorBuildAttempt(
+  val id: Long,
+  val index: BindingIndex,
+  val baseBundle: FilePresentationBundle,
+  val modificationStamp: Long,
+  val job: Job,
+)
+
+/** Terminal state for a presentation worker attempt. */
+private sealed interface FilePresentationBuildOutcome {
+  data class Succeeded(val bundle: FilePresentationBundle) : FilePresentationBuildOutcome
+
+  data object Failed : FilePresentationBuildOutcome
+
+  data object Canceled : FilePresentationBuildOutcome
+}
+
+private sealed interface ResolutionCoordinatorEvent {
+  val coalescingKey: Any
+
+  data class Psi(val changes: PendingPsiChanges) : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any = ResolutionIngressEventKey.Psi
+  }
+
+  data object ProjectInputs : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any = ResolutionIngressEventKey.ProjectInputs
+  }
+
+  data object Settings : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any = ResolutionIngressEventKey.Settings
+  }
+
+  data class PresentationDemand(val module: Module) : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any = ResolutionIngressEventKey.PresentationDemand(module)
+  }
+
+  class Build(
+    val module: Module,
+    var intent: IndexBuildIntent,
+    val completions: MutableList<CompletableDeferred<IndexBuildOutcome>>,
+  ) : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any = ResolutionIngressEventKey.Build(module)
+  }
+
+  data class ManualRefresh(val requestId: Long) : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any = ResolutionIngressEventKey.ManualRefresh
+  }
+
+  data class FilePresentationRequest(
+    val index: BindingIndex,
+    val key: FilePresentationKey,
+  ) : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any = ResolutionIngressEventKey.FilePresentationRequest(key)
+  }
+
+  data class FilePresentationComplete(
+    val index: BindingIndex,
+    val key: FilePresentationKey,
+    val attemptId: Long,
+    val outcome: FilePresentationBuildOutcome,
+  ) : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any =
+      ResolutionIngressEventKey.FilePresentationComplete(key, attemptId)
+  }
+
+  data class FilePresentationAnchorRequest(
+    val index: BindingIndex,
+    val key: FilePresentationKey,
+    val baseBundle: FilePresentationBundle,
+    val modificationStamp: Long,
+  ) : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any = ResolutionIngressEventKey.FilePresentationAnchorRequest(key)
+  }
+
+  data class FilePresentationAnchorComplete(
+    val index: BindingIndex,
+    val key: FilePresentationKey,
+    val attemptId: Long,
+    val baseBundle: FilePresentationBundle,
+    val modificationStamp: Long,
+    val outcome: FilePresentationBuildOutcome,
+  ) : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any =
+      ResolutionIngressEventKey.FilePresentationAnchorComplete(key, attemptId)
+  }
+
+  class TestBarrier(val completion: CompletableDeferred<Unit>) : ResolutionCoordinatorEvent {
+    override val coalescingKey: Any = this
+  }
+}
+
+private sealed interface ResolutionIngressEventKey {
+  data object Psi : ResolutionIngressEventKey
+
+  data object ProjectInputs : ResolutionIngressEventKey
+
+  data object Settings : ResolutionIngressEventKey
+
+  data object ManualRefresh : ResolutionIngressEventKey
+
+  data class PresentationDemand(val module: Module) : ResolutionIngressEventKey
+
+  data class Build(val module: Module) : ResolutionIngressEventKey
+
+  data class FilePresentationRequest(val key: FilePresentationKey) : ResolutionIngressEventKey
+
+  data class FilePresentationComplete(val key: FilePresentationKey, val attemptId: Long) :
+    ResolutionIngressEventKey
+
+  data class FilePresentationAnchorRequest(val key: FilePresentationKey) : ResolutionIngressEventKey
+
+  data class FilePresentationAnchorComplete(
+    val key: FilePresentationKey,
+    val attemptId: Long,
+  ) : ResolutionIngressEventKey
+}
+
+private fun mergeResolutionCoordinatorEvents(
+  existing: ResolutionCoordinatorEvent,
+  added: ResolutionCoordinatorEvent,
+): ResolutionCoordinatorEvent {
+  check(existing.coalescingKey == added.coalescingKey)
+  return when (added) {
+    is ResolutionCoordinatorEvent.Psi -> {
+      val previous = existing as ResolutionCoordinatorEvent.Psi
+      ResolutionCoordinatorEvent.Psi(previous.changes.mergeInPlace(added.changes))
+    }
+    is ResolutionCoordinatorEvent.Build -> {
+      val previous = existing as ResolutionCoordinatorEvent.Build
+      if (added.intent == IndexBuildIntent.EXPLICIT) previous.intent = IndexBuildIntent.EXPLICIT
+      previous.completions += added.completions
+      previous
+    }
+    else -> added
+  }
 }
 
 /** Keeps one factory instance per source parameter while retaining every exact graph owner. */
@@ -1590,16 +3267,31 @@ private class FactoryInputBindingGroup(
   var additionalOwners: MutableSet<GraphDeclarationId>? = null,
 )
 
-/** Retries platform read-action cancellations without cancelling the long-lived index worker. */
+/** Retries platform read-action cancellations while the calling operation remains active. */
 internal suspend fun <T> retryCancelledIndexBuild(build: suspend () -> T): T {
   while (true) {
     try {
       return build()
-    } catch (_: ProcessCanceledException) {
-      // Yield before retrying so a cancelled service scope still stops the worker promptly.
+    } catch (exception: ProcessCanceledException) {
+      if (exception is ResolutionBuildPendingException) {
+        when (exception.completion.await()) {
+          IndexBuildOutcome.PUBLISHED -> Unit
+          IndexBuildOutcome.CANCELED ->
+            throw CancellationException("Metro resolution service was disposed")
+          IndexBuildOutcome.SKIPPED,
+          IndexBuildOutcome.FAILED -> throw exception
+        }
+      }
+      // Yield before retrying so cancellation of the calling coroutine stops promptly.
       yield()
     }
   }
+}
+
+private class ResolutionBuildPendingException(
+  val completion: CompletableDeferred<IndexBuildOutcome>
+) : ProcessCanceledException() {
+  override fun fillInStackTrace(): Throwable = this
 }
 
 private val FORCE_TRACKER_KEY = Key.create<SimpleModificationTracker>("metro.shard.force.tracker")
@@ -1611,60 +3303,165 @@ private data class SnapshotKey(
 
 private data class IndexInputs(val roots: Long, val compilerSettings: Long)
 
-/**
- * Captures the pre-change state once so deferred callbacks retain activation and refresh events.
- */
-private data class PendingProjectInputs(val snapshot: SourceSnapshot?)
-
-private data class IndexSnapshot(
-  val index: BindingIndex,
-  val generation: Long,
-  val rootsGeneration: Long,
+/** Immutable indexes and the index selected for each module in one generation. */
+private class ResolutionGeneration(
+  val token: IndexGenerationToken,
+  val inputs: IndexInputs,
+  val semanticRevision: Long,
+  val source: SourceSnapshot?,
+  indexesByKey: Map<SnapshotKey, BindingIndex>,
+  keysByModule: Map<Module, SnapshotKey>,
 ) {
-  fun matches(currentGeneration: Long, currentRootsGeneration: Long): Boolean =
-    generation == currentGeneration && rootsGeneration == currentRootsGeneration
-}
+  val indexesByKey: Map<SnapshotKey, BindingIndex> = indexesByKey.toMap()
+  val keysByModule: Map<Module, SnapshotKey> = keysByModule.toMap()
+  val indexGenerationTokens: Set<IndexGenerationToken> =
+    this.indexesByKey.values.mapTo(linkedSetOf()) { it.generationToken }
 
-/**
- * Pending invalidations as one immutable value. [stamp] moves on every transition so a builder's
- * publish compare-and-set observes any concurrent change. [generation] moves only on semantic
- * invalidations and keys the snapshot cache.
- */
-private class Invalidations(
-  val stamp: Long = 0,
-  val generation: Long = 0,
-  val dirty: Set<VirtualFile> = emptySet(),
-  val forced: Set<VirtualFile> = emptySet(),
-  val requested: Set<VirtualFile> = emptySet(),
-  /** Re-shard every indexed file, recorded as a flag so listeners never copy the shard set. */
-  val forceAll: Boolean = false,
-) {
-  fun bumpGeneration(): Invalidations =
-    Invalidations(stamp + 1, generation + 1, dirty, forced, requested, forceAll)
-
-  fun withDirty(files: Set<VirtualFile>): Invalidations =
-    Invalidations(stamp + 1, generation + 1, dirty + files, forced, requested, forceAll)
-
-  fun withForceAll(): Invalidations =
-    Invalidations(stamp + 1, generation + 1, dirty, forced, requested, forceAll = true)
-
-  /** Requested files feed a future pass and do not invalidate published results. */
-  fun withRequested(file: VirtualFile): Invalidations =
-    if (file in requested) {
-      this
-    } else {
-      Invalidations(stamp + 1, generation, dirty, forced, requested + file, forceAll)
-    }
-
-  /** Directory events merge all requests once instead of repeatedly copying the growing set. */
-  fun withRequested(files: Set<VirtualFile>): Invalidations {
-    if (files.isEmpty() || requested.containsAll(files)) return this
-    return Invalidations(stamp + 1, generation, dirty, forced, requested + files, forceAll)
+  fun index(module: Module): BindingIndex {
+    val key = keysByModule[module] ?: return BindingIndex.EMPTY
+    return indexesByKey[key] ?: BindingIndex.EMPTY
   }
 
-  /** The ledger after a successful publish, which consumed every pending entry. */
-  fun drainAll(): Invalidations = Invalidations(stamp + 1, generation)
+  fun contains(index: BindingIndex): Boolean = indexesByKey.values.any { it === index }
+
+  /** Updates project-input versions when the binding data is unchanged. */
+  fun withUpdatedInputs(
+    previousSource: SourceSnapshot,
+    updatedSource: SourceSnapshot,
+    updatedInputs: IndexInputs,
+  ): ResolutionGeneration {
+    if (source !== previousSource) return this
+    return ResolutionGeneration(
+      token = token,
+      inputs = updatedInputs,
+      semanticRevision = semanticRevision,
+      source = updatedSource,
+      indexesByKey = indexesByKey,
+      keysByModule = keysByModule,
+    )
+  }
+
+  companion object {
+    const val EMPTY_REVISION = -1L
+    val EMPTY =
+      ResolutionGeneration(
+        token = IndexGenerationToken.EMPTY,
+        inputs = IndexInputs(roots = -1L, compilerSettings = -1L),
+        semanticRevision = EMPTY_REVISION,
+        source = null,
+        indexesByKey = emptyMap(),
+        keysByModule = emptyMap(),
+      )
+  }
 }
+
+/**
+ * Complete reader state. Disposal is terminal and browser revisions track the frozen presentation.
+ */
+private data class PublishedResolution(
+  val current: ResolutionGeneration,
+  val presentation: ResolutionGeneration,
+  val filePresentationBundles: Map<FilePresentationKey, FilePresentationBundle> = emptyMap(),
+  val classifiedSemanticClock: Long = 0L,
+  val latestSemanticRevision: Long = 0L,
+  val trackedSourceFiles: Set<VirtualFile> = emptySet(),
+  val knownIrrelevantFiles: Set<VirtualFile> = emptySet(),
+  val graphBrowserActivated: Boolean = false,
+  val graphBrowserRefreshRevision: Long = 0L,
+  val manualStaleNotificationSent: Boolean = false,
+  val isDisposed: Boolean = false,
+) {
+  companion object {
+    val EMPTY = PublishedResolution(ResolutionGeneration.EMPTY, ResolutionGeneration.EMPTY)
+    val DISPOSED = EMPTY.copy(isDisposed = true)
+  }
+}
+
+private enum class SharedDeclarationChange(val forcesGlobalInvalidation: Boolean) {
+  NONE(false),
+  FILE_METADATA(false),
+  DECLARATION_CONTAINER(false),
+  FILE_CONTENTS(false),
+  DECLARATION(true),
+}
+
+private data class PendingFileChange(
+  val structuralChange: Boolean = false,
+  val sharedDeclarationChanges: Set<SharedDeclarationChange> = emptySet(),
+  val removedTrackedSharedDeclaration: Boolean = false,
+  val requestedByQuery: Boolean = false,
+) {
+  fun merge(other: PendingFileChange): PendingFileChange {
+    return PendingFileChange(
+      structuralChange = structuralChange || other.structuralChange,
+      sharedDeclarationChanges = sharedDeclarationChanges + other.sharedDeclarationChanges,
+      removedTrackedSharedDeclaration =
+        removedTrackedSharedDeclaration || other.removedTrackedSharedDeclaration,
+      requestedByQuery = requestedByQuery || other.requestedByQuery,
+    )
+  }
+}
+
+private class PendingPsiChanges(
+  files: Map<VirtualFile, PendingFileChange> = emptyMap(),
+  directories: Set<VirtualFile> = emptySet(),
+) {
+  val files = LinkedHashMap(files)
+  val directories = LinkedHashSet(directories)
+
+  val isEmpty: Boolean
+    get() = files.isEmpty() && directories.isEmpty()
+
+  fun mergeInPlace(added: PendingPsiChanges): PendingPsiChanges {
+    for ((file, change) in added.files) {
+      files[file] = files[file]?.merge(change) ?: change
+    }
+    directories += added.directories
+    return this
+  }
+}
+
+private data class ClassifiedPsiChanges(
+  val dirty: Set<VirtualFile>,
+  val requested: Set<VirtualFile>,
+  val requestedToRemove: Set<VirtualFile>,
+  val forceAll: Boolean,
+  val restartDaemon: Boolean,
+  val fingerprints: Map<VirtualFile, String?>,
+  val irrelevantFiles: Set<VirtualFile>,
+  val irrelevantFilesToRemove: Set<VirtualFile>,
+) {
+  class Builder {
+    val dirty = linkedSetOf<VirtualFile>()
+    val requested = linkedSetOf<VirtualFile>()
+    val requestedToRemove = linkedSetOf<VirtualFile>()
+    var forceAll = false
+    var restartDaemon = false
+    val fingerprints = linkedMapOf<VirtualFile, String?>()
+    val irrelevantFiles = linkedSetOf<VirtualFile>()
+    val irrelevantFilesToRemove = linkedSetOf<VirtualFile>()
+
+    fun build(): ClassifiedPsiChanges =
+      ClassifiedPsiChanges(
+        dirty = dirty.toSet(),
+        requested = requested.toSet(),
+        requestedToRemove = requestedToRemove.toSet(),
+        forceAll = forceAll,
+        restartDaemon = restartDaemon,
+        fingerprints = fingerprints.toMap(),
+        irrelevantFiles = irrelevantFiles.toSet(),
+        irrelevantFilesToRemove = irrelevantFilesToRemove.toSet(),
+      )
+  }
+}
+
+/** Immutable source work captured for one generation attempt. */
+private data class CapturedInvalidations(
+  val dirty: Set<VirtualFile>,
+  val requested: Set<VirtualFile>,
+  val forceAll: Boolean,
+  val semanticRevision: Long,
+)
 
 /** An immutable source view. Incremental passes copy it with only the changed shards replaced. */
 private class SourceSnapshot(
@@ -1676,8 +3473,10 @@ private class SourceSnapshot(
   val shardOrder: List<VirtualFile>,
   /** Dependency file to the shard files that must rebuild when it changes. */
   val dependencyOwners: PartitionedFileMap<Set<VirtualFile>>,
+  /** Maps shared declaration files to the shards that reference them. */
+  val sharedDeclarationOwners: PartitionedFileMap<Set<VirtualFile>>,
   /** Reused when changed shards leave every effective binary lookup input unchanged. */
-  val librarySummary: SourceLibrarySummaryReference,
+  val librarySummary: FinalizedSourceLibrarySummary?,
 ) {
   fun withInputs(newInputs: IndexInputs): SourceSnapshot =
     SourceSnapshot(
@@ -1687,14 +3486,30 @@ private class SourceSnapshot(
       shards,
       shardOrder,
       dependencyOwners,
+      sharedDeclarationOwners,
       librarySummary,
     )
+
+  fun withLibrarySummary(summary: FinalizedSourceLibrarySummary): SourceSnapshot {
+    if (librarySummary === summary) return this
+    return SourceSnapshot(
+      inputs,
+      moduleFingerprints,
+      shortNames,
+      shards,
+      shardOrder,
+      dependencyOwners,
+      sharedDeclarationOwners,
+      summary,
+    )
+  }
 }
 
-/** Collects one immutable source transition without copying unrelated shards or owner sets. */
+/** Collects changed shards and dependency owners, then builds a snapshot sharing unchanged data. */
 private class SourceSnapshotTransaction(private val previous: SourceSnapshot? = null) {
   private val shardChanges = linkedMapOf<VirtualFile, FileShard?>()
   private val ownerChanges = linkedMapOf<VirtualFile, MutableSet<VirtualFile>?>()
+  private val sharedOwnerChanges = linkedMapOf<VirtualFile, MutableSet<VirtualFile>?>()
 
   fun containsShard(file: VirtualFile): Boolean = currentShard(file) != null
 
@@ -1705,6 +3520,9 @@ private class SourceSnapshotTransaction(private val previous: SourceSnapshot? = 
     shardChanges[file] = shard
     for (dependencyFile in shard.dependencyFiles) {
       mutableOwners(dependencyFile).add(file)
+    }
+    for (sharedDeclarationFile in shard.sharedDeclarationFiles) {
+      mutableSharedOwners(sharedDeclarationFile).add(file)
     }
   }
 
@@ -1718,6 +3536,13 @@ private class SourceSnapshotTransaction(private val previous: SourceSnapshot? = 
         ownerChanges[dependencyFile] = null
       }
     }
+    for (sharedDeclarationFile in existing.sharedDeclarationFiles) {
+      val owners = mutableSharedOwners(sharedDeclarationFile)
+      owners.remove(file)
+      if (owners.isEmpty()) {
+        sharedOwnerChanges[sharedDeclarationFile] = null
+      }
+    }
   }
 
   fun snapshot(
@@ -1727,12 +3552,18 @@ private class SourceSnapshotTransaction(private val previous: SourceSnapshot? = 
   ): SourceSnapshot {
     val previousShards = previous?.shards ?: PartitionedFileMap.empty()
     val previousOwners = previous?.dependencyOwners ?: PartitionedFileMap.empty()
+    val previousSharedOwners = previous?.sharedDeclarationOwners ?: PartitionedFileMap.empty()
     val ownerUpdates = linkedMapOf<VirtualFile, Set<VirtualFile>?>()
     for ((file, owners) in ownerChanges) {
       ownerUpdates[file] = owners?.toSet()
     }
+    val sharedOwnerUpdates = linkedMapOf<VirtualFile, Set<VirtualFile>?>()
+    for ((file, owners) in sharedOwnerChanges) {
+      sharedOwnerUpdates[file] = owners?.toSet()
+    }
     val shards = previousShards.withChanges(shardChanges)
     val owners = previousOwners.withChanges(ownerUpdates)
+    val sharedOwners = previousSharedOwners.withChanges(sharedOwnerUpdates)
 
     val existingOrder = previous?.shardOrder.orEmpty()
     val membershipChanged = shardChanges.any { (file, updated) ->
@@ -1760,9 +3591,7 @@ private class SourceSnapshotTransaction(private val previous: SourceSnapshot? = 
           val after = updated?.librarySignature()
           before != after
         }
-    val librarySummary =
-      if (!libraryInputsChanged && previousSummary != null) previousSummary
-      else SourceLibrarySummaryReference()
+    val librarySummary = if (!libraryInputsChanged) previousSummary else null
     return SourceSnapshot(
       inputs,
       moduleFingerprints,
@@ -1770,6 +3599,7 @@ private class SourceSnapshotTransaction(private val previous: SourceSnapshot? = 
       shards,
       order,
       owners,
+      sharedOwners,
       librarySummary,
     )
   }
@@ -1787,6 +3617,16 @@ private class SourceSnapshotTransaction(private val previous: SourceSnapshot? = 
     }
     val existing = previous?.dependencyOwners?.get(file).orEmpty()
     return LinkedHashSet(existing).also { ownerChanges[file] = it }
+  }
+
+  private fun mutableSharedOwners(file: VirtualFile): MutableSet<VirtualFile> {
+    if (sharedOwnerChanges.containsKey(file)) {
+      val existing = sharedOwnerChanges[file]
+      if (existing != null) return existing
+      return linkedSetOf<VirtualFile>().also { sharedOwnerChanges[file] = it }
+    }
+    val existing = previous?.sharedDeclarationOwners?.get(file).orEmpty()
+    return LinkedHashSet(existing).also { sharedOwnerChanges[file] = it }
   }
 }
 
@@ -2172,7 +4012,7 @@ private data class FactoryInputLibrarySignature(
   val bindings: List<BindingLibrarySignature>,
 )
 
-/** Fixed-width immutable hash buckets; a transition copies only buckets whose entries change. */
+/** Stores immutable hash buckets so updates copy only the buckets containing changed entries. */
 private class PartitionedFileMap<V : Any>
 private constructor(private val buckets: Array<Map<VirtualFile, V>?>) {
 
@@ -2215,47 +4055,28 @@ private constructor(private val buckets: Array<Map<VirtualFile, V>?>) {
   }
 }
 
-/** A failed or canceled calculation is never published; equivalent source snapshots share this. */
-private class SourceLibrarySummaryReference {
-  @Volatile private var summary: SourceLibrarySummary? = null
-
-  fun getOrCreate(project: Project, source: SourceAggregate): SourceLibrarySummary {
-    summary?.let {
-      return it
-    }
-    synchronized(this) {
-      summary?.let {
-        return it
-      }
-      val sourceIndex = buildSourceOwnershipIndex(project, source)
-      val consumerOwnership = ConsumerOwnershipBundle.build(sourceIndex)
-      val sourceFactories =
-        SourceAssistedFactoryPostProcessor(
-            project,
-            source.bindings,
-            source.consumers,
-            consumerOwnership,
-          )
-          .resolveInitial()
-      val completeSource = source.withAddedFactories(sourceFactories.addedBindings)
-      val inputs = completeSource.libraryInputs(project, sourceFactories, consumerOwnership)
-      val result =
-        SourceLibrarySummary(
-          inputs,
-          sourceFactories.factoryUseSites,
-          consumerOwnership,
-          sourceFactories,
-        )
-      ProgressManager.checkCanceled()
-      summary = result
-      return result
-    }
-  }
+private fun buildFinalizedSourceLibrarySummary(
+  project: Project,
+  source: SourceAggregate,
+  sourceIndex: BindingIndex,
+): FinalizedSourceLibrarySummary {
+  val consumerOwnership = ConsumerOwnershipBundle.build(sourceIndex)
+  val sourceFactories =
+    SourceAssistedFactoryPostProcessor(
+        project,
+        source.bindings,
+        source.consumers,
+        consumerOwnership,
+      )
+      .resolveInitial()
+  val completeSource = source.withAddedFactories(sourceFactories.addedBindings)
+  val inputs = completeSource.libraryInputs(project, sourceFactories, consumerOwnership)
+  ProgressManager.checkCanceled()
+  return FinalizedSourceLibrarySummary(inputs, consumerOwnership, sourceFactories)
 }
 
-private data class SourceLibrarySummary(
+private data class FinalizedSourceLibrarySummary(
   val inputs: LibraryInputs,
-  val factoryUseSites: SourceAssistedFactoryUseSites,
   val consumerOwnership: ConsumerOwnershipBundle,
   val sourceFactories: SourceFactoryResolution,
 )
@@ -2508,12 +4329,21 @@ internal fun sweepAnnotationIds(options: MetroOptions): Set<ClassId> {
  * Includes local import aliases without resolving annotations or starting an Analysis API session.
  */
 internal fun KtFile.annotationShortNamesIncludingAliases(annotationIds: Set<ClassId>): Set<String> {
-  val names = annotationIds.mapTo(mutableSetOf()) { it.shortClassName.asString() }
+  val names = mutableSetOf<String>()
+  for (annotationId in annotationIds) {
+    ProgressManager.checkCanceled()
+    names += annotationId.shortClassName.asString()
+  }
   for (directive in importDirectives) {
+    ProgressManager.checkCanceled()
     val alias = directive.aliasName ?: continue
     val importedName = directive.importedFqName ?: continue
-    if (annotationIds.any { it.asSingleFqName() == importedName }) {
-      names += alias
+    for (annotationId in annotationIds) {
+      ProgressManager.checkCanceled()
+      if (annotationId.asSingleFqName() == importedName) {
+        names += alias
+        break
+      }
     }
   }
   return names

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/ResolutionIngress.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/ResolutionIngress.kt
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea.index
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+
+/**
+ * Accepts requests from concurrent IDE callbacks and merges matching keys before the coordinator
+ * drains them. The channel signals pending work. Requests stay queued until [drain] or [close].
+ */
+internal class ResolutionIngress<E : Any>(
+  private val coalescingKey: (E) -> Any? = { null },
+  private val merge: (E, E) -> E = { _, added -> added },
+) {
+  private val lock = Any()
+  private val wakeChannel = Channel<Unit>(Channel.CONFLATED)
+
+  private var closed = false
+  private var eventClock = 0L
+  private var semanticClock = 0L
+  private var latestManualRequestId = 0L
+  private var coalescedEvents = linkedMapOf<Any, E>()
+  private var uncoalescedEvents = mutableListOf<E>()
+
+  val wakeups: ReceiveChannel<Unit>
+    get() = wakeChannel
+
+  fun submit(
+    semanticChange: Boolean = false,
+    manualRefresh: Boolean = false,
+    event: (ResolutionIngressTicket) -> E,
+  ): ResolutionIngressTicket? {
+    val ticket =
+      synchronized(lock) {
+        if (closed) return@synchronized null
+        eventClock++
+        if (semanticChange) semanticClock++
+        if (manualRefresh) latestManualRequestId = eventClock
+        val accepted =
+          ResolutionIngressTicket(
+            eventClock = eventClock,
+            semanticClock = semanticClock,
+            latestManualRequestId = latestManualRequestId,
+          )
+        val added = event(accepted)
+        val key = coalescingKey(added)
+        if (key == null) {
+          uncoalescedEvents += added
+        } else {
+          val existing = coalescedEvents[key]
+          coalescedEvents[key] = if (existing == null) added else merge(existing, added)
+        }
+        accepted
+      }
+    if (ticket != null) wakeChannel.trySend(Unit)
+    return ticket
+  }
+
+  fun drain(): ResolutionIngressDrain<E> {
+    return synchronized(lock) {
+      val drained =
+        buildList(coalescedEvents.size + uncoalescedEvents.size) {
+          addAll(coalescedEvents.values)
+          addAll(uncoalescedEvents)
+        }
+      coalescedEvents = linkedMapOf()
+      uncoalescedEvents = mutableListOf()
+      ResolutionIngressDrain(snapshotLocked(), drained)
+    }
+  }
+
+  fun snapshot(): ResolutionIngressSnapshot = synchronized(lock) { snapshotLocked() }
+
+  /** Stops accepting requests and returns queued events so the caller can cancel their waiters. */
+  fun close(): List<E> {
+    val abandoned =
+      synchronized(lock) {
+        if (closed) return@synchronized emptyList()
+        closed = true
+        val pending =
+          buildList(coalescedEvents.size + uncoalescedEvents.size) {
+            addAll(coalescedEvents.values)
+            addAll(uncoalescedEvents)
+          }
+        coalescedEvents = linkedMapOf()
+        uncoalescedEvents = mutableListOf()
+        pending
+      }
+    wakeChannel.close()
+    return abandoned
+  }
+
+  private fun snapshotLocked(): ResolutionIngressSnapshot {
+    return ResolutionIngressSnapshot(
+      eventClock = eventClock,
+      semanticClock = semanticClock,
+      latestManualRequestId = latestManualRequestId,
+      hasPendingEvents = coalescedEvents.isNotEmpty() || uncoalescedEvents.isNotEmpty(),
+      isClosed = closed,
+    )
+  }
+}
+
+internal data class ResolutionIngressTicket(
+  val eventClock: Long,
+  val semanticClock: Long,
+  val latestManualRequestId: Long,
+)
+
+internal data class ResolutionIngressSnapshot(
+  val eventClock: Long,
+  val semanticClock: Long,
+  val latestManualRequestId: Long,
+  val hasPendingEvents: Boolean,
+  val isClosed: Boolean,
+)
+
+internal data class ResolutionIngressDrain<E : Any>(
+  val snapshot: ResolutionIngressSnapshot,
+  val events: List<E>,
+)

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/ResolutionIngress.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/ResolutionIngress.kt
@@ -8,6 +8,14 @@ import kotlinx.coroutines.channels.ReceiveChannel
 /**
  * Accepts requests from concurrent IDE callbacks and merges matching keys before the coordinator
  * drains them. The channel signals pending work. Requests stay queued until [drain] or [close].
+ *
+ * The queue and its counters share one lock. Counters start at zero, advance when requests arrive,
+ * and survive drains. Several submissions can merge into one queued event, so the counters can
+ * advance by more than the number of events returned by [drain].
+ *
+ * An editor-hint request advances only [eventClock], allowing an index build to continue. A PSI
+ * change also advances [semanticClock], so the build must reconsider its inputs. A manual refresh
+ * records its [eventClock] in [latestManualRequestId] so a newer refresh can replace an older one.
  */
 internal class ResolutionIngress<E : Any>(
   private val coalescingKey: (E) -> Any? = { null },
@@ -17,15 +25,37 @@ internal class ResolutionIngress<E : Any>(
   private val wakeChannel = Channel<Unit>(Channel.CONFLATED)
 
   private var closed = false
+
+  /** Sequence number of every accepted submission. Also supplies unique manual-refresh IDs. */
   private var eventClock = 0L
+
+  /**
+   * Counts submissions marked as potentially changing bindings, such as PSI, roots, or settings
+   * changes. A newer value makes an in-progress build retry and tells current-data queries that
+   * classification is pending. This still advances when classification finds no relevant change.
+   */
   private var semanticClock = 0L
+
+  /**
+   * The [eventClock] of the latest manual refresh, or zero before the first refresh. Unrelated
+   * requests leave it unchanged. Only manual-refresh builds compare this ID to detect replacement.
+   */
   private var latestManualRequestId = 0L
   private var coalescedEvents = linkedMapOf<Any, E>()
   private var uncoalescedEvents = mutableListOf<E>()
 
+  /** Merges repeated wakeups while retaining queued events for the next [drain]. */
   val wakeups: ReceiveChannel<Unit>
     get() = wakeChannel
 
+  /**
+   * Accepts one submission and returns the counter values assigned to it, or null after [close].
+   * [event], [coalescingKey], and [merge] run under the queue lock and must remain short.
+   *
+   * [semanticChange] marks work that may invalidate binding data. Ordinary build requests and
+   * worker completions leave it false. [manualRefresh] assigns a new refresh ID independently of
+   * whether binding data changed.
+   */
   fun submit(
     semanticChange: Boolean = false,
     manualRefresh: Boolean = false,
@@ -57,6 +87,11 @@ internal class ResolutionIngress<E : Any>(
     return ticket
   }
 
+  /**
+   * Detaches the queued events and captures their counters under the same lock. The returned
+   * snapshot has an empty queue even though the coordinator still needs to process these events.
+   * New submissions can arrive as soon as the lock is released.
+   */
   fun drain(): ResolutionIngressDrain<E> {
     return synchronized(lock) {
       val drained =
@@ -70,6 +105,7 @@ internal class ResolutionIngress<E : Any>(
     }
   }
 
+  /** Reads the latest counters and queue state without consuming events. */
   fun snapshot(): ResolutionIngressSnapshot = synchronized(lock) { snapshotLocked() }
 
   /** Stops accepting requests and returns queued events so the caller can cancel their waiters. */
@@ -102,20 +138,34 @@ internal class ResolutionIngress<E : Any>(
   }
 }
 
+/** Counter values captured for one accepted submission. */
 internal data class ResolutionIngressTicket(
+  /** Sequence number assigned to this submission, including submissions merged by key. */
   val eventClock: Long,
+  /** Number of accepted requests that may change binding data, through this submission. */
   val semanticClock: Long,
+  /** Latest manual-refresh submission's [eventClock], or zero before the first refresh. */
   val latestManualRequestId: Long,
 )
 
+/**
+ * Counter values and queue state captured together. They describe accepted requests. The
+ * coordinator tracks which changes it has classified and which indexes it has published.
+ */
 internal data class ResolutionIngressSnapshot(
+  /** Sequence number of the latest accepted submission. Ordinary requests also advance it. */
   val eventClock: Long,
+  /** Compared with a build's starting value to detect incoming changes that require a retry. */
   val semanticClock: Long,
+  /** Compared with a manual-refresh build's ID to detect a newer refresh request. */
   val latestManualRequestId: Long,
+  /** Whether events remain in this queue. Drained events may still be awaiting processing. */
   val hasPendingEvents: Boolean,
+  /** Whether [ResolutionIngress.close] has stopped further submissions. */
   val isClosed: Boolean,
 )
 
+/** One detached batch and the queue state captured immediately after detaching it. */
 internal data class ResolutionIngressDrain<E : Any>(
   val snapshot: ResolutionIngressSnapshot,
   val events: List<E>,

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/IndexBuildStatusPanel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/IndexBuildStatusPanel.kt
@@ -51,6 +51,13 @@ internal class IndexBuildStatusPanel : JPanel(BorderLayout(0, JBUI.scale(4))) {
     isVisible = true
   }
 
+  fun showRefreshRequired() {
+    messageLabel.text = "Metro graph data may be stale. Click Refresh to update"
+    progressBar.isVisible = false
+    progressBar.isIndeterminate = false
+    isVisible = true
+  }
+
   fun clear() {
     isVisible = false
     progressBar.isIndeterminate = false

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
@@ -199,6 +199,7 @@ internal class MetroToolWindowPanel(private val project: Project) :
       when {
         progress != null -> indexBuildStatus.show(progress)
         !resolutionService.isGraphBrowserActivated -> indexBuildStatus.showNotLoaded()
+        resolutionService.isManualGraphDataRefreshRequired -> indexBuildStatus.showRefreshRequired()
         else -> indexBuildStatus.clear()
       }
     }
@@ -245,7 +246,7 @@ internal class MetroToolWindowPanel(private val project: Project) :
   private fun findGraph(classId: ClassId, file: VirtualFile?): KaGraphDeclaration? {
     val psiFile =
       file?.let { PsiManager.getInstance(project).findFile(it) } as? KtFile ?: return null
-    return project.service<MetroResolutionService>().index(psiFile).graphs.firstOrNull {
+    return project.service<MetroResolutionService>().currentIndex(psiFile).graphs.firstOrNull {
       it.classId == classId && it.pointer.virtualFile == file
     }
   }
@@ -474,7 +475,7 @@ internal class LoadOrRefreshGraphsAction(
   }
 
   override fun actionPerformed(e: AnActionEvent) {
-    resolutionService.activateGraphBrowser()
+    resolutionService.refreshGraphData()
     refresh()
   }
 }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroTreeStructure.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroTreeStructure.kt
@@ -304,7 +304,7 @@ private fun validationSummary(result: KaGraphValidationResult): String {
 internal class MetroTreeStructure(
   private val project: Project,
   private val indexProvider: (Module) -> BindingIndex = { module ->
-    project.service<MetroResolutionService>().index(module)
+    project.service<MetroResolutionService>().currentIndex(module)
   },
   private val pinService: GraphContextPinService = project.service(),
   private val filterText: () -> String,

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/usages/MetroFindUsages.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/usages/MetroFindUsages.kt
@@ -26,6 +26,7 @@ import com.intellij.usages.impl.rules.UsageWithType
 import com.intellij.util.Processor
 import dev.zacsweers.metro.idea.GraphContextPinService
 import dev.zacsweers.metro.idea.index.MetroResolutionService
+import dev.zacsweers.metro.idea.index.retryCancelledIndexBuild
 import dev.zacsweers.metro.idea.model.BindingIndex
 import dev.zacsweers.metro.idea.model.GraphPath
 import dev.zacsweers.metro.idea.model.matchingContextEntry
@@ -202,7 +203,9 @@ internal suspend fun collectMetroUsages(
 ): List<Usage> {
   val project = element.project
   if (DumbService.isDumb(project)) return emptyList()
-  val result = smartReadAction(project) { collectMetroUsagesInReadAction(element, options) }
+  val result = retryCancelledIndexBuild {
+    smartReadAction(project) { collectMetroUsagesInReadAction(element, options) }
+  }
   result.cacheEntry?.let(project.service<MetroUsageTypeCache>()::replace)
   return result.usages
 }

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroDynamicGraphTest.kt
@@ -47,7 +47,7 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
         val dynamicGraph = createDynamicGraph<AppGraph>(FakeBindings)
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val contexts = index.contextsFor(graph)
     val staticContext = contexts.single { it.dynamicGraph == null }
@@ -109,7 +109,7 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
           .trimIndent(),
       ) as KtFile
 
-    val index = service.index(declarations)
+    val index = service.awaitIndex(declarations)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val dynamicContexts = index.contextsFor(graph).filter { it.dynamicGraph != null }
 
@@ -147,7 +147,7 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
         val factory = createDynamicGraphFactory<AppGraph.Factory>(GenericBindings("fake"))
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val context = index.contextsFor(graph).single { it.dynamicGraph != null }
     val dynamicGraph = checkNotNull(context.dynamicGraph)
@@ -198,7 +198,7 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
         val dynamicGraph = createDynamicGraph<AppGraph>(FakeBindings)
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val parent = index.graphs.single { it.name == "AppGraph" }
     val child = index.graphs.single { it.name == "ChildGraph" }
     val parentContext = index.contextsFor(parent).single { it.dynamicGraph != null }
@@ -245,7 +245,7 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
         val dynamicGraph = createDynamicGraph<AppGraph>(FakeBindings)
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val context = index.contextsFor(graph).single { it.dynamicGraph != null }
     val queryContext = checkNotNull(index.queryContext(context))
@@ -295,7 +295,7 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
           createDynamicGraph<AppGraph>(FirstFakeBindings, SecondFakeBindings)
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val context = index.contextsFor(graph).single { it.dynamicGraph != null }
     val result =
@@ -319,7 +319,7 @@ class MetroDynamicGraphTest : BasePlatformTestCase() {
         val unrelated: AppGraph = createDynamicGraph(FakeBindings)
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val dynamicContexts = index.contextsFor(graph).filter { it.dynamicGraph != null }
     val metroCall =

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroFilePresentationTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroFilePresentationTest.kt
@@ -1,0 +1,364 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
+package dev.zacsweers.metro.idea
+
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.Disposer
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.PlatformTestUtil
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import dev.zacsweers.metro.idea.index.MetroResolutionService
+import dev.zacsweers.metro.idea.model.GraphPath
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+
+/** Focused publication and anchor-maintenance coverage for file presentation bundles. */
+class MetroFilePresentationTest : BasePlatformTestCase() {
+
+  override fun setUp() {
+    super.setUp()
+    project.setMetroOptions()
+    module.addMetroRuntimeLibrary()
+    val service = project.service<MetroResolutionService>()
+    MetroSettings.getInstance(project).state.automaticallyRefreshGraphData = true
+    service.settingsChanged()
+    awaitCoordinator(service)
+    service.resetGraphBrowserActivation()
+  }
+
+  fun testPresentationReverseUsageRetainsNegativePinnedContextAnswers() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        abstract class OtherScope
+
+        interface Repo
+
+        @Inject
+        @ContributesBinding(AppScope::class)
+        class AppRepo : Repo
+
+        @Inject
+        @ContributesBinding(OtherScope::class)
+        class OtherRepo : Repo
+
+        @Inject class Consumer(val repo: Repo)
+
+        @DependencyGraph(AppScope::class)
+        interface AppGraph {
+          val consumer: Consumer
+        }
+
+        @DependencyGraph(OtherScope::class)
+        interface OtherGraph {
+          val consumer: Consumer
+        }
+        """
+      )
+    val service = project.service<MetroResolutionService>()
+    val index = service.awaitIndex(file)
+    val declarations = file.declarationsIncludingNested()
+    val presentation =
+      checkNotNull(file.awaitMetroPresentation().declaration(declarations.klass("AppRepo")))
+    val reverseUsage = checkNotNull(presentation.reverseUsage)
+    val contexts =
+      index.graphs.associate { graph -> graph.name to index.contextsFor(graph).single().path }
+
+    fun consumerNames(path: GraphPath?): List<String?> {
+      return reverseUsage.consumersFor(path).map { consumer ->
+        (consumer.pointer.element as? KtNamedDeclaration)?.name
+      }
+    }
+
+    assertEquals(listOf("repo"), consumerNames(null))
+    assertEquals(listOf("repo"), consumerNames(contexts.getValue("AppGraph")))
+    assertTrue(consumerNames(contexts.getValue("OtherGraph")).isEmpty())
+  }
+
+  fun testPresentationAnchorsFollowBodyEditsAndReorderingUntilManualRefresh() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        @Inject
+        class First {
+          fun label(): String = "before"
+        }
+
+        @Inject class Second
+        """
+      )
+    val service = project.service<MetroResolutionService>()
+    val initialIndex = service.awaitIndex(file)
+    val initialBundle = file.awaitMetroPresentation()
+    val initialDeclarations = file.declarationsIncludingNested()
+    val firstPresentation =
+      checkNotNull(initialBundle.declaration(initialDeclarations.klass("First")))
+    val secondPresentation =
+      checkNotNull(initialBundle.declaration(initialDeclarations.klass("Second")))
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+
+    try {
+      file.updateDocument { document ->
+        val valueStart = document.text.indexOf("\"before\"")
+        document.replaceString(valueStart, valueStart + "\"before\"".length, "\"after value\"")
+        val firstStart = document.text.indexOf("@Inject\nclass First")
+        document.insertString(firstStart, "// shifted anchor\n")
+      }
+      val bodyEdited = file.awaitMetroPresentation()
+      val bodyEditedDeclarations = file.declarationsIncludingNested()
+      assertTrue(bodyEdited.sharesSemanticData(initialBundle))
+      assertSame(
+        firstPresentation,
+        bodyEdited.declaration(bodyEditedDeclarations.klass("First")),
+      )
+      assertSame(
+        secondPresentation,
+        bodyEdited.declaration(bodyEditedDeclarations.klass("Second")),
+      )
+
+      file.updateDocument { document ->
+        val firstStart = document.text.indexOf("// shifted anchor")
+        val secondStart = document.text.indexOf("@Inject class Second")
+        val firstBlock = document.text.substring(firstStart, secondStart).trim()
+        val secondBlock = document.text.substring(secondStart).trim()
+        document.replaceString(
+          firstStart,
+          document.textLength,
+          "$secondBlock\n\n$firstBlock",
+        )
+      }
+      val reordered = file.awaitMetroPresentation()
+      val reorderedDeclarations = file.declarationsIncludingNested()
+      assertTrue(reordered.sharesSemanticData(initialBundle))
+      val reorderedFirst = reordered.declaration(reorderedDeclarations.klass("First"))
+      val reorderedSecond = reordered.declaration(reorderedDeclarations.klass("Second"))
+      assertTrue(
+        "Reordering must not attach Second's presentation to First",
+        reorderedFirst == null || reorderedFirst === firstPresentation,
+      )
+      assertTrue(
+        "Reordering must not attach First's presentation to Second",
+        reorderedSecond == null || reorderedSecond === secondPresentation,
+      )
+
+      file.updateDocument { document ->
+        document.insertString(document.textLength, "\n\n@Inject class AddedLater")
+      }
+      val frozen = file.awaitMetroPresentation()
+      val added = file.declarationsIncludingNested().klass("AddedLater")
+      assertTrue(frozen.sharesSemanticData(initialBundle))
+      assertNull(frozen.declaration(added))
+      assertSame(initialIndex, service.presentationIndex(file))
+
+      val refreshed = CompletableFuture<Unit>()
+      service.addIndexListener(testRootDisposable) {
+        val addedPublished =
+          service.presentationIndex(file).bindings.any { binding ->
+            binding.implementationName == "AddedLater"
+          }
+        if (!service.isManualGraphDataRefreshRequired && addedPublished) {
+          refreshed.complete(Unit)
+        }
+      }
+      service.refreshGraphData()
+      PlatformTestUtil.waitForFuture(refreshed, 30_000)
+
+      val refreshedBundle = file.awaitMetroPresentation()
+      assertFalse(refreshedBundle.sharesSemanticData(initialBundle))
+      assertNotNull(refreshedBundle.declaration(added))
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+      awaitCoordinator(service)
+    }
+  }
+
+  fun testColdPresentationAnchorsRejectEqualLengthReplacementAndDeletion() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        @Inject class Original
+
+        @Inject class Removed
+
+        @Inject class Stable
+        """
+      )
+    val service = project.service<MetroResolutionService>()
+    val initialIndex = service.awaitIndex(file)
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    awaitCoordinator(service)
+
+    try {
+      // Build the first presentation from frozen semantics after its source declarations change.
+      file.updateDocument { document ->
+        val originalStart = document.text.indexOf("Original")
+        document.replaceString(
+          originalStart,
+          originalStart + "Original".length,
+          "Replaced",
+        )
+        val removedStart = document.text.indexOf("@Inject class Removed")
+        val removedEnd = removedStart + "@Inject class Removed\n\n".length
+        document.deleteString(removedStart, removedEnd)
+      }
+
+      val updated = file.awaitMetroPresentation()
+      val currentDeclarations = file.declarationsIncludingNested()
+      val replaced = currentDeclarations.klass("Replaced")
+      val stable = currentDeclarations.klass("Stable")
+
+      assertSame(initialIndex.generationToken, updated.generationToken)
+      assertNull(updated.declaration(replaced))
+      val stablePresentation = updated.declaration(stable)
+      if (stablePresentation != null) {
+        assertEquals(
+          listOf("Stable"),
+          stablePresentation.bindingEntries.mapNotNull { it.implementationName }.distinct(),
+        )
+      }
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+      awaitCoordinator(service)
+    }
+  }
+
+  fun testRepeatedPresentationRequestsReuseCurrentAnchors() {
+    val file = myFixture.configureMetroFile("@Inject class Target")
+    val service = project.service<MetroResolutionService>()
+    service.awaitIndex(file)
+    val initialBundle = file.awaitMetroPresentation()
+    val initialPresentation =
+      checkNotNull(initialBundle.declaration(file.declarationsIncludingNested().klass("Target")))
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    awaitCoordinator(service)
+
+    try {
+      file.updateDocument { document -> document.insertString(0, "// offset\n") }
+      val target = file.declarationsIncludingNested().klass("Target")
+      assertNull(initialBundle.declaration(target))
+      repeat(8) {
+        val requested = checkNotNull(service.presentationBundle(target))
+        assertTrue(requested.sharesSemanticData(initialBundle))
+      }
+
+      val updated = file.awaitMetroPresentation()
+      assertSame(initialPresentation, updated.declaration(target))
+      repeat(8) { assertSame(updated, service.presentationBundle(target)) }
+      awaitCoordinator(service)
+      assertSame(updated, file.awaitMetroPresentation())
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+      awaitCoordinator(service)
+    }
+  }
+
+  fun testPresentationAnchorsFollowTheLatestOfRepeatedEdits() {
+    val file = myFixture.configureMetroFile("@Inject class Target")
+    val service = project.service<MetroResolutionService>()
+    service.awaitIndex(file)
+    val initialBundle = file.awaitMetroPresentation()
+    val initialPresentation =
+      checkNotNull(initialBundle.declaration(file.declarationsIncludingNested().klass("Target")))
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    awaitCoordinator(service)
+
+    try {
+      repeat(8) { edit ->
+        file.updateDocument { document -> document.insertString(0, "// edit $edit\n") }
+        val target = file.declarationsIncludingNested().klass("Target")
+        val requested = checkNotNull(service.presentationBundle(target))
+        assertTrue(requested.sharesSemanticData(initialBundle))
+      }
+
+      val updated = file.awaitMetroPresentation()
+      val target = file.declarationsIncludingNested().klass("Target")
+      assertTrue(updated.anchorsAreCurrent(file.modificationStamp))
+      assertTrue(updated.sharesSemanticData(initialBundle))
+      assertSame(initialPresentation, updated.declaration(target))
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+      awaitCoordinator(service)
+    }
+  }
+
+  fun testDisposalDiscardsQueuedPresentationAnchorRequests() {
+    val file = myFixture.configureMetroFile("@Inject class Target")
+    val executor = Executors.newSingleThreadExecutor()
+    val dispatcher = executor.asCoroutineDispatcher()
+    val serviceScope = CoroutineScope(SupervisorJob() + dispatcher)
+    val service = MetroResolutionService(project, serviceScope)
+    val settings = MetroSettings.getInstance(project).state
+    val projectService = project.service<MetroResolutionService>()
+    val paused = CompletableFuture<Unit>()
+    val release = CountDownLatch(1)
+
+    try {
+      service.awaitIndex(file)
+      val initialBundle = file.awaitMetroPresentation(service)
+      settings.automaticallyRefreshGraphData = false
+      service.settingsChanged()
+      projectService.settingsChanged()
+      awaitCoordinator(service)
+      awaitCoordinator(projectService)
+
+      // Hold the service's executor so its next ordinary presentation request remains queued.
+      executor.submit {
+        paused.complete(Unit)
+        release.await()
+      }
+      PlatformTestUtil.waitForFuture(paused, 30_000)
+      file.updateDocument { document -> document.insertString(0, "// dispose\n") }
+      val target = file.declarationsIncludingNested().klass("Target")
+      assertSame(initialBundle, service.presentationBundle(target))
+
+      Disposer.dispose(service)
+      release.countDown()
+      // JUnit 3 discovers zero-argument void functions generated for empty Runnable lambdas.
+      val drained = CompletableFuture.supplyAsync({ Unit }, executor)
+      PlatformTestUtil.waitForFuture(drained, 30_000)
+
+      assertNull(service.presentationBundle(target))
+    } finally {
+      release.countDown()
+      if (!Disposer.isDisposed(service)) Disposer.dispose(service)
+      serviceScope.cancel()
+      dispatcher.close()
+      settings.automaticallyRefreshGraphData = true
+      projectService.settingsChanged()
+      awaitCoordinator(projectService)
+    }
+  }
+
+  private fun KtFile.updateDocument(update: (Document) -> Unit) {
+    val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(this))
+    WriteCommandAction.runWriteCommandAction(project) { update(document) }
+    PsiDocumentManager.getInstance(project).commitAllDocuments()
+  }
+
+  private fun awaitCoordinator(service: MetroResolutionService) {
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+  }
+}

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationParityTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationParityTest.kt
@@ -253,7 +253,7 @@ class MetroGraphValidationParityTest : BasePlatformTestCase() {
       val source = compilerContracts.source(case)
       val file =
         myFixture.configureByText(case.sourceFile ?: "${case.fixtureName}.kt", source) as KtFile
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val graphName = case.graphPath.first()
       val graph = index.graphs.single { it.classId?.asFqNameString() == graphName }
       val context =

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
@@ -50,7 +50,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     graphName: String = "AppGraph",
   ): KaGraphValidationResult {
     val file = myFixture.configureMetroFile(source)
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == graphName }
     return project
       .service<MetroGraphValidationService>()
@@ -73,7 +73,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
 
   fun testUnexpectedFailureReturnsInternalError() {
     val file = myFixture.configureMetroFile("@DependencyGraph interface AppGraph")
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     val failure = IllegalStateException("broken model")
     var reported: Throwable? = null
@@ -96,7 +96,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
 
   fun testExpectedAnalysisLimitReturnsIncompleteWithoutLoggingAnInternalError() {
     val file = myFixture.configureMetroFile("@DependencyGraph interface AppGraph")
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     val reason = "source assisted-factory analysis reached its type-depth limit"
     var reported: Throwable? = null
@@ -119,7 +119,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
 
   fun testCancellationEscapesInternalErrorBoundary() {
     val file = myFixture.configureMetroFile("@DependencyGraph interface AppGraph")
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     val cancellation = CancellationException("cancelled")
     var reported: Throwable? = null
@@ -141,7 +141,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
 
   fun testPlatformCancellationEscapesInternalErrorBoundary() {
     val file = myFixture.configureMetroFile("@DependencyGraph interface AppGraph")
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     val cancellation = ProcessCanceledException()
     var reported: Throwable? = null
@@ -163,7 +163,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
 
   fun testPlatformCancellationRetriesGraphValidation() {
     val file = myFixture.configureMetroFile("@DependencyGraph interface AppGraph")
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     val expected = project.service<MetroGraphValidationService>().validate(file, context)
     var attempts = 0
@@ -282,7 +282,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val parent = index.graphs.single { it.name == "AppGraph" }
     val results =
       project.service<MetroGraphValidationService>().validateWithExtensions(file, parent)
@@ -1166,7 +1166,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
       appendLine("}")
     }
     val file = myFixture.configureMetroFile(source)
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val queryContext = checkNotNull(index.queryContext(index.contextsFor(graph).single()))
     var parameterScopeChecks = 0
@@ -1620,7 +1620,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val widget = declarations.klass("Widget")
     val consumer = checkNotNull(index.consumerEntryAt(declarations.parameter("widget")))
@@ -1798,7 +1798,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val parent = index.graphs.single { it.name == "AppGraph" }
     val parentContext = index.contextsFor(parent).single()
     val child = index.graphs.single { it.name == "ChildGraph" }
@@ -1871,7 +1871,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val parent = index.graphs.single { it.name == "AppGraph" }
     val results =
       project.service<MetroGraphValidationService>().validateWithExtensions(file, parent)
@@ -2029,7 +2029,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val parent = index.graphs.single { it.name == "AppGraph" }
     val results =
       project.service<MetroGraphValidationService>().validateWithExtensions(file, parent)
@@ -2277,7 +2277,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val parent = index.graphs.single { it.name == "AppGraph" }
     val results =
       project.service<MetroGraphValidationService>().validateWithExtensions(file, parent)
@@ -2452,7 +2452,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val child = index.graphs.single { it.name == "ChildGraph" }
     val contextsByParent = index.contextsFor(child).associateBy { it.chain[1].name }
     val leftContext = contextsByParent.getValue("LeftParent")
@@ -2555,7 +2555,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val appGraph = index.graphs.single { it.name == "AppGraph" }
     val results =
       project.service<MetroGraphValidationService>().validateWithExtensions(file, appGraph)
@@ -2592,7 +2592,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val childGraph = index.graphs.single { it.name == "ChildGraph" }
     val contexts = index.contextsFor(childGraph)
     val leftContext = contexts.single { it.chain[1].name == "LeftGraph" }
@@ -2712,7 +2712,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single()
     val result =
       project
@@ -3011,7 +3011,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
           }
           """
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       // The concrete factory is reached through the contribution's Alias binding, not a source
       // consumer that directly requests ContributedFactory or Inner.Factory<Int>.
       assertTrue(index.consumers.none { it.key.renderedType == "test.ContributedFactory" })
@@ -3123,7 +3123,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         interface IntGraph : GenericBase<Int>
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val service = project.service<MetroGraphValidationService>()
     for ((graphName, expectedType) in
       listOf("StringGraph" to "kotlin.String", "IntGraph" to "kotlin.Int")) {
@@ -3171,7 +3171,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val validation = project.service<MetroGraphValidationService>()
 
     for ((graphName, expectedParameterType) in
@@ -3244,7 +3244,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val result =
       project
@@ -3358,7 +3358,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         """
       )
     PsiDocumentManager.getInstance(project).commitAllDocuments()
-    val index = project.service<MetroResolutionService>().index(graph)
+    val index = project.service<MetroResolutionService>().awaitIndex(graph)
     val declaration = index.graphs.single { it.name == "AppGraph" }
     val result =
       project
@@ -3611,7 +3611,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val parent = index.graphs.single { it.name == "AppGraph" }
     val child = index.graphs.single { it.name == "ChildGraph" }
     val parentContext = index.contextsFor(parent).single()
@@ -3958,7 +3958,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     val service = project.service<MetroResolutionService>()
     assertEquals(
       listOf("kotlin.String"),
-      service.index(graph).consumers.map { it.key.renderedType },
+      service.awaitIndex(graph).consumers.map { it.key.renderedType },
     )
 
     val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(base))
@@ -3978,7 +3978,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
 
     assertEquals(
       listOf("kotlin.Int"),
-      service.index(graph).consumers.map { it.key.renderedType },
+      service.awaitIndex(graph).consumers.map { it.key.renderedType },
     )
   }
 
@@ -3997,7 +3997,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     // Project-file fixtures can leave the second document uncommitted.
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-    val index = project.service<MetroResolutionService>().index(fileA)
+    val index = project.service<MetroResolutionService>().awaitIndex(fileA)
     val graphs = index.graphs.filter { it.classId?.asFqNameString() == "test.AppGraph" }
     assertEquals(2, graphs.size)
     val (graphA, graphB) = graphs
@@ -4198,7 +4198,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         interface AppGraph
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single()
     val context = index.contextsFor(graph).single()
     val validationService = project.service<MetroGraphValidationService>()
@@ -4215,7 +4215,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         interface AppGraph
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single()
     val context = index.contextsFor(graph).single()
     val validationService = project.service<MetroGraphValidationService>()
@@ -4226,6 +4226,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     myFixture.openFileInEditor(file.virtualFile)
     myFixture.type(" ")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
+    project.service<MetroResolutionService>().awaitIndex(file)
     val cached = validationService.cachedResult(file, context)!!
     assertSame(result, cached.result)
     assertTrue(cached.stale)
@@ -4239,7 +4240,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         interface AppGraph
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single()
     val context = index.contextsFor(graph).single()
     val validationService = project.service<MetroGraphValidationService>()
@@ -4256,6 +4257,7 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     }
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
+    project.service<MetroResolutionService>().awaitIndex(file)
     val cached = validationService.cachedResult(file, context)!!
     assertSame(result, cached.result)
     assertTrue(cached.stale)

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroImplicitUsageProviderTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroImplicitUsageProviderTest.kt
@@ -3,7 +3,9 @@
 package dev.zacsweers.metro.idea
 
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.components.service
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import dev.zacsweers.metro.idea.index.MetroResolutionService
 import dev.zacsweers.metro.idea.unused.MetroUnusedDeclarationInspectionSuppressor
 import dev.zacsweers.metro.idea.unused.isMetroImplicitUsage
 import kotlin.test.assertFalse
@@ -292,6 +294,8 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
     myFixture.enableInspections(UnusedSymbolInspection())
     configureMetroFile()
 
+    // The highlighting fixture rejects the cancellation used to wait for a cold index.
+    project.service<MetroResolutionService>().awaitIndex(myFixture.file)
     val warnings = myFixture.doHighlighting(HighlightSeverity.WARNING)
     val warningText = warnings.joinToString("\n") { "${it.text}: ${it.description}" }
     val warningDescriptions = warnings.map { it.description }.toSet()
@@ -335,6 +339,7 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
         .trimIndent(),
     )
 
+    project.service<MetroResolutionService>().awaitIndex(myFixture.file)
     val warnings = myFixture.doHighlighting(HighlightSeverity.WARNING)
     val warningText = warnings.joinToString("\n") { "${it.text}: ${it.description}" }
     assertFalse("Secondary @Inject constructor should not be reported as unused:\n$warningText") {
@@ -348,6 +353,7 @@ class MetroImplicitUsageProviderTest : BasePlatformTestCase() {
     val declarations = circuitFileDeclarations()
     myFixture.configureFromExistingVirtualFile(declarations.first().containingFile.virtualFile)
 
+    project.service<MetroResolutionService>().awaitIndex(myFixture.file)
     val warnings = myFixture.doHighlighting(HighlightSeverity.WARNING)
     val warningText = warnings.joinToString("\n") { "${it.text}: ${it.description}" }
     val descriptions = warnings.map { it.description }.toSet()

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroIndexDependenciesTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroIndexDependenciesTest.kt
@@ -111,7 +111,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testProvidesFunctionParametersAreDependencies() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val entry = index.bindingEntriesAt(declarations.function("provideBaseUrl")).single()
@@ -124,7 +124,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testBindsDependencyIsItsSourceKey() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val entry = index.bindingEntriesAt(declarations.function("bindService")).single()
@@ -134,7 +134,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testInjectConstructorParametersAreDependencies() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val entry = index.bindingEntriesAt(declarations.klass("Consumer")).single()
@@ -155,7 +155,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testContributedBindingAliasesItsOwnInjectBinding() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val entries = index.bindingEntriesAt(declarations.klass("RealHttpApi"))
@@ -172,7 +172,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testAssistedFactoryFlattensTargetConstructorDependencies() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val entry = index.bindingEntriesAt(declarations.klass("WidgetFactory")).single()
@@ -183,7 +183,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testMapKeyValuesAreCaptured() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val handlerA = index.bindingEntriesAt(declarations.function("handlerA")).single()
@@ -198,7 +198,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testConsumerEntriesCarryContextualKeys() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val providerParam = index.consumerEntryAt(declarations.parameter("serviceProvider"))!!
@@ -215,7 +215,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testSealFacingQueries() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val graph = index.graphEntryAt(declarations.klass("AppGraph"))!!
@@ -264,7 +264,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
         .trimIndent(),
     )
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val consumer = checkNotNull(index.consumerEntryAt(declarations.property("baseUrl")))
     assertNotNull(consumer.graphId)
@@ -326,7 +326,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val consumer = checkNotNull(index.consumerEntryAt(declarations.property("value")))
     val unrelatedGraph = index.graphs.single { it.name == "UnrelatedGraph" }
@@ -348,7 +348,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testProvidesReceiverIsADependencyAndConsumer() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val provideTag = declarations.function("provideTag")
@@ -363,7 +363,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testMemberInjectSitesFoldIntoClassBindingDependencies() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val entry = index.bindingEntriesAt(declarations.klass("Telemetry")).single()
@@ -376,7 +376,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testMemberInjectionsOnlyTraverseHasMemberInjectionsSuperclasses() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     // Superclass marked @HasMemberInjections contributes its member-inject keys
@@ -393,7 +393,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
 
   fun testGraphInjectorMembersConsumeTargetMemberInjectKeys() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val injectFunction = declarations.function("inject")
@@ -418,7 +418,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
         """,
         fileName = "App.kt",
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
 
     // The generated class is keyed by the function's name in its package
     val binding = index.bindings.single { it.typeKey.renderedType == "test.App" }
@@ -445,7 +445,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
         """,
         fileName = "App.kt",
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
 
     assertTrue(index.bindings.none { it.typeKey.renderedType == "test.App" })
     val declarations = file.declarationsIncludingNested()
@@ -478,7 +478,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
         """,
         fileName = "Activities.kt",
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val consumer = index.consumerEntryAt(declarations.property("activityProviders"))!!
@@ -505,7 +505,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
           """,
           fileName = "LibConsumer.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
 
       val clientParam = index.consumerEntryAt(declarations.parameter("client"))!!
@@ -541,7 +541,7 @@ class MetroIndexDependenciesTest : BasePlatformTestCase() {
         """,
         fileName = "InheritedFactory.kt",
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declaration = file.declarationsIncludingNested().klass("WidgetFactory")
     val factory = index.bindingEntriesAt(declaration).single() as KaBinding.AssistedFactory
 

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroInlayProviderTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroInlayProviderTest.kt
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea
 
+import com.intellij.codeInsight.hints.InlayDumpUtil
 import com.intellij.openapi.components.service
 import com.intellij.testFramework.utils.inlays.declarative.DeclarativeInlayHintsProviderTestCase
 import dev.zacsweers.metro.idea.index.MetroInjectedImplementationInlayProvider
 import dev.zacsweers.metro.idea.index.MetroResolutionService
+import dev.zacsweers.metro.idea.model.BindingIndex
+import org.jetbrains.kotlin.psi.KtFile
 
 class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
 
@@ -17,8 +20,23 @@ class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
     project.service<GraphContextPinService>().clear()
   }
 
+  /** Builds presentation data for the same configured PSI that the platform inlay pass uses. */
+  private fun doTestMetroProvider(
+    fileName: String,
+    expectedText: String,
+    provider: MetroInjectedImplementationInlayProvider,
+    configure: (BindingIndex) -> Unit = {},
+  ) {
+    val sourceText = InlayDumpUtil.removeInlays(expectedText)
+    val file = myFixture.configureByText(fileName, sourceText) as KtFile
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
+    configure(index)
+    file.awaitMetroPresentation()
+    doTestProviderWithConfigured(sourceText, expectedText, provider, emptyMap())
+  }
+
   fun testImplementationAndAssistedInlays() {
-    doTestProvider(
+    doTestMetroProvider(
       "CircuitImpl.kt",
       """
       package test
@@ -54,7 +72,7 @@ class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
   }
 
   fun testContextDependentResolutionHasNoImplementationInlay() {
-    doTestProvider(
+    doTestMetroProvider(
       "ContextDependent.kt",
       """
       package test
@@ -122,20 +140,18 @@ class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
       }
       """
         .trimIndent()
-    val file = myFixture.configureByText("PinnedContext.kt", source)
-    val index = project.service<MetroResolutionService>().index(file)
-    val appGraph = index.graphs.single { it.name == "AppGraph" }
-    project.service<GraphContextPinService>().pin(index.contextsFor(appGraph).single().path)
-
-    doTestProvider(
+    doTestMetroProvider(
       "PinnedContext.kt",
       source,
       MetroInjectedImplementationInlayProvider(),
-    )
+    ) { index ->
+      val appGraph = index.graphs.single { it.name == "AppGraph" }
+      project.service<GraphContextPinService>().pin(index.contextsFor(appGraph).single().path)
+    }
   }
 
   fun testGenericProviderParameterUsesItsConcreteImplementationInlay() {
-    doTestProvider(
+    doTestMetroProvider(
       "GenericProvider.kt",
       """
       package test
@@ -163,7 +179,7 @@ class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
   }
 
   fun testIdenticalGenericSpecializationsKeepTheirImplementationInlay() {
-    doTestProvider(
+    doTestMetroProvider(
       "MatchingGenericProviders.kt",
       """
       package test
@@ -195,7 +211,7 @@ class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
   }
 
   fun testParentAndChildSpecializedAliasesKeepTheirImplementationInlay() {
-    doTestProvider(
+    doTestMetroProvider(
       "InheritedParentChildBindings.kt",
       """
       package test
@@ -228,7 +244,7 @@ class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
   }
 
   fun testDifferentAliasTargetsDoNotShowImplementationInlays() {
-    doTestProvider(
+    doTestMetroProvider(
       "DifferentAliasTargets.kt",
       """
       package test
@@ -267,7 +283,7 @@ class MetroInlayProviderTest : DeclarativeInlayHintsProviderTestCase() {
   }
 
   fun testDifferentGenericProviderSpecializationsDoNotShowAnImplementationInlay() {
-    doTestProvider(
+    doTestMetroProvider(
       "ContextDependentGenericProvider.kt",
       """
       package test

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroLineMarkerProviderTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroLineMarkerProviderTest.kt
@@ -8,7 +8,9 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import dev.zacsweers.metro.idea.graph.KaGraphValidationResult
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
 import dev.zacsweers.metro.idea.index.MetroResolutionService
+import dev.zacsweers.metro.idea.model.BindingIndex
 import kotlin.test.assertTrue
+import org.jetbrains.kotlin.psi.KtFile
 
 class MetroLineMarkerProviderTest : BasePlatformTestCase() {
 
@@ -18,6 +20,14 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     module.addMetroRuntimeLibrary()
     project.service<MetroGraphValidationService>().clearResults()
     project.service<GraphContextPinService>().clear()
+  }
+
+  /** Waits for the index and file bundle before running the platform's highlighting pass. */
+  private fun highlightMetroFile() {
+    val file = myFixture.file as KtFile
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
+    if (index !== BindingIndex.EMPTY) file.awaitMetroPresentation()
+    myFixture.doHighlighting()
   }
 
   private fun configureAndHighlight(): List<String> {
@@ -55,7 +65,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       """
         .trimIndent(),
     )
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val metroIcons =
       setOf(
         MetroIcons.PROVIDER,
@@ -90,7 +100,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       }
       """
     )
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val tooltips =
       myFixture
         .findAllGutters()
@@ -116,7 +126,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       }
       """
     )
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val tooltips =
       myFixture
         .findAllGutters()
@@ -153,7 +163,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       }
       """
     )
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val tooltips =
       myFixture
         .findAllGutters()
@@ -191,7 +201,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       }
       """
     )
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val tooltips =
       myFixture
         .findAllGutters()
@@ -236,7 +246,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       }
       """
     )
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val tooltips =
       myFixture
         .findAllGutters()
@@ -263,7 +273,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
         }
         """
       )
-    myFixture.doHighlighting()
+    highlightMetroFile()
     fun validateIcons() =
       myFixture
         .findAllGutters()
@@ -276,12 +286,12 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     // Not validated yet: plain graph icon
     assertEquals(listOf<Any>(MetroIcons.GRAPH), validateIcons())
 
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single()
     project.service<MetroGraphValidationService>().validate(file, index.contextsFor(graph).single())
     // The file didn't change, so mimic production's post-validation daemon restart
     DaemonCodeAnalyzer.getInstance(project).restart()
-    myFixture.doHighlighting()
+    highlightMetroFile()
     assertEquals(listOf<Any>(MetroIcons.GRAPH_PROBLEMS), validateIcons())
     val tooltip =
       myFixture
@@ -311,7 +321,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     val validationService = project.service<MetroGraphValidationService>()
     val result = validationService.validate(file, context)
@@ -320,7 +330,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     assertSame(result, validationService.validate(file, context))
 
     DaemonCodeAnalyzer.getInstance(project).restart()
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val gutters = myFixture.findAllGutters()
     assertTrue(gutters.none { it.icon === MetroIcons.GRAPH_VALIDATED })
     val tooltip =
@@ -352,7 +362,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val child = index.graphs.single { it.name == "ChildGraph" }
     val contexts = index.contextsFor(child)
     assertEquals(2, contexts.size)
@@ -360,7 +370,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
 
     validationService.validate(file, contexts.first())
     DaemonCodeAnalyzer.getInstance(project).restart()
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val partialTooltips =
       myFixture
         .findAllGutters()
@@ -374,18 +384,18 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     val pinService = project.service<GraphContextPinService>()
     val pinnedRoot = contexts.first().rootGraph
     pinService.pin(index.contextsFor(pinnedRoot).single().path)
-    myFixture.doHighlighting()
+    highlightMetroFile()
     assertEquals(
       1,
       myFixture.findAllGutters().count { it.icon === MetroIcons.GRAPH_VALIDATED },
     )
     pinService.clear()
-    myFixture.doHighlighting()
+    highlightMetroFile()
     assertTrue(myFixture.findAllGutters().none { it.icon === MetroIcons.GRAPH_VALIDATED })
 
     validationService.validate(file, contexts.last())
     DaemonCodeAnalyzer.getInstance(project).restart()
-    myFixture.doHighlighting()
+    highlightMetroFile()
     assertEquals(
       1,
       myFixture.findAllGutters().count { it.icon === MetroIcons.GRAPH_VALIDATED },
@@ -411,7 +421,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       }
       """
     )
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val tooltips =
       myFixture
         .findAllGutters()
@@ -471,7 +481,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       }
       """
     )
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val gutters = myFixture.findAllGutters()
     val providerTooltips =
       gutters.filter { it.icon === MetroIcons.PROVIDER }.mapNotNull { it.tooltipText }
@@ -510,7 +520,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       }
       """
     )
-    myFixture.doHighlighting()
+    highlightMetroFile()
 
     val marker =
       myFixture.findAllGutters().single {
@@ -552,7 +562,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       }
       """
       )
-    myFixture.doHighlighting()
+    highlightMetroFile()
 
     val marker =
       myFixture.findAllGutters().single {
@@ -564,7 +574,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
       "bindings differ across 2 graph contexts · 2 candidates" in marker.tooltipText.orEmpty()
     }
 
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val contexts =
       index.graphs.associate { graph ->
         graph.name to index.contextsFor(graph).single()
@@ -572,7 +582,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     val pinService = project.service<GraphContextPinService>()
 
     pinService.pin(contexts.getValue("AppGraph").path)
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val appMarker =
       myFixture.findAllGutters().single {
         it.icon === MetroIcons.CONSUMER &&
@@ -585,7 +595,7 @@ class MetroLineMarkerProviderTest : BasePlatformTestCase() {
     )
 
     pinService.pin(contexts.getValue("OtherGraph").path)
-    myFixture.doHighlighting()
+    highlightMetroFile()
     val otherMarker =
       myFixture.findAllGutters().single {
         it.icon === MetroIcons.CONSUMER &&

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroMultiModuleResolutionTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroMultiModuleResolutionTest.kt
@@ -4,13 +4,16 @@ package dev.zacsweers.metro.idea
 
 import com.intellij.facet.FacetManager
 import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.SmartPointerManager
 import com.intellij.testFramework.IndexingTestUtil
+import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.UsefulTestCase
 import com.intellij.testFramework.builders.EmptyModuleFixtureBuilder
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
@@ -29,6 +32,8 @@ import dev.zacsweers.metro.idea.model.HintAvailability
 import dev.zacsweers.metro.idea.model.KaBinding
 import dev.zacsweers.metro.idea.model.sourcePointerIdentity
 import java.util.IdentityHashMap
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaModuleProvider
 import org.jetbrains.kotlin.idea.facet.KotlinFacetType
 import org.jetbrains.kotlin.idea.facet.initializeIfNeeded
@@ -127,7 +132,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val inputs = index.resolutionInputs
     val appView = checkNotNull(inputs.moduleViewFor(appFile.virtualFile))
     val libraryView = checkNotNull(inputs.moduleViewFor(libraryFile.virtualFile))
@@ -248,7 +253,10 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    // Synchronous validation needs a current index for each graph's declaration module.
+    fixture.project.service<MetroResolutionService>().awaitIndex(apiFile)
+    fixture.project.service<MetroResolutionService>().awaitIndex(implementationFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val validation = fixture.project.service<MetroGraphValidationService>()
     val graph =
       checkNotNull(index.graphEntryAt(appFile.declarationsIncludingNested().klass("AppGraph")))
@@ -406,7 +414,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val validation = fixture.project.service<MetroGraphValidationService>()
     fun context(name: String) = index.contextsFor(index.graphs.single { it.name == name }).single()
     fun accessors(name: String) =
@@ -517,7 +525,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val validation = fixture.project.service<MetroGraphValidationService>()
     fun context(name: String) = index.contextsFor(index.graphs.single { it.name == name }).single()
     fun accessors(name: String) =
@@ -609,7 +617,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    fixture.project.service<MetroResolutionService>().awaitIndex(apiFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val child =
       checkNotNull(index.graphEntryAt(apiFile.declarationsIncludingNested().klass("SharedChild")))
     val childContexts = index.contextsFor(child).associateBy { it.rootGraph.name }
@@ -682,7 +691,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val serviceConsumer =
       index.consumerEntryAt(libraryFile.declarationsIncludingNested().parameter("service"))!!
     val resolution = index.resolveConsumer(serviceConsumer)
@@ -779,7 +788,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val graph = index.graphs.single { it.name == "LibGraph" }
     val contexts = index.contextsFor(graph)
     val staticContext = contexts.single { it.dynamicGraph == null }
@@ -871,7 +880,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val graph = index.graphs.single { it.name == "LibGraph" }
     val contexts = index.contextsFor(graph)
     val staticContext = contexts.single { it.dynamicGraph == null }
@@ -930,7 +939,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(indirectGraphFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(indirectGraphFile)
     val contribution = libraryFile.declarationsIncludingNested().klass("LibService")
     val graph = index.graphs.single { it.name == "IndirectGraph" }
     assertTrue(
@@ -1009,7 +1018,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val baseIndex = fixture.project.service<MetroResolutionService>().index(friendFile)
+    val baseIndex = fixture.project.service<MetroResolutionService>().awaitIndex(friendFile)
     val declarations = libraryFile.declarationsIncludingNested()
     val hiddenService = declarations.klass("HiddenService")
     val hiddenContainer =
@@ -1161,7 +1170,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    fixture.project.service<MetroResolutionService>().awaitIndex(bridgeFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val appGraph = index.graphEntryAt(appFile.declarationsIncludingNested().klass("SharedGraph"))!!
     val bridgeGraph =
       index.graphEntryAt(bridgeFile.declarationsIncludingNested().klass("SharedGraph"))!!
@@ -1233,7 +1243,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    fixture.project.service<MetroResolutionService>().awaitIndex(bridgeFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val service = fixture.project.service<MetroGraphValidationService>()
     for ((file, expectedType) in listOf(appFile to "kotlin.String", bridgeFile to "kotlin.Int")) {
       val declaration = file.declarationsIncludingNested().klass("SharedGraph")
@@ -1295,7 +1306,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
       PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
       IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-      val index = fixture.project.service<MetroResolutionService>().index(appFile)
+      val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
       val graph = index.graphs.single { it.name == "AppGraph" }
       val result =
         fixture.project
@@ -1394,7 +1405,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
       PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
       IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-      val index = fixture.project.service<MetroResolutionService>().index(appFile)
+      val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
       val graph =
         checkNotNull(index.graphEntryAt(appFile.declarationsIncludingNested().klass("AppGraph")))
       val context = index.contextsFor(graph).single()
@@ -1465,7 +1476,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
         PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
         IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-        val index = fixture.project.service<MetroResolutionService>().index(appFile)
+        fixture.project.service<MetroResolutionService>().awaitIndex(bridgeFile)
+        val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
         val includedConsumer =
           index.consumers.single {
             it.includedContainerKey?.renderedType ==
@@ -1533,7 +1545,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
       PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
       IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-      val index = fixture.project.service<MetroResolutionService>().index(appFile)
+      val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
       val graph =
         checkNotNull(index.graphEntryAt(appFile.declarationsIncludingNested().klass("AppGraph")))
       val context = index.contextsFor(graph).single()
@@ -1616,7 +1628,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
       PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
       IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-      val index = fixture.project.service<MetroResolutionService>().index(appFile)
+      val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
       val sourceFactoryType = "app.Outer.Factory<libtest.LibClientWithDeps>"
       assertTrue(index.consumers.none { it.key.renderedType == sourceFactoryType })
       assertTrue(
@@ -1708,7 +1720,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
       PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
       IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-      val index = fixture.project.service<MetroResolutionService>().index(annotatedFile)
+      fixture.project.service<MetroResolutionService>().awaitIndex(ordinaryFile)
+      val index = fixture.project.service<MetroResolutionService>().awaitIndex(annotatedFile)
       val annotatedGraph =
         checkNotNull(
           index.graphEntryAt(annotatedFile.declarationsIncludingNested().klass("SharedGraph"))
@@ -1829,7 +1842,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
       PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
       IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-      val index = fixture.project.service<MetroResolutionService>().index(appFile)
+      fixture.project.service<MetroResolutionService>().awaitIndex(bridgeFile)
+      val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
       val validation = fixture.project.service<MetroGraphValidationService>()
       val appGraph =
         checkNotNull(index.graphEntryAt(appFile.declarationsIncludingNested().klass("SharedGraph")))
@@ -1908,7 +1922,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
       PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
       IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-      val index = fixture.project.service<MetroResolutionService>().index(appFile)
+      val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
       val graph = index.graphs.single { it.name == "AppGraph" }
       val result =
         fixture.project
@@ -1988,7 +2002,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
       PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
       IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-      val index = fixture.project.service<MetroResolutionService>().index(appFile)
+      val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
       val graph = index.graphs.single { it.name == "AppGraph" }
       val result =
         fixture.project
@@ -2084,7 +2098,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
         PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
         IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-        val index = fixture.project.service<MetroResolutionService>().index(appFile)
+        fixture.project.service<MetroResolutionService>().awaitIndex(bridgeFile)
+        val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
         val includedConsumer =
           index.consumers.single {
             it.includedContainerKey?.renderedType ==
@@ -2155,7 +2170,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    fixture.project.service<MetroResolutionService>().awaitIndex(bridgeFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val validation = fixture.project.service<MetroGraphValidationService>()
     for (file in listOf(appFile, bridgeFile)) {
       val declaration = file.declarationsIncludingNested().klass("SharedGraph")
@@ -2223,7 +2239,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val appDeclarations = appFile.declarationsIncludingNested()
     val bridgeDeclarations = bridgeFile.declarationsIncludingNested()
     val appParent = index.graphEntryAt(appDeclarations.klass("ParentGraph"))!!
@@ -2297,7 +2313,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    fixture.project.service<MetroResolutionService>().awaitIndex(bridgeFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val validationService = fixture.project.service<MetroGraphValidationService>()
     val appGraph = index.graphEntryAt(appFile.declarationsIncludingNested().klass("FactoryGraph"))!!
     val bridgeGraph =
@@ -2352,8 +2369,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
     val resolutionService = fixture.project.service<MetroResolutionService>()
-    val appIndex = resolutionService.index(appFile)
-    assertNotSame(appIndex, resolutionService.index(libraryFile))
+    val appIndex = resolutionService.awaitIndex(appFile)
+    assertNotSame(appIndex, resolutionService.awaitIndex(libraryFile))
     val appGraph = appIndex.graphEntryAt(appFile.declarationsIncludingNested().klass("AppGraph"))!!
     val results =
       fixture.project
@@ -2366,6 +2383,134 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
       results.first().requireCompleted().diagnostics.map { it.id },
     )
     assertTrue(results.last().requireCompleted().diagnostics.isEmpty())
+  }
+
+  fun testManualRefreshPublishesDifferentOptionKeysAsOneGeneration() {
+    val libraryFile =
+      fixture.addFileToProject(
+        "library/lib/LibraryGraph.kt",
+        """
+        package lib
+
+        import dev.zacsweers.metro.*
+
+        @Inject class OriginalLibraryService
+
+        @DependencyGraph
+        interface LibraryGraph {
+          val service: OriginalLibraryService
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    val appFile =
+      fixture.addFileToProject(
+        "app/app/AppGraph.kt",
+        """
+        package app
+
+        import dev.zacsweers.metro.*
+
+        @Inject class OriginalAppService
+
+        @DependencyGraph
+        interface AppGraph {
+          val service: OriginalAppService
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    val appModule = checkNotNull(ModuleUtilCore.findModuleForPsiElement(appFile))
+    val libraryModule = checkNotNull(ModuleUtilCore.findModuleForPsiElement(libraryFile))
+    appModule.setModuleMetroOptions("enable-function-providers" to "true")
+    libraryModule.setModuleMetroOptions("enable-function-providers" to "false")
+    for (otherModule in ModuleManager.getInstance(fixture.project).modules) {
+      if (otherModule != appModule && otherModule != libraryModule) {
+        otherModule.setModuleMetroOptions("enabled" to "false")
+      }
+    }
+    PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
+    IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
+
+    val service = fixture.project.service<MetroResolutionService>()
+    // Wait for both option keys before reading the shared presentation generation.
+    service.awaitIndex(appFile)
+    service.awaitIndex(libraryFile)
+    val initialApp = service.presentationIndex(appFile)
+    val initialLibrary = service.presentationIndex(libraryFile)
+    assertNotSame(initialApp, initialLibrary)
+    assertSame(initialApp.generationToken, initialLibrary.generationToken)
+    val settings = MetroSettings.getInstance(fixture.project).state
+
+    try {
+      settings.automaticallyRefreshGraphData = false
+      service.settingsChanged()
+
+      val documents = PsiDocumentManager.getInstance(fixture.project)
+      val appDocument = checkNotNull(documents.getDocument(appFile))
+      val libraryDocument = checkNotNull(documents.getDocument(libraryFile))
+      runInEdtAndWait {
+        WriteCommandAction.runWriteCommandAction(fixture.project) {
+          appDocument.insertString(appDocument.textLength, "\n\n@Inject class AddedAppService")
+          libraryDocument.insertString(
+            libraryDocument.textLength,
+            "\n\n@Inject class AddedLibraryService",
+          )
+        }
+        documents.commitAllDocuments()
+      }
+
+      assertSame(initialApp, service.presentationIndex(appFile))
+      assertSame(initialLibrary, service.presentationIndex(libraryFile))
+
+      val refreshStarted = AtomicBoolean()
+      val inconsistentListenerSnapshot = AtomicBoolean()
+      val refreshed = CompletableFuture<Pair<BindingIndex, BindingIndex>>()
+      service.addIndexListener(testRootDisposable) {
+        if (!refreshStarted.get()) return@addIndexListener
+        val appPresentation = service.presentationIndex(appFile)
+        val libraryPresentation = service.presentationIndex(libraryFile)
+        val appChanged = appPresentation !== initialApp
+        val libraryChanged = libraryPresentation !== initialLibrary
+        val appContainsEdit =
+          appPresentation.bindings.any { it.typeKey.renderedType == "app.AddedAppService" }
+        val libraryContainsEdit =
+          libraryPresentation.bindings.any {
+            it.typeKey.renderedType == "lib.AddedLibraryService"
+          }
+        val completePublication =
+          appChanged &&
+            libraryChanged &&
+            appPresentation.generationToken === libraryPresentation.generationToken &&
+            appContainsEdit &&
+            libraryContainsEdit
+        if ((appChanged || libraryChanged) && !completePublication) {
+          inconsistentListenerSnapshot.set(true)
+        }
+        if (completePublication) {
+          refreshed.complete(appPresentation to libraryPresentation)
+        }
+      }
+
+      refreshStarted.set(true)
+      service.refreshGraphData()
+      PlatformTestUtil.waitForFuture(refreshed, 30_000)
+      val (refreshedApp, refreshedLibrary) = refreshed.join()
+
+      assertFalse(inconsistentListenerSnapshot.get())
+      assertNotSame(initialApp, refreshedApp)
+      assertNotSame(initialLibrary, refreshedLibrary)
+      assertTrue(refreshedApp.bindings.any { it.typeKey.renderedType == "app.AddedAppService" })
+      assertTrue(
+        refreshedLibrary.bindings.any {
+          it.typeKey.renderedType == "lib.AddedLibraryService"
+        }
+      )
+      assertSame(refreshedApp.generationToken, refreshedLibrary.generationToken)
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
   }
 
   fun testParentSuspendResolutionUsesParentOptionsButRejectsDisabledChild() {
@@ -2419,7 +2564,8 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val appIndex = fixture.project.service<MetroResolutionService>().index(appFile)
+    fixture.project.service<MetroResolutionService>().awaitIndex(libraryFile)
+    val appIndex = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val extension = appIndex.graphs.single { it.name == "LibExtension" }
     val context = appIndex.contextsFor(extension).single { it.chain.last().name == "AppGraph" }
     val result =
@@ -2488,7 +2634,7 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
     IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
 
-    val index = fixture.project.service<MetroResolutionService>().index(appFile)
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
     val appAccessor =
       index.consumerEntryAt(appFile.declarationsIncludingNested().property("appValue"))!!
     val bridgeAccessor =

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
@@ -112,6 +113,37 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       serviceScope.cancel()
       serviceScope.coroutineContext.job.awaitTestCompletion()
       dispatcher.close()
+    }
+  }
+
+  fun testTemporaryProjectClosurePreservesPendingPsiClassification() {
+    val file = myFixture.configureMetroFile("@Inject class BeforeClosure")
+    val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    val service = MetroResolutionService(project, serviceScope)
+    val interrupted = AtomicBoolean()
+    try {
+      val initial = service.awaitIndex(file)
+      service.setPsiClassificationObserver {
+        service.setPsiClassificationObserver(null)
+        interrupted.set(true)
+        // Capture the unavailable phase without closing the platform fixture itself. The next
+        // classification attempt sees the available project and must apply the retained batch.
+        service.checkPsiClassificationActive(projectDisposed = true)
+      }
+      WriteCommandAction.runWriteCommandAction(project) {
+        val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(file))
+        document.setText(file.text.replace("BeforeClosure", "AfterClosure"))
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+      }
+      val updated = service.awaitIndex(file)
+      assertTrue(interrupted.get())
+      assertNotSame(initial, updated)
+      assertEquals(listOf("AfterClosure"), updated.bindings.map { it.implementationName })
+    } finally {
+      service.setPsiClassificationObserver(null)
+      Disposer.dispose(service)
+      serviceScope.cancel()
+      serviceScope.coroutineContext.job.awaitTestCompletion()
     }
   }
 

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.smartReadAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.roots.ProjectRootModificationTracker
+import com.intellij.openapi.util.Disposer
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.util.WaitFor
 import com.intellij.util.ui.UIUtil
 import dev.zacsweers.metro.compiler.graph.WrappedType
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
@@ -23,8 +27,19 @@ import dev.zacsweers.metro.idea.model.BindingIndex
 import dev.zacsweers.metro.idea.model.ConsumerResolution
 import dev.zacsweers.metro.idea.model.KaBinding
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.jetbrains.kotlin.analysis.api.permissions.allowAnalysisOnEdt
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -41,11 +56,131 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     project.service<MetroResolutionService>().resetGraphBrowserActivation()
   }
 
+  fun testQueuedPresentationRequestsUseLatestBindingsAndReusePublishedBundles() {
+    fun presentationFile(name: String): KtFile {
+      return myFixture.addFileToProject(
+        "test/$name.kt",
+        """
+        package test
+
+        import dev.zacsweers.metro.Inject
+
+        @Inject class $name
+        """
+          .trimIndent(),
+      ) as KtFile
+    }
+
+    val files = listOf("PresentationA", "PresentationB", "PresentationC").map(::presentationFile)
+    val executor = Executors.newSingleThreadExecutor()
+    val dispatcher = executor.asCoroutineDispatcher()
+    val serviceScope = CoroutineScope(SupervisorJob() + dispatcher)
+    val service = MetroResolutionService(project, serviceScope)
+    val paused = CompletableFuture<Unit>()
+    val release = CountDownLatch(1)
+
+    try {
+      val initial = service.awaitIndex(module)
+      // Hold ordinary execution while presentation requests and a new source file queue.
+      executor.submit {
+        paused.complete(Unit)
+        release.await()
+      }
+      PlatformTestUtil.waitForFuture(paused, 30_000)
+      repeat(5) {
+        for (file in files) assertNull(service.presentationBundle(file.declarations.single()))
+      }
+
+      val added = presentationFile("PresentationAdded")
+      assertTrue(ApplicationManager.getApplication().isDispatchThread)
+      assertSame(initial, service.index(files.first()))
+      assertSame(initial, service.index(added))
+      assertNull(service.presentationBundle(added.declarations.single()))
+
+      release.countDown()
+      val refreshed = service.awaitIndex(added)
+      assertNotSame(initial, refreshed)
+      assertTrue(refreshed.bindings.any { it.typeKey.renderedType == "test.PresentationAdded" })
+      for (file in files + added) {
+        val bundle = file.awaitMetroPresentation(service)
+        val declaration = file.declarations.single()
+        repeat(3) { assertSame(bundle, service.presentationBundle(declaration)) }
+      }
+    } finally {
+      release.countDown()
+      Disposer.dispose(service)
+      serviceScope.cancel()
+      serviceScope.coroutineContext.job.awaitTestCompletion()
+      dispatcher.close()
+    }
+  }
+
+  fun testQueuedIndexRequestsShareThePublishedIndex() {
+    configure()
+    val executor = Executors.newSingleThreadExecutor()
+    val dispatcher = executor.asCoroutineDispatcher()
+    val serviceScope = CoroutineScope(SupervisorJob() + dispatcher)
+    val paused = CompletableFuture<Unit>()
+    val release = CountDownLatch(1)
+    executor.submit {
+      paused.complete(Unit)
+      release.await()
+    }
+    val service = MetroResolutionService(project, serviceScope)
+    val scheduledRequests = CountDownLatch(6)
+    val requestExecutor = Executors.newFixedThreadPool(6)
+
+    fun requestIndex(): CompletableFuture<BindingIndex> {
+      return CompletableFuture.supplyAsync(
+        {
+          runBlocking {
+            retryCancelledIndexBuild {
+              smartReadAction(project) {
+                try {
+                  service.currentIndex(module)
+                } finally {
+                  // A pending query releases its read action after submitting the build request.
+                  scheduledRequests.countDown()
+                }
+              }
+            }
+          }
+        },
+        requestExecutor,
+      )
+    }
+
+    try {
+      PlatformTestUtil.waitForFuture(paused, 30_000)
+      val requests = List(6) { requestIndex() }
+      assertTrue(scheduledRequests.await(30, TimeUnit.SECONDS))
+      assertTrue(requests.none { it.isDone })
+
+      release.countDown()
+      val indexes = requests.map { PlatformTestUtil.waitForFuture(it, 30_000) }
+      val initial = indexes.first()
+      assertNotSame(BindingIndex.EMPTY, initial)
+      indexes.forEach { assertSame(initial, it) }
+      assertSame(initial, service.awaitIndex(module))
+
+      service.refreshGraphData()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+      assertNotSame(initial, service.awaitIndex(module))
+    } finally {
+      release.countDown()
+      requestExecutor.shutdownNow()
+      Disposer.dispose(service)
+      serviceScope.cancel()
+      serviceScope.coroutineContext.job.awaitTestCompletion()
+      dispatcher.close()
+    }
+  }
+
   fun testDoesNotBuildAnIndexWhenMetroIsNotConfigured() {
     project.clearMetroOptions()
     val file = configure()
 
-    assertTrue(project.service<MetroResolutionService>().index(file).bindings.isEmpty())
+    assertTrue(project.service<MetroResolutionService>().awaitIndex(file).bindings.isEmpty())
   }
 
   fun testColdIndexFindsFilesUsingOnlyAliasedMetroAnnotations() {
@@ -67,7 +202,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         .trimIndent(),
     )
 
-    val index = project.service<MetroResolutionService>().index(module)
+    val index = project.service<MetroResolutionService>().awaitIndex(module)
 
     assertEquals(listOf("AliasedGraph"), index.graphs.map { it.name })
     assertEquals(listOf("test.AliasedService"), index.bindings.map { it.typeKey.renderedType })
@@ -87,7 +222,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         .trimIndent(),
     )
 
-    val index = project.service<MetroResolutionService>().index(module)
+    val index = project.service<MetroResolutionService>().awaitIndex(module)
 
     assertTrue(index.bindings.isEmpty())
     assertTrue(index.graphs.isEmpty())
@@ -104,7 +239,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
       )
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
     assertEquals(
       setOf("test.Service", "test.ServiceImpl"),
       initial.bindings.mapTo(mutableSetOf()) { it.typeKey.renderedType },
@@ -112,7 +247,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
     project.setMetroOptions("generate-contribution-providers" to "true")
 
-    val generated = service.index(file)
+    val generated = service.awaitIndex(file)
     assertNotSame(initial, generated)
     assertEquals(listOf("test.Service"), generated.bindings.map { it.typeKey.renderedType })
     assertTrue(generated.bindings.single() is KaBinding.Provided)
@@ -121,7 +256,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
   fun testLibraryRootChangesNotifyExistingIndexListeners() {
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    service.index(file)
+    service.awaitIndex(file)
     var notifications = 0
     val notified = CompletableFuture<Unit>()
     service.addIndexListener(testRootDisposable) {
@@ -158,7 +293,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
   fun testCompilerSettingsChangesNotifyExistingIndexListenersWithoutRootChanges() {
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    service.index(file)
+    service.awaitIndex(file)
     var notifications = 0
     val notified = CompletableFuture<Unit>()
     service.addIndexListener(testRootDisposable) {
@@ -169,6 +304,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
     project.setMetroOptions("generate-contribution-providers" to "true")
     PlatformTestUtil.waitForFuture(notified, 30_000)
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
 
     assertEquals(
       initialRoots,
@@ -201,20 +337,28 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
   fun testCompilerSettingsDisableAndReenableMetroWithoutRootChanges() {
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    assertFalse(service.index(file).bindings.isEmpty())
+    assertFalse(service.awaitIndex(file).bindings.isEmpty())
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+    UIUtil.dispatchAllInvocationEvents()
     var notifications = 0
-    service.addIndexListener(testRootDisposable) { notifications++ }
+    var notified = CompletableFuture<Unit>()
+    service.addIndexListener(testRootDisposable) {
+      notifications++
+      notified.complete(Unit)
+    }
     val initialRoots = ProjectRootModificationTracker.getInstance(project).modificationCount
 
     project.setMetroOptions("enabled" to "false")
+    PlatformTestUtil.waitForFuture(notified, 30_000)
+    assertTrue(service.awaitIndex(file).bindings.isEmpty())
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
     UIUtil.dispatchAllInvocationEvents()
-    assertTrue(service.index(file).bindings.isEmpty())
     val disabledNotifications = notifications
     assertTrue("Disabling Metro should refresh an open window", disabledNotifications > 0)
 
+    notified = CompletableFuture()
     project.setMetroOptions()
-    UIUtil.dispatchAllInvocationEvents()
-
+    PlatformTestUtil.waitForFuture(notified, 30_000)
     assertEquals(
       initialRoots,
       ProjectRootModificationTracker.getInstance(project).modificationCount,
@@ -223,35 +367,43 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       "Reenabling Metro should refresh an open window",
       notifications > disabledNotifications,
     )
-    assertFalse(service.index(file).bindings.isEmpty())
+    assertFalse(service.awaitIndex(file).bindings.isEmpty())
   }
 
   fun testRemovingMetroCompilerSettingsNotifiesExistingIndexListenersWithoutRootChanges() {
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    service.index(file)
+    service.awaitIndex(file)
     var notifications = 0
-    service.addIndexListener(testRootDisposable) { notifications++ }
+    val notified = CompletableFuture<Unit>()
+    service.addIndexListener(testRootDisposable) {
+      notifications++
+      notified.complete(Unit)
+    }
     val initialRoots = ProjectRootModificationTracker.getInstance(project).modificationCount
 
     project.clearMetroOptions()
-    UIUtil.dispatchAllInvocationEvents()
+    PlatformTestUtil.waitForFuture(notified, 30_000)
 
     assertEquals(
       initialRoots,
       ProjectRootModificationTracker.getInstance(project).modificationCount,
     )
     assertTrue("Removing Metro options should refresh an open window", notifications > 0)
-    assertTrue(service.index(file).bindings.isEmpty())
+    assertTrue(service.awaitIndex(file).bindings.isEmpty())
   }
 
   fun testBatchedCompilerSettingsChangesKeepTheLatestIndexAndNotifyOnce() {
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
     UIUtil.dispatchAllInvocationEvents()
     var notifications = 0
-    service.addIndexListener(testRootDisposable) { notifications++ }
+    val notified = CompletableFuture<Unit>()
+    service.addIndexListener(testRootDisposable) {
+      notifications++
+      notified.complete(Unit)
+    }
 
     project.setMetroOptions("generate-contribution-providers" to "true")
     project.setMetroOptions(
@@ -263,21 +415,19 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       "enable-suspend-providers" to "true",
     )
 
-    // A direct editor query must see the newest options before deferred listeners run.
-    val latest = service.index(file)
-    assertNotSame(initial, latest)
-    assertEquals(0, notifications)
-
-    UIUtil.dispatchAllInvocationEvents()
-
+    PlatformTestUtil.waitForFuture(notified, 30_000)
     assertEquals(1, notifications)
-    assertSame(latest, service.index(file))
+
+    // The settings notification arrives before the explicitly requested index is published.
+    val latest = service.awaitIndex(file)
+    assertNotSame(initial, latest)
+    assertSame(latest, service.awaitIndex(file))
   }
 
   fun testBatchedOutputOnlyCompilerSettingsDoNotNotifyOrReplaceTheIndex() {
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
     UIUtil.dispatchAllInvocationEvents()
     var notifications = 0
     service.addIndexListener(testRootDisposable) { notifications++ }
@@ -289,9 +439,10 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       "trace-destination" to "/tmp/metro-traces",
     )
     UIUtil.dispatchAllInvocationEvents()
-
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+    UIUtil.dispatchAllInvocationEvents()
     assertEquals(0, notifications)
-    assertSame(initial, service.index(file))
+    assertSame(initial, service.awaitIndex(file))
   }
 
   fun testPlatformCancellationRetriesTheRequestedIndexBuild() {
@@ -310,46 +461,486 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
   }
 
   fun testToolWindowIndexWaitsForActivationThenBuildsInBackgroundAndReportsProgress() {
-    configure()
     val service = project.service<MetroResolutionService>()
+    val projectStateService = project.service<MetroIdeProjectService>()
+    configure()
+    projectStateService.clearCurrentState(module)
     val progress = mutableListOf<IndexBuildProgress?>()
     val completed = CompletableFuture<Unit>()
+    val warmupStarted = CompletableFuture<Pair<Boolean, Boolean>>()
     var started = false
-    service.addIndexBuildProgressListener(testRootDisposable) { update ->
-      progress += update
-      if (update != null) {
-        started = true
-      } else if (started) {
-        completed.complete(Unit)
+
+    val progressUpdates =
+      service.indexBuildProgress.collectInTest { update ->
+        progress += update
+        if (update != null) {
+          started = true
+        } else if (started) {
+          completed.complete(Unit)
+        }
       }
+    projectStateService.setStateWarmupObserver {
+      val application = ApplicationManager.getApplication()
+      warmupStarted.complete(application.isDispatchThread to application.isReadAccessAllowed)
     }
 
-    assertFalse(service.isGraphBrowserActivated)
-    assertSame(BindingIndex.EMPTY, service.indexForToolWindow(module))
-    assertTrue(progress.none { it != null })
+    try {
+      assertNull(projectStateService.currentStateOrNull(module))
+      assertFalse(service.isGraphBrowserActivated)
+      assertSame(BindingIndex.EMPTY, service.indexForToolWindow(module))
+      PlatformTestUtil.waitForFuture(warmupStarted, 30_000)
+      val warmupContext = warmupStarted.join()
+      assertFalse("Compiler settings must not load on the EDT", warmupContext.first)
+      assertTrue("Compiler settings warmup needs read access", warmupContext.second)
 
-    service.activateGraphBrowser()
-    assertTrue(service.isGraphBrowserActivated)
-    assertSame(BindingIndex.EMPTY, service.indexForToolWindow(module))
-    PlatformTestUtil.waitForFuture(completed, 30_000)
+      assertTrue(progress.none { it != null })
+      object : WaitFor(30_000) {
+          override fun condition(): Boolean = projectStateService.currentStateOrNull(module) != null
+        }
+        .assertCompleted("Compiler settings should finish warming in the background")
 
-    assertNotSame(BindingIndex.EMPTY, service.indexForToolWindow(module))
-    val phases = progress.mapNotNull { it?.phase }.toSet()
-    assertTrue(IndexBuildPhase.DISCOVERING_SOURCE_FILES in phases)
-    assertTrue(IndexBuildPhase.ANALYZING_DECLARATIONS in phases)
-    assertTrue(IndexBuildPhase.COMBINING_DECLARATIONS in phases)
-    assertTrue(IndexBuildPhase.BUILDING_GRAPH_INDEX in phases)
-    assertNull(progress.last())
+      service.activateGraphBrowser()
+      assertTrue(service.isGraphBrowserActivated)
+      assertSame(BindingIndex.EMPTY, service.indexForToolWindow(module))
+      PlatformTestUtil.waitForFuture(completed, 30_000)
+      progressUpdates.close()
+
+      assertNotSame(BindingIndex.EMPTY, service.indexForToolWindow(module))
+      val phases = progress.mapNotNull { it?.phase }.toSet()
+      assertTrue(IndexBuildPhase.DISCOVERING_SOURCE_FILES in phases)
+      assertTrue(IndexBuildPhase.ANALYZING_DECLARATIONS in phases)
+      assertTrue(IndexBuildPhase.COMBINING_DECLARATIONS in phases)
+      assertTrue(IndexBuildPhase.BUILDING_GRAPH_INDEX in phases)
+      assertNull(progress.last())
+    } finally {
+      progressUpdates.close()
+      projectStateService.setStateWarmupObserver(null)
+    }
   }
 
   fun testToolWindowUsesAnIndexAlreadyBuiltByEditorFeatures() {
     configure()
     val service = project.service<MetroResolutionService>()
-    val warmIndex = service.index(module)
+    val warmIndex = service.awaitIndex(module)
 
     assertFalse(service.isGraphBrowserActivated)
     assertSame(warmIndex, service.indexForToolWindow(module))
     assertTrue(service.isGraphBrowserActivated)
+  }
+
+  fun testDisabledAutomaticRefreshKeepsPresentationSnapshotUntilManualRefresh() {
+    val file = configure()
+    val service = project.service<MetroResolutionService>()
+    val initial = service.awaitIndex(file)
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    service.activateGraphBrowser()
+
+    try {
+      val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(file))
+      WriteCommandAction.runWriteCommandAction(project) {
+        document.insertString(document.textLength, "\n\n@Inject class AddedAfterRefresh")
+      }
+      PsiDocumentManager.getInstance(project).commitAllDocuments()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      val stale = service.presentationIndex(file)
+      assertSame(initial, stale)
+      assertFalse(stale.bindings.any { it.typeKey.renderedType == "test.AddedAfterRefresh" })
+      assertTrue(service.isManualGraphDataRefreshRequired)
+      UIUtil.dispatchAllInvocationEvents()
+
+      val refreshFinished = CompletableFuture<Unit>()
+      var refreshNotifications = 0
+      service.addIndexListener(testRootDisposable) {
+        refreshNotifications++
+        val refreshed = service.cachedIndex(file)
+        if (
+          !service.isManualGraphDataRefreshRequired &&
+            refreshed.bindings.any { it.typeKey.renderedType == "test.AddedAfterRefresh" }
+        ) {
+          refreshFinished.complete(Unit)
+        }
+      }
+      service.refreshGraphData()
+      PlatformTestUtil.waitForFuture(refreshFinished, 30_000)
+
+      val refreshed = service.presentationIndex(file)
+      assertNotSame(initial, refreshed)
+      assertTrue(refreshed.bindings.any { it.typeKey.renderedType == "test.AddedAfterRefresh" })
+      assertFalse(service.isManualGraphDataRefreshRequired)
+      assertEquals(1, refreshNotifications)
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
+  }
+
+  fun testManualRefreshUpdatesTypeAliases() {
+    val aliases =
+      myFixture.addFileToProject("test/Aliases.kt", "package test\n\ntypealias Alias = String")
+    myFixture.addFileToProject(
+      "test/Unrelated.kt",
+      "package test\n\n@dev.zacsweers.metro.Inject class Unrelated",
+    )
+    val file =
+      myFixture.configureMetroFile(
+        """
+        interface Providers {
+          @Provides fun provideAlias(): Alias = error("unused")
+        }
+        """
+      )
+    val service = project.service<MetroResolutionService>()
+    val initial = service.awaitIndex(file)
+    assertTrue(
+      initial.bindings.any { it.typeKey.type.classId?.asFqNameString() == "kotlin.String" }
+    )
+    val initialUnrelated = initial.bindings.single { it.typeKey.renderedType == "test.Unrelated" }
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    service.activateGraphBrowser()
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+    try {
+      val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(aliases))
+      WriteCommandAction.runWriteCommandAction(project) {
+        val start = document.text.indexOf("String")
+        document.replaceString(start, start + "String".length, "Int")
+      }
+      PsiDocumentManager.getInstance(project).commitAllDocuments()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      service.refreshGraphData()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      val refreshed = service.presentationIndex(file)
+      assertTrue(
+        refreshed.bindings.any { it.typeKey.type.classId?.asFqNameString() == "kotlin.Int" }
+      )
+      assertNotSame(
+        initialUnrelated,
+        refreshed.bindings.single { it.typeKey.renderedType == "test.Unrelated" },
+      )
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
+  }
+
+  fun testManualRefreshIncludesNewFiles() {
+    val file = configure()
+    val service = project.service<MetroResolutionService>()
+    service.awaitIndex(file)
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    service.activateGraphBrowser()
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+    try {
+      myFixture.addFileToProject(
+        "test/AddedBeforeRefresh.kt",
+        "package test\n\n@dev.zacsweers.metro.Inject class AddedBeforeRefresh",
+      )
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      service.refreshGraphData()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      assertTrue(
+        service.presentationIndex(file).bindings.any {
+          it.typeKey.renderedType == "test.AddedBeforeRefresh"
+        }
+      )
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
+  }
+
+  fun testDisabledAutomaticRefreshFreezesColdContributionResolutionUntilManualRefresh() {
+    val contributionFile =
+      myFixture.addFileToProject(
+        "test/Contribution.kt",
+        """
+        package test
+
+        import dev.zacsweers.metro.AppScope
+        import dev.zacsweers.metro.ContributesBinding
+        import dev.zacsweers.metro.Inject
+
+        interface Service
+
+        @ContributesBinding(AppScope::class)
+        @Inject
+        class ServiceImpl : Service
+        """
+          .trimIndent(),
+      ) as KtFile
+    val graphFile =
+      myFixture.addFileToProject(
+        "test/ContributionGraph.kt",
+        """
+        package test
+
+        import dev.zacsweers.metro.AppScope
+        import dev.zacsweers.metro.DependencyGraph
+
+        @DependencyGraph(AppScope::class)
+        interface ContributionGraph {
+          val service: Service
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    val service = project.service<MetroResolutionService>()
+    val initialPresentation = service.awaitIndex(graphFile)
+    assertSame(initialPresentation, service.presentationIndex(graphFile))
+    assertTrue(initialPresentation.bindings.any { it.implementationName == "ServiceImpl" })
+
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    service.activateGraphBrowser()
+
+    try {
+      val contribution = contributionFile.declarationsIncludingNested().klass("ServiceImpl")
+      WriteCommandAction.runWriteCommandAction(project) { contribution.delete() }
+      PsiDocumentManager.getInstance(project).commitAllDocuments()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      val presentation = service.presentationIndex(graphFile)
+      val current = service.awaitIndex(graphFile)
+      assertSame(initialPresentation, presentation)
+      assertNotSame(presentation, current)
+      assertTrue(service.isManualGraphDataRefreshRequired)
+
+      fun contributionNames(index: BindingIndex): List<String> {
+        val graph = index.graphs.single { it.name == "ContributionGraph" }
+        val context = index.contextsFor(graph).single()
+        val queryContext = checkNotNull(index.queryContext(context))
+        return index.contributionsFor(queryContext).mapNotNull {
+          it.classId?.shortClassName?.asString()
+        }
+      }
+
+      // Query each generation only after the edit to verify a cold frozen result.
+      assertEquals(listOf("ServiceImpl"), contributionNames(presentation))
+      assertTrue(contributionNames(current).isEmpty())
+
+      val refreshFinished = CompletableFuture<Unit>()
+      service.addIndexListener(testRootDisposable) {
+        if (!service.isManualGraphDataRefreshRequired) refreshFinished.complete(Unit)
+      }
+      service.refreshGraphData()
+      PlatformTestUtil.waitForFuture(refreshFinished, 30_000)
+
+      val refreshedPresentation = service.presentationIndex(graphFile)
+      assertNotSame(presentation, refreshedPresentation)
+      assertTrue(contributionNames(refreshedPresentation).isEmpty())
+      assertFalse(service.isManualGraphDataRefreshRequired)
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
+  }
+
+  fun testDisabledAutomaticRefreshFreezesColdExtensionContextsUntilManualRefresh() {
+    val childFile =
+      myFixture.addFileToProject(
+        "test/ChildGraph.kt",
+        """
+        package test
+
+        import dev.zacsweers.metro.GraphExtension
+
+        abstract class ChildScope
+
+        @GraphExtension(ChildScope::class)
+        interface ChildGraph
+        """
+          .trimIndent(),
+      ) as KtFile
+    val parentFile =
+      myFixture.addFileToProject(
+        "test/ParentGraph.kt",
+        """
+        package test
+
+        import dev.zacsweers.metro.AppScope
+        import dev.zacsweers.metro.DependencyGraph
+
+        @DependencyGraph(AppScope::class)
+        interface ParentGraph {
+          val childGraph: ChildGraph
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    val service = project.service<MetroResolutionService>()
+    val initialPresentation = service.awaitIndex(childFile)
+    assertSame(initialPresentation, service.presentationIndex(childFile))
+    assertEquals(
+      setOf("ChildGraph", "ParentGraph"),
+      initialPresentation.graphs.mapTo(mutableSetOf()) { it.name },
+    )
+
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    service.activateGraphBrowser()
+
+    try {
+      val creationAccessor = parentFile.declarationsIncludingNested().property("childGraph")
+      WriteCommandAction.runWriteCommandAction(project) { creationAccessor.delete() }
+      PsiDocumentManager.getInstance(project).commitAllDocuments()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      val presentation = service.presentationIndex(childFile)
+      val current = service.awaitIndex(childFile)
+      assertSame(initialPresentation, presentation)
+      assertNotSame(presentation, current)
+      assertTrue(service.isManualGraphDataRefreshRequired)
+
+      fun contextChains(index: BindingIndex): List<List<String>> {
+        val child = index.graphs.single { it.name == "ChildGraph" }
+        return index.contextsFor(child).map { context ->
+          context.chain.map { graph -> checkNotNull(graph.name) }
+        }
+      }
+
+      // Resolve parent contexts only after deleting the accessor.
+      assertEquals(listOf(listOf("ChildGraph", "ParentGraph")), contextChains(presentation))
+      assertEquals(listOf(listOf("ChildGraph")), contextChains(current))
+
+      val refreshFinished = CompletableFuture<Unit>()
+      service.addIndexListener(testRootDisposable) {
+        if (!service.isManualGraphDataRefreshRequired) refreshFinished.complete(Unit)
+      }
+      service.refreshGraphData()
+      PlatformTestUtil.waitForFuture(refreshFinished, 30_000)
+
+      val refreshedPresentation = service.presentationIndex(childFile)
+      assertNotSame(presentation, refreshedPresentation)
+      assertEquals(listOf(listOf("ChildGraph")), contextChains(refreshedPresentation))
+      assertFalse(service.isManualGraphDataRefreshRequired)
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
+  }
+
+  fun testReenablingAutomaticRefreshBuildsForEarlierPresentationRequests() {
+    val file = configure()
+    val service = project.service<MetroResolutionService>()
+    service.awaitIndex(file)
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    service.presentationIndex(file)
+    val completed = CompletableFuture<Unit>()
+    var buildStarted = false
+
+    val progressUpdates =
+      service.indexBuildProgress.collectInTest { progress ->
+        if (progress != null) {
+          buildStarted = true
+        } else if (buildStarted) {
+          completed.complete(Unit)
+        }
+      }
+
+    try {
+      val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(file))
+      WriteCommandAction.runWriteCommandAction(project) {
+        document.insertString(document.textLength, "\n\n@Inject class AddedAutomatically")
+      }
+      PsiDocumentManager.getInstance(project).commitAllDocuments()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+      assertSame(BindingIndex.EMPTY, service.cachedIndex(file))
+
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+      PlatformTestUtil.waitForFuture(completed, 30_000)
+
+      assertTrue(
+        service.cachedIndex(file).bindings.any {
+          it.typeKey.renderedType == "test.AddedAutomatically"
+        }
+      )
+    } finally {
+      progressUpdates.close()
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
+  }
+
+  fun testReenablingAutomaticRefreshPublishesExplicitlyUpdatedData() {
+    val file = configure()
+    val service = project.service<MetroResolutionService>()
+    val initial = service.awaitIndex(file)
+    val settings = MetroSettings.getInstance(project).state
+    service.activateGraphBrowser()
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+
+    try {
+      val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(file))
+      WriteCommandAction.runWriteCommandAction(project) {
+        document.insertString(document.textLength, "\n\n@Inject class AddedWhileManual")
+      }
+      PsiDocumentManager.getInstance(project).commitAllDocuments()
+
+      val current = service.awaitIndex(file)
+      assertTrue(service.isCurrent(current))
+      assertTrue(current.bindings.any { it.typeKey.renderedType == "test.AddedWhileManual" })
+      assertSame(initial, service.presentationIndex(file))
+
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+      val resumed = CompletableFuture.runAsync {
+        runBlocking { service.awaitCoordinatorBarrier() }
+      }
+      PlatformTestUtil.waitForFuture(resumed, 30_000)
+
+      // The tool window uses the production background path even in unit tests.
+      val presentation = service.indexForToolWindow(module)
+      assertNotSame(BindingIndex.EMPTY, presentation)
+      assertTrue(service.isCurrent(presentation))
+      assertTrue(presentation.bindings.any { it.typeKey.renderedType == "test.AddedWhileManual" })
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
+  }
+
+  fun testManualExplicitBuildPreservesOtherPublishedOptionSnapshots() {
+    val file = configure()
+    val service = project.service<MetroResolutionService>()
+    val settings = MetroSettings.getInstance(project).state
+    val withLibraries = service.awaitIndex(file)
+
+    try {
+      settings.automaticallyRefreshGraphData = false
+      service.settingsChanged()
+      settings.resolveFromLibraries = false
+      service.settingsChanged()
+
+      val withoutLibraries = service.awaitIndex(file)
+      assertNotSame(withLibraries, withoutLibraries)
+
+      settings.resolveFromLibraries = true
+      service.settingsChanged()
+
+      assertSame(withLibraries, service.presentationIndex(file))
+    } finally {
+      settings.resolveFromLibraries = true
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
   }
 
   fun testIndexBuildProgressReporterThrottlesIntermediateCounts() {
@@ -386,19 +977,100 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     }
   }
 
+  fun testExplicitReadActionWaitsOutsideTheReadForItsGeneration() {
+    val file = configure()
+    val service = project.service<MetroResolutionService>()
+    service.awaitIndex(file)
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+
+    try {
+      val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(file))
+      WriteCommandAction.runWriteCommandAction(project) {
+        document.insertString(document.textLength, "\n\n@Inject class AddedBackgroundWait")
+      }
+      PsiDocumentManager.getInstance(project).commitAllDocuments()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      val attempts = AtomicInteger()
+      val ranOnEdt = AtomicBoolean()
+      val ranWithoutReadAccess = AtomicBoolean()
+      val updated = CompletableFuture.supplyAsync {
+        runBlocking {
+          retryCancelledIndexBuild {
+            smartReadAction(project) {
+              attempts.incrementAndGet()
+              val application = ApplicationManager.getApplication()
+              if (application.isDispatchThread) ranOnEdt.set(true)
+              if (!application.isReadAccessAllowed) ranWithoutReadAccess.set(true)
+              service.currentIndex(file)
+            }
+          }
+        }
+      }
+      PlatformTestUtil.waitForFuture(updated, 30_000)
+
+      assertTrue(attempts.get() >= 2)
+      assertFalse(ranOnEdt.get())
+      assertFalse(ranWithoutReadAccess.get())
+      assertTrue(
+        updated.join().bindings.any { it.typeKey.renderedType == "test.AddedBackgroundWait" }
+      )
+    } finally {
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
+  }
+
   fun testUnrelatedKotlinFileEditsPreserveTheExistingSnapshot() {
     val unrelated =
       myFixture.addFileToProject("test/Unrelated.kt", "package test\n\nclass Unrelated")
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
-
+    service.awaitIndex(file)
     myFixture.openFileInEditor(unrelated.virtualFile)
+    // Enroll the file before recording the baseline.
+    service.awaitIndex(unrelated)
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+    val initial = service.awaitIndex(file)
+
     myFixture.editor.caretModel.moveToOffset(unrelated.textLength)
     myFixture.type("\nclass AlsoUnrelated")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+    assertSame(initial, service.awaitIndex(file))
+  }
 
-    assertSame(initial, service.index(file))
+  fun testReplacingAndRemovingUnrelatedClassesAndFilesPreservesTheExistingSnapshot() {
+    val file = configure()
+    val service = project.service<MetroResolutionService>()
+    val initial = service.awaitIndex(file)
+    val unrelated =
+      myFixture.addFileToProject(
+        "test/Unrelated.kt",
+        "package test\n\nclass First\nclass Second",
+      ) as KtFile
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+    val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(unrelated))
+    WriteCommandAction.runWriteCommandAction(project) {
+      document.setText("package test\n\nclass Replacement")
+    }
+    PsiDocumentManager.getInstance(project).commitAllDocuments()
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+    assertSame(initial, service.awaitIndex(file))
+
+    WriteCommandAction.runWriteCommandAction(project) { unrelated.declarations.first().delete() }
+    PsiDocumentManager.getInstance(project).commitAllDocuments()
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+    assertSame(initial, service.awaitIndex(file))
+
+    WriteCommandAction.runWriteCommandAction(project) { unrelated.delete() }
+    PsiDocumentManager.getInstance(project).commitAllDocuments()
+    myFixture.addFileToProject("test/AfterDeletion.kt", "package test\n\nclass AfterDeletion")
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+    assertSame(initial, service.awaitIndex(file))
   }
 
   fun testIrrelevantFileQueriesPreserveTheExistingSnapshot() {
@@ -406,12 +1078,58 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       myFixture.addFileToProject("test/Unrelated.kt", "package test\n\nclass Unrelated") as KtFile
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
 
     // Repeated queries from a non-Metro file must not invalidate anything.
-    assertSame(initial, service.index(unrelated))
-    assertSame(initial, service.index(unrelated))
-    assertSame(initial, service.index(file))
+    assertSame(initial, service.awaitIndex(unrelated))
+    assertSame(initial, service.awaitIndex(unrelated))
+    assertSame(initial, service.awaitIndex(file))
+  }
+
+  fun testRemovedNewFilesAreRemovedFromPendingRequestsAfterClassification() {
+    val file = configure()
+    val service = project.service<MetroResolutionService>()
+    service.awaitIndex(file)
+    val settings = MetroSettings.getInstance(project).state
+    settings.automaticallyRefreshGraphData = false
+    service.settingsChanged()
+    service.activateGraphBrowser()
+    runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+    val analyzingTotal = CompletableFuture<Int>()
+
+    val progressUpdates =
+      service.indexBuildProgress.collectInTest { progress ->
+        if (progress?.phase == IndexBuildPhase.ANALYZING_DECLARATIONS && progress.completed == 0) {
+          progress.total?.let(analyzingTotal::complete)
+        }
+      }
+
+    try {
+      val newFile =
+        myFixture.addFileToProject(
+          "test/NewIrrelevant.kt",
+          "package test\n\n@dev.zacsweers.metro.Inject class NewIrrelevant",
+        )
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      WriteCommandAction.runWriteCommandAction(project) { newFile.delete() }
+      PsiDocumentManager.getInstance(project).commitAllDocuments()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      service.refreshGraphData()
+      runBlocking { withTimeout(30_000) { service.awaitCoordinatorBarrier() } }
+
+      assertEquals(1, PlatformTestUtil.waitForFuture(analyzingTotal, 30_000))
+      assertFalse(
+        service.presentationIndex(file).bindings.any {
+          it.typeKey.renderedType == "test.NewIrrelevant"
+        }
+      )
+    } finally {
+      progressUpdates.close()
+      settings.automaticallyRefreshGraphData = true
+      service.settingsChanged()
+    }
   }
 
   fun testUnannotatedTypeAliasChangesRefreshDependentBindingKeys() {
@@ -428,7 +1146,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val service = project.service<MetroResolutionService>()
     assertEquals(
       listOf("kotlin.String"),
-      service.index(file).bindings.map { it.typeKey.type.classId?.asFqNameString() },
+      service.awaitIndex(file).bindings.map { it.typeKey.type.classId?.asFqNameString() },
     )
 
     myFixture.openFileInEditor(aliases.virtualFile)
@@ -439,7 +1157,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
     assertEquals(
       listOf("kotlin.Int"),
-      service.index(file).bindings.map { it.typeKey.type.classId?.asFqNameString() },
+      service.awaitIndex(file).bindings.map { it.typeKey.type.classId?.asFqNameString() },
     )
   }
 
@@ -458,7 +1176,9 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
       )
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
+    val classified = CompletableFuture<Unit>()
+    service.addIndexListener(testRootDisposable) { classified.complete(Unit) }
     assertEquals(
       "kotlin.String",
       initial.bindings.single().typeKey.type.classId?.asFqNameString(),
@@ -468,8 +1188,9 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       checkNotNull(shared.containingDirectory).delete()
     }
     PsiDocumentManager.getInstance(project).commitAllDocuments()
+    PlatformTestUtil.waitForFuture(classified, 30_000)
 
-    val updated = service.index(file)
+    val updated = service.awaitIndex(file)
     assertNotSame(initial, updated)
     assertTrue(
       "Removing shared declarations should invalidate the old resolved binding key",
@@ -494,18 +1215,30 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val service = project.service<MetroResolutionService>()
     assertEquals(
       "kotlin.String",
-      service.index(providers).bindings.single().typeKey.type.classId?.asFqNameString(),
+      service.awaitIndex(providers).bindings.single().typeKey.type.classId?.asFqNameString(),
     )
-
     myFixture.openFileInEditor(aliases.virtualFile)
     val stringOffset = aliases.text.indexOf("String")
     myFixture.editor.selectionModel.setSelection(stringOffset, stringOffset + "String".length)
     myFixture.type("Int")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
+    object : WaitFor(30_000) {
+        override fun condition(): Boolean {
+          return service
+            .awaitIndex(providers)
+            .bindings
+            .single()
+            .typeKey
+            .type
+            .classId
+            ?.asFqNameString() == "kotlin.Int"
+        }
+      }
+      .assertCompleted("The typealias import change should refresh its dependent binding key")
 
     assertEquals(
       "kotlin.Int",
-      service.index(providers).bindings.single().typeKey.type.classId?.asFqNameString(),
+      service.awaitIndex(providers).bindings.single().typeKey.type.classId?.asFqNameString(),
     )
   }
 
@@ -524,7 +1257,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
       )
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file).bindings.single().typeKey.qualifier
+    val initial = service.awaitIndex(file).bindings.single().typeKey.qualifier
     assertTrue(initial.toString().contains("before"))
 
     myFixture.openFileInEditor(constants.virtualFile)
@@ -533,7 +1266,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     myFixture.type("after")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-    val updated = service.index(file).bindings.single().typeKey.qualifier
+    val updated = service.awaitIndex(file).bindings.single().typeKey.qualifier
     assertNotSame(initial, updated)
     assertTrue(updated.toString().contains("after"))
   }
@@ -553,7 +1286,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
       )
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file).bindings.single().typeKey.qualifier
+    val initial = service.awaitIndex(file).bindings.single().typeKey.qualifier
     assertTrue(initial.toString().contains("before"))
 
     myFixture.openFileInEditor(constants.virtualFile)
@@ -562,7 +1295,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     myFixture.type("after")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-    val updated = service.index(file).bindings.single().typeKey.qualifier
+    val updated = service.awaitIndex(file).bindings.single().typeKey.qualifier
     assertNotSame(initial, updated)
     assertTrue(updated.toString().contains("after"))
   }
@@ -584,7 +1317,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
       )
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file).bindings.single().typeKey.qualifier
+    val initial = service.awaitIndex(file).bindings.single().typeKey.qualifier
     assertTrue(initial.toString().contains("before"))
 
     myFixture.openFileInEditor(constants.virtualFile)
@@ -593,7 +1326,41 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     myFixture.type("val")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-    val updated = service.index(file).bindings.single().typeKey.qualifier
+    val updated = service.awaitIndex(file).bindings.single().typeKey.qualifier
+    assertTrue(updated.toString(), updated?.toString()?.contains("before") != true)
+  }
+
+  fun testFileLevelReplacementPreservesRemovedSharedDeclarationContext() {
+    val constants =
+      myFixture.addFileToProject(
+        "test/Constants.kt",
+        "package test\n\nobject Constants { const val SERVICE_NAME = \"before\" }",
+      ) as KtFile
+    val file =
+      myFixture.configureMetroFile(
+        """
+        interface Providers {
+          @Provides @Named(Constants.SERVICE_NAME) fun provideService(): String = "service"
+        }
+        """
+      )
+    val service = project.service<MetroResolutionService>()
+    val initial = service.awaitIndex(file).bindings.single().typeKey.qualifier
+    assertTrue(initial.toString().contains("before"))
+    val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(constants))
+    WriteCommandAction.runWriteCommandAction(project) {
+      document.setText("package test\n\nclass Constants")
+    }
+    PsiDocumentManager.getInstance(project).commitAllDocuments()
+    object : WaitFor(30_000) {
+        override fun condition(): Boolean {
+          val qualifier = service.awaitIndex(file).bindings.single().typeKey.qualifier
+          return qualifier?.toString()?.contains("before") != true
+        }
+      }
+      .assertCompleted("Removing a shared declaration should refresh dependent qualifiers")
+
+    val updated = service.awaitIndex(file).bindings.single().typeKey.qualifier
     assertTrue(updated.toString(), updated?.toString()?.contains("before") != true)
   }
 
@@ -624,7 +1391,11 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       )
     val service = project.service<MetroResolutionService>()
     val initial =
-      service.index(file).bindings.single { it.typeKey.renderedType == "kotlin.String" }.typeKey
+      service
+        .awaitIndex(file)
+        .bindings
+        .single { it.typeKey.renderedType == "kotlin.String" }
+        .typeKey
     assertTrue(initial.toString().contains("before"))
 
     myFixture.openFileInEditor(constants.virtualFile)
@@ -634,7 +1405,11 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
     val updated =
-      service.index(file).bindings.single { it.typeKey.renderedType == "kotlin.String" }.typeKey
+      service
+        .awaitIndex(file)
+        .bindings
+        .single { it.typeKey.renderedType == "kotlin.String" }
+        .typeKey
     assertTrue(updated.toString().contains("after"))
   }
 
@@ -655,7 +1430,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       )
     val service = project.service<MetroResolutionService>()
     val original =
-      service.index(providers).bindings.single {
+      service.awaitIndex(providers).bindings.single {
         it.typeKey.type.classId?.asFqNameString() == "kotlin.String"
       }
 
@@ -667,7 +1442,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
     val updated =
-      service.index(providers).bindings.single {
+      service.awaitIndex(providers).bindings.single {
         it.typeKey.type.classId?.asFqNameString() == "kotlin.String"
       }
     assertSame("An unrelated class edit must not force every shard to rebuild", original, updated)
@@ -689,7 +1464,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       )
     val service = project.service<MetroResolutionService>()
     val original =
-      service.index(providers).bindings.single {
+      service.awaitIndex(providers).bindings.single {
         it.typeKey.type.classId?.asFqNameString() == "kotlin.String"
       }
 
@@ -701,7 +1476,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
     val updated =
-      service.index(providers).bindings.single {
+      service.awaitIndex(providers).bindings.single {
         it.typeKey.type.classId?.asFqNameString() == "kotlin.String"
       }
     assertSame("An unrelated class edit must not force every shard to rebuild", original, updated)
@@ -720,14 +1495,14 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     PsiDocumentManager.getInstance(project).commitAllDocuments()
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    val original = service.index(file).bindings.map { it.typeKey.renderedType }
+    val original = service.awaitIndex(file).bindings.map { it.typeKey.renderedType }
 
     myFixture.openFileInEditor(first.virtualFile)
     myFixture.editor.caretModel.moveToOffset(first.textLength)
     myFixture.type(" { fun unrelated() = 1 }")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-    assertEquals(original, service.index(file).bindings.map { it.typeKey.renderedType })
+    assertEquals(original, service.awaitIndex(file).bindings.map { it.typeKey.renderedType })
   }
 
   fun testRemovingOneSharedDependencyOwnerKeepsOtherOwnersCurrent() {
@@ -745,7 +1520,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val second = myFixture.configureMetroFile("@DependencyGraph interface SecondGraph : BaseGraph")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(second)
+    val initial = service.awaitIndex(second)
     val initialGraph = initial.graphs.single { it.name == "SecondGraph" }
     assertEquals(
       listOf("kotlin.String"),
@@ -760,50 +1535,65 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     )
     myFixture.type(" ")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
-    service.index(second)
+    val detached = service.awaitIndex(second)
+    val detachedFirstGraph = detached.graphs.single { it.name == "FirstGraph" }
+    val analyzingTotal = CompletableFuture<Int>()
 
-    myFixture.openFileInEditor(dependency.virtualFile)
-    val stringOffset = dependency.text.indexOf("String")
-    myFixture.editor.selectionModel.setSelection(stringOffset, stringOffset + "String".length)
-    myFixture.type("Int")
-    PsiDocumentManager.getInstance(project).commitAllDocuments()
+    val progressUpdates =
+      service.indexBuildProgress.collectInTest { progress ->
+        if (progress?.phase == IndexBuildPhase.ANALYZING_DECLARATIONS && progress.completed == 0) {
+          progress.total?.let(analyzingTotal::complete)
+        }
+      }
 
-    val updated = service.index(second)
-    val updatedGraph = updated.graphs.single { it.name == "SecondGraph" }
-    assertEquals(
-      listOf("kotlin.Int"),
-      updated.accessorsFor(updatedGraph).map { it.key.renderedType },
-    )
+    try {
+      myFixture.openFileInEditor(dependency.virtualFile)
+      val stringOffset = dependency.text.indexOf("String")
+      myFixture.editor.selectionModel.setSelection(stringOffset, stringOffset + "String".length)
+      myFixture.type("Int")
+      PsiDocumentManager.getInstance(project).commitAllDocuments()
+
+      val updated = service.awaitIndex(second)
+      val updatedGraph = updated.graphs.single { it.name == "SecondGraph" }
+      assertEquals(
+        listOf("kotlin.Int"),
+        updated.accessorsFor(updatedGraph).map { it.key.renderedType },
+      )
+      assertEquals(2, PlatformTestUtil.waitForFuture(analyzingTotal, 30_000))
+      assertSame(detachedFirstGraph, updated.graphs.single { it.name == "FirstGraph" })
+    } finally {
+      progressUpdates.close()
+    }
   }
 
   fun testOutputOnlyCompilerOptionsPreserveTheExistingSnapshot() {
     project.setMetroOptions("reports-destination" to "/tmp/metro-first")
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
 
     project.setMetroOptions(
       "reports-destination" to "/tmp/metro-second",
       "trace-destination" to "/tmp/metro-traces",
     )
 
-    assertSame(initial, service.index(file))
+    assertSame(initial, service.awaitIndex(file))
   }
 
   fun testGraphValidationCompilerOptionsInvalidateTheExistingSnapshot() {
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
 
     project.setMetroOptions("enable-suspend-providers" to "true")
-    val suspendEnabled = service.index(file)
+    val suspendEnabled = service.awaitIndex(file)
     assertNotSame(initial, suspendEnabled)
 
     project.setMetroOptions(
       "enable-suspend-providers" to "true",
       "enable-function-providers" to "false",
     )
-    val functionProvidersDisabled = service.index(file)
+    val functionProvidersDisabled = service.awaitIndex(file)
     assertNotSame(suspendEnabled, functionProvidersDisabled)
 
     project.setMetroOptions(
@@ -811,22 +1601,28 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       "enable-function-providers" to "false",
       "shrink-unused-bindings" to "false",
     )
-    assertNotSame(functionProvidersDisabled, service.index(file))
+    assertNotSame(functionProvidersDisabled, service.awaitIndex(file))
   }
 
   fun testNewlyAnnotatedFilesAreAddedWithoutRebuildingUnchangedDeclarations() {
     val additional = myFixture.addFileToProject("test/Additional.kt", "package test\n\nclass Added")
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
     val unchanged = initial.bindings.single { it.typeKey.renderedType == "test.ServiceImpl" }
 
     myFixture.openFileInEditor(additional.virtualFile)
     myFixture.editor.caretModel.moveToOffset(additional.text.indexOf("class Added"))
     myFixture.type("@dev.zacsweers.metro.Inject ")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
+    object : WaitFor(30_000) {
+        override fun condition(): Boolean {
+          return service.awaitIndex(file).bindings.any { it.typeKey.renderedType == "test.Added" }
+        }
+      }
+      .assertCompleted("The newly annotated file should join the background index")
 
-    val updated = service.index(file)
+    val updated = service.awaitIndex(file)
     assertNotSame(initial, updated)
     assertTrue(updated.bindings.any { it.typeKey.renderedType == "test.Added" })
     assertSame(unchanged, updated.bindings.single { it.typeKey.renderedType == "test.ServiceImpl" })
@@ -840,7 +1636,9 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       )
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    assertTrue(service.index(file).bindings.any { it.typeKey.renderedType == "test.Temporary" })
+    assertTrue(
+      service.awaitIndex(file).bindings.any { it.typeKey.renderedType == "test.Temporary" }
+    )
 
     myFixture.openFileInEditor(additional.virtualFile)
     myFixture.editor.selectionModel.setSelection(
@@ -850,19 +1648,21 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     myFixture.type(" ")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-    assertFalse(service.index(file).bindings.any { it.typeKey.renderedType == "test.Temporary" })
+    assertFalse(
+      service.awaitIndex(file).bindings.any { it.typeKey.renderedType == "test.Temporary" }
+    )
   }
 
   fun testEditorDecorationSettingsDoNotInvalidateTheIndex() {
     val file = configure()
     val service = project.service<MetroResolutionService>()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
     val settings = MetroSettings.getInstance(project).state
     settings.enableBindingResolution = false
     try {
       service.settingsChanged()
 
-      assertSame(initial, service.index(file))
+      assertSame(initial, service.awaitIndex(file))
     } finally {
       settings.enableBindingResolution = true
     }
@@ -933,7 +1733,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
   fun testBindsBindingIsIndexedWithImplementation() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val entry = index.bindingEntriesAt(declarations.function("bindService")).single()
@@ -948,7 +1748,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
   fun testInjectedClassProvidesItsOwnTypeAndConsumesConstructorParams() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val entry = index.bindingEntriesAt(declarations.klass("Consumer")).single()
@@ -966,7 +1766,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
   fun testContributedBindingBindsItsSoleSupertypeWithScope() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val entries = index.bindingEntriesAt(declarations.klass("RealHttpApi"))
@@ -981,7 +1781,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
   fun testSetMultibindingContributionsJoinTheirMultibindingConsumer() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val analyticsParam = index.consumerEntryAt(declarations.parameter("analytics"))!!
@@ -1002,7 +1802,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
   fun testMapMultibindingContributionsJoinTheirMultibindingConsumer() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val handlersParam = index.consumerEntryAt(declarations.parameter("handlers"))!!
@@ -1027,7 +1827,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
   fun testQualifiersDisambiguateKeys() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val cdnParam = index.consumerEntryAt(declarations.parameter("cdnUrl"))!!
@@ -1062,7 +1862,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val previousResolveFromLibraries = settings.resolveFromLibraries
     settings.resolveFromLibraries = false
     try {
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val graph = index.graphs.single { it.name == "AppGraph" }
       val query = checkNotNull(index.queryContext(index.contextsFor(graph).single()))
       val expected =
@@ -1112,7 +1912,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val previousResolveFromLibraries = settings.resolveFromLibraries
     settings.resolveFromLibraries = false
     try {
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val graph = index.graphs.single { it.name == "AppGraph" }
       val query = checkNotNull(index.queryContext(index.contextsFor(graph).single()))
       val expected =
@@ -1162,7 +1962,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val previousResolveFromLibraries = settings.resolveFromLibraries
     settings.resolveFromLibraries = false
     try {
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val graph = index.graphs.single { it.name == "AppGraph" }
       val query = checkNotNull(index.queryContext(index.contextsFor(graph).single()))
       val expected =
@@ -1241,7 +2041,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     settings.resolveFromLibraries = false
     try {
       val service = project.service<MetroResolutionService>()
-      val initial = service.index(file)
+      val initial = service.awaitIndex(file)
       val accessor = file.declarationsIncludingNested().property("endpoint")
       val initialConsumer = checkNotNull(initial.consumerEntryAt(accessor))
       assertEquals("@Endpoint(name = \"main\") String", initialConsumer.key.render(short = true))
@@ -1259,7 +2059,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       }
       PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-      val updated = service.index(file)
+      val updated = service.awaitIndex(file)
       val updatedConsumer = checkNotNull(updated.consumerEntryAt(accessor))
       assertNotSame(initial, updated)
       assertEquals("@Endpoint(name = \"other\") String", updatedConsumer.key.render(short = true))
@@ -1302,7 +2102,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val repositoryEntries = index.bindingEntriesAt(declarations.klass("Repository"))
@@ -1324,7 +2124,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
 
   fun testGraphEntryExposesScopesAccessorsAndContributions() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val graph = index.graphEntryAt(declarations.klass("AppGraph"))!!
@@ -1379,7 +2179,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     // The exact inputs the implementation inlay needs
@@ -1439,7 +2239,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     // Both functions contribute generated factories into the scope's factory sets
@@ -1529,7 +2329,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     // The factory's @Provides param is an instance binding, not a consumer
@@ -1561,7 +2361,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """
             .trimIndent(),
         ) as KtFile
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
 
       val clientParam = index.consumerEntryAt(declarations.parameter("client"))!!
@@ -1595,7 +2395,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "BinaryGenericGraphs.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
       val stringAccessor = index.consumerEntryAt(declarations.property("stringValue"))!!
       val intAccessor = index.consumerEntryAt(declarations.property("intValue"))!!
@@ -1639,7 +2439,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "BinaryGenericFactories.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val factories = index.bindings.filterIsInstance<KaBinding.AssistedFactory>()
 
       fun factory(type: String): KaBinding.AssistedFactory = factories.single {
@@ -1710,7 +2510,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "WrongQualifiedBinaryFactory.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val accessor = file.declarationsIncludingNested().property("factory")
       val consumer = checkNotNull(index.consumerEntryAt(accessor))
 
@@ -1739,7 +2539,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """
             .trimIndent(),
         ) as KtFile
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
 
       val clientParam = index.consumerEntryAt(declarations.parameter("client"))!!
@@ -1767,7 +2567,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """
             .trimIndent(),
         ) as KtFile
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
 
       val clientParam = index.consumerEntryAt(declarations.parameter("client"))!!
@@ -1786,10 +2586,10 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         fileName = "LibConsumer.kt",
       )
     val service = project.service<MetroResolutionService>()
-    val withoutLibrary = service.index(file)
+    val withoutLibrary = service.awaitIndex(file)
 
     module.withMetroLibFixtureLibrary {
-      val withLibrary = service.index(file)
+      val withLibrary = service.awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
       val client = withLibrary.consumerEntryAt(declarations.parameter("client"))!!
 
@@ -1800,7 +2600,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       )
     }
 
-    assertNotSame(withoutLibrary, service.index(file))
+    assertNotSame(withoutLibrary, service.awaitIndex(file))
   }
 
   fun testUnchangedLibraryInputsReuseBinaryDeclarationsAfterSourceEdits() {
@@ -1815,7 +2615,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           fileName = "LibConsumer.kt",
         )
       val service = project.service<MetroResolutionService>()
-      val initial = service.index(file)
+      val initial = service.awaitIndex(file)
       val initialLibraryBinding =
         initial.bindings.single { it.typeKey.renderedType == "libtest.LibHttpClient" }
 
@@ -1823,7 +2623,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       myFixture.type("\n")
       PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-      val updated = service.index(file)
+      val updated = service.awaitIndex(file)
       val updatedLibraryBinding =
         updated.bindings.single { it.typeKey.renderedType == "libtest.LibHttpClient" }
       assertNotSame(initial, updated)
@@ -1866,7 +2666,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           fileName = "StableFactoryGraph.kt",
         )
       val service = project.service<MetroResolutionService>()
-      val initial = service.index(graphFile)
+      val initial = service.awaitIndex(graphFile)
       val initialFactory =
         initial.bindings.filterIsInstance<KaBinding.AssistedFactory>().single {
           it.typeKey.renderedType == "test.StableExample.Factory<libtest.LibClientWithDeps>"
@@ -1884,7 +2684,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       }
       PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-      val updated = service.index(graphFile)
+      val updated = service.awaitIndex(graphFile)
       val updatedFactory =
         updated.bindings.filterIsInstance<KaBinding.AssistedFactory>().single {
           it.typeKey.renderedType == "test.StableExample.Factory<libtest.LibClientWithDeps>"
@@ -1940,7 +2740,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val previousResolveFromLibraries = settings.resolveFromLibraries
     settings.resolveFromLibraries = false
     try {
-      val index = project.service<MetroResolutionService>().index(graphFile)
+      val index = project.service<MetroResolutionService>().awaitIndex(graphFile)
       val factories = index.bindings.filterIsInstance<KaBinding.AssistedFactory>()
 
       assertEquals(factoryCount, factories.map { it.typeKey }.distinct().size)
@@ -2014,7 +2814,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           fileName = "NestedFactoryCacheGraph.kt",
         )
       val service = project.service<MetroResolutionService>()
-      val initial = service.index(graphFile)
+      val initial = service.awaitIndex(graphFile)
       val innerKey = "test.CacheInner.Factory<kotlin.Int>"
       val initialInner =
         initial.bindings.filterIsInstance<KaBinding.AssistedFactory>().single {
@@ -2033,7 +2833,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       }
       PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-      val unchanged = service.index(graphFile)
+      val unchanged = service.awaitIndex(graphFile)
       assertNotSame(initial, unchanged)
       assertSame(
         initialInner,
@@ -2060,7 +2860,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       }
       PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-      val updated = service.index(graphFile)
+      val updated = service.awaitIndex(graphFile)
       val updatedInner =
         updated.bindings.filterIsInstance<KaBinding.AssistedFactory>().single {
           it.typeKey.renderedType == innerKey
@@ -2119,7 +2919,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           fileName = "BinaryToSourceFactoryGraph.kt",
         )
       val service = project.service<MetroResolutionService>()
-      val initial = service.index(graphFile)
+      val initial = service.awaitIndex(graphFile)
       val factoryKey = "test.DefaultedExample.Factory<kotlin.Int>"
       val initialFactory =
         initial.bindings.filterIsInstance<KaBinding.AssistedFactory>().single {
@@ -2136,7 +2936,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       }
       PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-      val updated = service.index(graphFile)
+      val updated = service.awaitIndex(graphFile)
       val updatedFactory =
         updated.bindings.filterIsInstance<KaBinding.AssistedFactory>().single {
           it.typeKey.renderedType == factoryKey
@@ -2192,7 +2992,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "SharedFactoryGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val specializedFactories =
         index.bindings.filterIsInstance<KaBinding.AssistedFactory>().filter {
           it.typeKey.renderedType == "test.SharedExample.Factory<libtest.LibClientWithDeps>"
@@ -2248,7 +3048,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           fileName = "RetargetedFactory.kt",
         )
       val service = project.service<MetroResolutionService>()
-      val initial = service.index(file)
+      val initial = service.awaitIndex(file)
       assertTrue(
         initial.bindings.any { it.typeKey.renderedType == "libtest.LibRetargetedDependencyA" }
       )
@@ -2268,7 +3068,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       }
       PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-      val updated = service.index(file)
+      val updated = service.awaitIndex(file)
       assertNotSame(initial, updated)
       assertFalse(
         updated.bindings.any { it.typeKey.renderedType == "libtest.LibRetargetedDependencyA" }
@@ -2303,7 +3103,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           fileName = "GeneratedProvider.kt",
         )
       val service = project.service<MetroResolutionService>()
-      val initial = service.index(file)
+      val initial = service.awaitIndex(file)
       assertTrue(
         initial.bindings.any { it.typeKey.renderedType == "libtest.LibRetargetedDependencyA" }
       )
@@ -2323,7 +3123,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       }
       PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-      val updated = service.index(file)
+      val updated = service.awaitIndex(file)
       assertNotSame(initial, updated)
       assertFalse(
         updated.bindings.any { it.typeKey.renderedType == "libtest.LibRetargetedDependencyA" }
@@ -2365,7 +3165,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           fileName = "ContributedAccessorGraph.kt",
         )
       val service = project.service<MetroResolutionService>()
-      val initial = service.index(file)
+      val initial = service.awaitIndex(file)
       val initialGraph = initial.graphs.single { it.name == "AppGraph" }
       val initialQuery =
         checkNotNull(initial.queryContext(initial.contextsFor(initialGraph).single()))
@@ -2385,7 +3185,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         document.insertString(document.textLength, "\n")
       }
       PsiDocumentManager.getInstance(project).commitAllDocuments()
-      val whitespaceOnly = service.index(file)
+      val whitespaceOnly = service.awaitIndex(file)
       assertSame(
         initialDependency,
         whitespaceOnly.bindings.single {
@@ -2404,7 +3204,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       }
       PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-      val updated = service.index(file)
+      val updated = service.awaitIndex(file)
       assertNotSame(initial, updated)
       assertFalse(
         updated.bindings.any { it.typeKey.renderedType == "libtest.LibRetargetedDependencyA" }
@@ -2522,14 +3322,14 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       PsiDocumentManager.getInstance(project).commitAllDocuments()
     }
 
-    val initial = service.index(graphFile)
+    val initial = service.awaitIndex(graphFile)
     assertEquals(listOf(stableType, inheritedType), roots(initial))
     val initialDependency = initial.bindings.single { it.typeKey.renderedType == inheritedType }
     assertTrue(initial.bindings.any { it.typeKey.renderedType == "libtest.LibClientWithDeps" })
     assertTrue(initial.bindings.any { it.typeKey.renderedType == "libtest.LibHttpClient" })
 
     addWhitespace()
-    val whitespaceOnly = service.index(graphFile)
+    val whitespaceOnly = service.awaitIndex(graphFile)
     assertEquals(listOf(stableType, inheritedType), roots(whitespaceOnly))
     assertSame(
       initialDependency,
@@ -2540,7 +3340,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     // whether the graph requests the library type, so the override metadata must invalidate the
     // shared source summary as well as the graph's accessor list.
     replaceMember(inheritedMember, concreteMember)
-    val concrete = service.index(graphFile)
+    val concrete = service.awaitIndex(graphFile)
     assertEquals(listOf(stableType), roots(concrete))
     assertFalse(concrete.bindings.any { it.typeKey.renderedType == inheritedType })
     // The fixture's AppScope-contributed service still requests this shared dependency chain.
@@ -2549,7 +3349,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val concreteStable = concrete.bindings.single { it.typeKey.renderedType == stableType }
 
     addWhitespace()
-    val concreteWhitespace = service.index(graphFile)
+    val concreteWhitespace = service.awaitIndex(graphFile)
     assertEquals(listOf(stableType), roots(concreteWhitespace))
     assertSame(
       concreteStable,
@@ -2557,7 +3357,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     )
 
     replaceMember(concreteMember, inheritedMember)
-    val restored = service.index(graphFile)
+    val restored = service.awaitIndex(graphFile)
     assertEquals(listOf(stableType, inheritedType), roots(restored))
     assertTrue(restored.bindings.any { it.typeKey.renderedType == inheritedType })
     assertTrue(restored.bindings.any { it.typeKey.renderedType == "libtest.LibClientWithDeps" })
@@ -2582,7 +3382,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "RankedLibraryGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val service = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
       val matching = index.resolveConsumer(service).uniformBindings.orEmpty()
 
@@ -2614,7 +3414,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "PrioritizedLibraryGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val service = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
       val matching = index.resolveConsumer(service).uniformBindings.orEmpty()
 
@@ -2648,7 +3448,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "PrioritizedOriginGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val service = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
 
       assertEquals(
@@ -2673,7 +3473,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "PrioritizedLibraryMapGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val services =
         index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
       val matching = index.resolveConsumer(services).uniformBindings.orEmpty()
@@ -2703,7 +3503,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "LibrarySetGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val services =
         index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
       val matching = index.resolveConsumer(services).uniformBindings.orEmpty()
@@ -2741,7 +3541,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "SetOriginGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val services =
         index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
 
@@ -2770,7 +3570,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "PrioritizedLibraryCustomMapGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val services =
         index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
       val matching = index.resolveConsumer(services).uniformBindings.orEmpty()
@@ -2805,7 +3605,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "MixedLibrarySetGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
       val service = index.consumerEntryAt(declarations.property("service"))!!
       val services = index.consumerEntryAt(declarations.property("services"))!!
@@ -2845,7 +3645,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "IgnoreQualifierLibrarySetGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val services =
         index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
       val matching = index.resolveConsumer(services).uniformBindings.orEmpty()
@@ -2875,7 +3675,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """,
           fileName = "BinaryQualifierGraph.kt",
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val accessor = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
 
       assertEquals(
@@ -2914,7 +3714,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """
             .trimIndent(),
         ) as KtFile
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
 
       val serviceAccessor = index.consumerEntryAt(declarations.property("service"))!!
@@ -2981,7 +3781,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
             """
               .trimIndent(),
           ) as KtFile
-        val index = project.service<MetroResolutionService>().index(file)
+        val index = project.service<MetroResolutionService>().awaitIndex(file)
         val declarations = file.declarationsIncludingNested()
         val clientParam = index.consumerEntryAt(declarations.parameter("client"))!!
         assertTrue(index.bindingsFor(clientParam).isEmpty())
@@ -3023,7 +3823,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     for (name in listOf("serviceProvider", "serviceLazy")) {
@@ -3080,7 +3880,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     // The @BindsOptionalOf declaration exposes an Optional<Service> binding.
@@ -3129,7 +3929,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     assertTrue(index.bindingEntriesAt(declarations.function("optionalService")).isEmpty())
   }
@@ -3160,7 +3960,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     // The @OptionalBinding accessor is a consumer (despite its default body) and is optional.
@@ -3193,7 +3993,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     // A bare default no longer counts; only the explicit annotation does.
@@ -3223,7 +4023,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val consumer = index.consumerEntryAt(declarations.parameter("serviceFactory"))!!
@@ -3249,7 +4049,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """
             .trimIndent(),
         ) as KtFile
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
 
       // Project-path ownership is not a visibility relationship; internal hints still require a
@@ -3282,7 +4082,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val factoryEntry = index.bindingEntriesAt(declarations.klass("EngineFactory")).single()
@@ -3326,7 +4126,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     // Two supertypes, no explicit binding<T>() — the @DefaultBinding supertype decides
@@ -3360,7 +4160,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     // Two supertypes both declare @DefaultBinding, so the bound type is ambiguous — no contributed
@@ -3397,7 +4197,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val handlersParam = index.consumerEntryAt(declarations.parameter("handlers"))!!
@@ -3434,7 +4234,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val accessor = index.consumerEntryAt(declarations.property("repo"))!!
@@ -3496,7 +4296,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val graph = index.graphEntryAt(declarations.klass("ExcludesGraph"))!!
@@ -3549,7 +4349,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val wired = index.contextsFor(index.graphEntryAt(declarations.klass("WiredGraph"))!!).single()
@@ -3604,7 +4404,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val graph = index.graphEntryAt(declarations.klass("IncludesGraph"))!!
@@ -3706,7 +4506,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val stringGraph = index.graphEntryAt(declarations.klass("StringGraph"))!!
@@ -3782,7 +4582,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val declarations = graphFile.declarationsIncludingNested()
     val accessor = declarations.property("second")
 
-    val initialIndex = project.service<MetroResolutionService>().index(graphFile)
+    val initialIndex = project.service<MetroResolutionService>().awaitIndex(graphFile)
     val initialGraph = initialIndex.graphEntryAt(declarations.klass("AppGraph"))!!
     val initialContext =
       initialIndex.queryContext(initialIndex.contextsFor(initialGraph).single())!!
@@ -3794,7 +4594,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     myFixture.type("  val second: Second\n")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-    val updatedIndex = project.service<MetroResolutionService>().index(graphFile)
+    val updatedIndex = project.service<MetroResolutionService>().awaitIndex(graphFile)
     val updatedGraph = updatedIndex.graphEntryAt(declarations.klass("AppGraph"))!!
     val updatedContext =
       updatedIndex.queryContext(updatedIndex.contextsFor(updatedGraph).single())!!
@@ -3854,7 +4654,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val child = index.graphEntryAt(declarations.klass("ChildGraph"))!!
@@ -3959,7 +4759,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val appRepo = index.consumerEntryAt(declarations.property("appRepo"))!!
@@ -4001,7 +4801,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val member = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
     val resolution = index.resolveConsumer(member)
 
@@ -4037,7 +4837,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         interface OtherGraph
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val member = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
 
     assertEquals(
@@ -4062,7 +4862,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val accessor = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
 
     assertEquals(
@@ -4100,7 +4900,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
       )
     val service = project.service<MetroResolutionService>()
     val declarations = file.declarationsIncludingNested()
-    val initial = service.index(file)
+    val initial = service.awaitIndex(file)
     val initialConsumer = initial.consumerEntryAt(declarations.property("service"))!!
     assertEquals(1, initial.resolveConsumer(initialConsumer).uniformBindings.orEmpty().size)
 
@@ -4110,7 +4910,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     myFixture.type("other")
     PsiDocumentManager.getInstance(project).commitAllDocuments()
 
-    val updated = service.index(file)
+    val updated = service.awaitIndex(file)
     val updatedConsumer = updated.consumerEntryAt(declarations.property("service"))!!
     assertNotSame(initial, updated)
     assertTrue(updated.resolveConsumer(updatedConsumer).uniformBindings.orEmpty().isEmpty())
@@ -4142,7 +4942,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val accessor = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
 
     assertEquals(
@@ -4182,7 +4982,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val accessor = index.consumerEntryAt(declarations.property("service"))!!
     val graph = index.graphEntryAt(declarations.klass("AppGraph"))!!
@@ -4235,7 +5035,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val graph = index.graphEntryAt(declarations.klass("AppGraph"))!!
     val queryContext = index.queryContext(index.contextsFor(graph).single())!!
@@ -4300,7 +5100,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val first = index.consumerEntryAt(declarations.property("first"))!!
     val second = index.consumerEntryAt(declarations.property("second"))!!
@@ -4339,7 +5139,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val services = index.consumerEntryAt(declarations.property("services"))!!
     val other = index.consumerEntryAt(declarations.property("other"))!!
@@ -4379,7 +5179,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val services = index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
 
     assertEquals(
@@ -4409,7 +5209,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val services = index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
     val matching = index.resolveConsumer(services).uniformBindings.orEmpty()
 
@@ -4438,7 +5238,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val services = index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
 
     assertEquals(
@@ -4465,7 +5265,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val services = index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
 
     assertEquals(
@@ -4499,7 +5299,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val services = index.consumerEntryAt(declarations.property("services"))!!
     val child = index.graphEntryAt(declarations.klass("ChildGraph"))!!
@@ -4547,7 +5347,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val mapped = index.consumerEntryAt(declarations.property("mapped"))!!
     val collected = index.consumerEntryAt(declarations.property("collected"))!!
@@ -4595,7 +5395,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val service = index.consumerEntryAt(declarations.property("service"))!!
     val services = index.consumerEntryAt(declarations.property("services"))!!
@@ -4654,7 +5454,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     for (propertyName in listOf("service", "implementation")) {
@@ -4706,7 +5506,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val accessor = index.consumerEntryAt(file.declarationsIncludingNested().property("services"))!!
 
     assertEquals(
@@ -4754,7 +5554,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val accessor =
       index.consumerEntryAt(file.declarationsIncludingNested().property("viewModels"))!!
     val matching = index.resolveConsumer(accessor).uniformBindings.orEmpty()
@@ -4815,7 +5615,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val accessor = index.consumerEntryAt(declarations.property("services"))!!
     val graph = index.graphEntryAt(declarations.klass("AppGraph"))!!
@@ -4856,7 +5656,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val accessor = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
 
     assertEquals(
@@ -4899,7 +5699,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val accessor = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
 
     assertEquals(
@@ -4934,7 +5734,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val accessor = index.consumerEntryAt(declarations.property("service"))!!
     val graph = index.graphEntryAt(declarations.klass("AppGraph"))!!
@@ -4985,7 +5785,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val accessor = index.consumerEntryAt(declarations.property("service"))!!
     val child = index.graphEntryAt(declarations.klass("ChildGraph"))!!
@@ -5035,7 +5835,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val accessor = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
 
     assertEquals(
@@ -5069,7 +5869,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val accessor = index.consumerEntryAt(file.declarationsIncludingNested().property("service"))!!
 
     assertEquals(
@@ -5129,7 +5929,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     fun resolution(parameterName: String): ConsumerResolution {
@@ -5232,7 +6032,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
 
     val child = index.graphEntryAt(declarations.klass("ChildGraph"))!!
@@ -5269,7 +6069,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
           """
             .trimIndent(),
         ) as KtFile
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val declarations = file.declarationsIncludingNested()
 
       val appContext =
@@ -5330,7 +6130,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
         """
           .trimIndent(),
       ) as KtFile
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val declarations = file.declarationsIncludingNested()
     val consumer = index.consumerEntryAt(declarations.property("appRepo"))!!
 
@@ -5359,7 +6159,7 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
   fun testIndexIsEmptyWhenMetroDisabled() {
     project.setMetroOptions("enabled" to "false")
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     assertTrue(index.bindings.isEmpty())
     assertTrue(index.consumers.isEmpty())
     assertTrue(index.graphs.isEmpty())

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroSuspendGraphValidationTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroSuspendGraphValidationTest.kt
@@ -23,7 +23,7 @@ class MetroSuspendGraphValidationTest : BasePlatformTestCase() {
   ): KaGraphValidationResult.Completed {
     project.setMetroOptions("enable-suspend-providers" to suspendProvidersEnabled.toString())
     val file = myFixture.configureMetroFile(source)
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == "AppGraph" }
     return project
       .service<MetroGraphValidationService>()
@@ -124,7 +124,7 @@ class MetroSuspendGraphValidationTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val child = index.graphs.single { it.name == "ChildGraph" }
     val result =
       project

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroToolWindowTreeTest.kt
@@ -22,6 +22,7 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.ui.tree.AsyncTreeModel
 import com.intellij.ui.tree.StructureTreeModel
 import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.WaitFor
 import com.intellij.util.ui.tree.TreeUtil
 import dev.zacsweers.metro.compiler.diagnostics.MetroDiagnosticId
 import dev.zacsweers.metro.idea.graph.GraphValidationProgress
@@ -102,7 +103,11 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
     )
   }
 
-  private fun structure(): MetroTreeStructure = MetroTreeStructure(project) { filter }
+  /** Direct tree assertions start after the asynchronous index has been published. */
+  private fun structure(): MetroTreeStructure {
+    project.service<MetroResolutionService>().awaitIndex(module)
+    return MetroTreeStructure(project) { filter }
+  }
 
   private fun MetroTreeStructure.children(node: MetroTreeNode): List<MetroTreeNode> =
     computeChildren(node)
@@ -243,7 +248,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
 
   fun testMissingPinnedContextFallsBackToAllGraphs() {
     val file = configure()
-    val realIndex = project.service<MetroResolutionService>().index(file)
+    val realIndex = project.service<MetroResolutionService>().awaitIndex(file)
     var currentIndex = realIndex
     val pinService = project.service<GraphContextPinService>()
     val structure =
@@ -269,7 +274,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
       document.replaceString(graphNameStart, graphNameStart + "AppGraph".length, "ReplacementGraph")
     }
     PsiDocumentManager.getInstance(project).commitAllDocuments()
-    currentIndex = project.service<MetroResolutionService>().index(file)
+    currentIndex = project.service<MetroResolutionService>().awaitIndex(file)
 
     assertEquals(listOf("ReplacementGraph"), structure.children(root).map { it.text })
     assertNull(pinService.pinnedPath)
@@ -277,7 +282,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
 
   fun testGraphContextSelectorAcquiresReadAccess() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val structure =
       MetroTreeStructure(project, indexProvider = { index }, pinService = project.service()) {
         filter
@@ -556,7 +561,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
 
   fun testValidationStatusPanelShowsPreparingAndCountedProgress() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     val panel = ValidationStatusPanel()
 
@@ -580,7 +585,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
 
   fun testValidateActionIsDisabledWhileTheSelectedGraphIsRunning() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     var selectedContext: GraphContext? = null
     var validationRunning = false
@@ -647,7 +652,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
 
   fun testToolWindowPanelRecoversAfterDumbMode() {
     val file = configure()
-    project.service<MetroResolutionService>().index(file)
+    project.service<MetroResolutionService>().awaitIndex(file)
     var panel: MetroToolWindowPanel? = null
     DumbModeTestUtils.runInDumbModeSynchronously(project) {
       panel = MetroToolWindowPanel(project)
@@ -658,15 +663,20 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
     }
 
     val tree = toolWindowTree(checkNotNull(panel))
-    PlatformTestUtil.waitForPromise(TreeUtil.promiseExpandAll(tree))
-    assertTrue("The Metro tree should populate when smart mode resumes", tree.rowCount > 0)
+    object : WaitFor(30_000) {
+        override fun condition(): Boolean {
+          PlatformTestUtil.waitForPromise(TreeUtil.promiseExpandAll(tree))
+          return tree.rowCount > 0
+        }
+      }
+      .assertCompleted("The Metro tree should populate when smart mode resumes")
     assertFalse(toolWindowStatus(checkNotNull(panel)).isVisible)
     com.intellij.openapi.util.Disposer.dispose(checkNotNull(panel))
   }
 
   fun testDisposedToolWindowPanelIgnoresValidationRequests() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single()
     val context = index.contextsFor(graph).single()
     val panel = MetroToolWindowPanel(project)
@@ -679,7 +689,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
 
   fun testMissingRequestedGraphDoesNotValidateTheSelectedGraph() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single()
     val context = index.contextsFor(graph).single()
     val panel = MetroToolWindowPanel(project)
@@ -772,7 +782,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
           }
           """
         )
-      val index = project.service<MetroResolutionService>().index(file)
+      val index = project.service<MetroResolutionService>().awaitIndex(file)
       val graph = index.graphs.single { it.name == "AppGraph" }
       val context = index.contextsFor(graph).single()
       val exporter = project.service<MetroGraphDebugExporter>()
@@ -895,7 +905,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val child = index.graphs.single { it.name == "ChildGraph" }
     val contexts = index.contextsFor(child).associateBy { it.rootGraph.name }
     val exporter = project.service<MetroGraphDebugExporter>()
@@ -936,7 +946,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
         }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val graph = index.graphs.single { it.name == "AppGraph" }
     val report =
       checkNotNull(
@@ -971,7 +981,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
         @DependencyGraph interface AppGraph { val service: Service }
         """
       )
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     val exporter = project.service<MetroGraphDebugExporter>()
     val validation = project.service<MetroGraphValidationService>()
@@ -989,6 +999,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
       document.insertString(insertion, "val missing: Long; ")
     }
     PsiDocumentManager.getInstance(project).commitAllDocuments()
+    project.service<MetroResolutionService>().awaitIndex(file)
 
     val stale = checkNotNull(exporter.report(context))
     assertTrue(stale, "freshness=stale" in stale)
@@ -999,7 +1010,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
 
   fun testExportGraphDebugInfoActionRequiresAnExactGraphSelection() {
     val file = configure()
-    val index = project.service<MetroResolutionService>().index(file)
+    val index = project.service<MetroResolutionService>().awaitIndex(file)
     val context = index.contextsFor(index.graphs.single()).single()
     var selected: GraphContext? = null
     val action = ExportGraphDebugInfoAction(project) { selected }
@@ -1102,6 +1113,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
       )
     }
     PsiDocumentManager.getInstance(project).commitAllDocuments()
+    project.service<MetroResolutionService>().awaitIndex(file)
 
     val after = structure.children(graph).single { it.text == "Unscoped" } as MetroTreeNode.Category
     assertFalse(before == after)
@@ -1284,6 +1296,7 @@ class MetroToolWindowTreeTest : BasePlatformTestCase() {
       document.insertString(memberOffset, "val missing: Long\n        ")
     }
     PsiDocumentManager.getInstance(project).commitAllDocuments()
+    project.service<MetroResolutionService>().awaitIndex(file)
 
     val currentGraph = treeStructure.children(root).single() as MetroTreeNode.Graph
     project.service<MetroGraphValidationService>().validate(file, currentGraph.context)

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/ktTestUtils.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/ktTestUtils.kt
@@ -2,17 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea
 
+import com.intellij.openapi.application.smartReadAction
+import com.intellij.openapi.components.service
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.util.WaitFor
 import dev.zacsweers.metro.idea.graph.KaGraphValidationResult
+import dev.zacsweers.metro.idea.index.FilePresentationBundle
+import dev.zacsweers.metro.idea.index.MetroResolutionService
+import dev.zacsweers.metro.idea.index.retryCancelledIndexBuild
+import dev.zacsweers.metro.idea.model.BindingIndex
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
+import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.runBlocking
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.idea.compiler.configuration.KotlinCommonCompilerArgumentsHolder
 import org.jetbrains.kotlin.psi.KtClass
@@ -148,6 +168,80 @@ internal fun CodeInsightTestFixture.configureMetroFile(
     appendLine(source.trimIndent())
   }
   return configureByText(fileName, text) as KtFile
+}
+
+/** Waits outside the fixture's EDT read action for the current index generation. */
+internal fun MetroResolutionService.awaitIndex(element: PsiElement): BindingIndex {
+  return awaitCurrentIndex(element.project) { index(element) }
+}
+
+/** Waits for a module's current index when a fixture has no single query declaration. */
+internal fun MetroResolutionService.awaitIndex(module: Module): BindingIndex {
+  return awaitCurrentIndex(module.project) { index(module) }
+}
+
+/** Drains queued invalidations before returning the fixture's final index. */
+private fun MetroResolutionService.awaitCurrentIndex(
+  project: Project,
+  query: () -> BindingIndex,
+): BindingIndex {
+  fun requestCurrentIndex(): BindingIndex {
+    val result = CompletableFuture.supplyAsync {
+      runBlocking {
+        retryCancelledIndexBuild { smartReadAction(project) { query() } }
+      }
+    }
+    PlatformTestUtil.waitForFuture(result, 30_000)
+    return result.join()
+  }
+
+  requestCurrentIndex()
+  val barrier = CompletableFuture.runAsync { runBlocking { awaitCoordinatorBarrier() } }
+  PlatformTestUtil.waitForFuture(barrier, 30_000)
+  return requestCurrentIndex()
+}
+
+/** Starts collecting state before returning and keeps test callbacks on the publishing thread. */
+internal fun <T> StateFlow<T>.collectInTest(onValue: (T) -> Unit): AutoCloseable {
+  val scope = CoroutineScope(Dispatchers.Unconfined)
+  val collection = scope.async(start = CoroutineStart.UNDISPATCHED) { collect(onValue) }
+  return AutoCloseable {
+    scope.cancel()
+    runBlocking {
+      try {
+        collection.await()
+      } catch (_: CancellationException) {
+        // Closing the test's collection cancels its suspended state subscription.
+      }
+    }
+  }
+}
+
+/** Pumps the EDT until a worker has finished, including its cancellation cleanup. */
+internal fun Job.awaitTestCompletion() {
+  val completed = CompletableFuture<Unit>()
+  invokeOnCompletion { completed.complete(Unit) }
+  PlatformTestUtil.waitForFuture(completed, 30_000)
+}
+
+/** Waits for a published bundle whose declaration anchors match the current PSI stamp. */
+internal fun KtFile.awaitMetroPresentation(
+  service: MetroResolutionService = project.service()
+): FilePresentationBundle {
+  var result: FilePresentationBundle? = null
+  object : WaitFor(30_000) {
+      override fun condition(): Boolean {
+        PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
+        val expectedStamp = modificationStamp
+        val bundle = service.presentationBundle(this@awaitMetroPresentation)
+        val anchorsAreCurrent = bundle != null && bundle.anchorsAreCurrent(expectedStamp)
+        if (!anchorsAreCurrent || modificationStamp != expectedStamp) return false
+        result = bundle
+        return true
+      }
+    }
+    .assertCompleted("Metro should publish a presentation bundle with current declaration anchors")
+  return checkNotNull(result)
 }
 
 internal fun KtFile.declarationsIncludingNested(): List<KtDeclaration> {


### PR DESCRIPTION
Move index building and editor-hint preparation into the background. A single coordinator combines repeated requests, limits background hint work, and discards results made stale by edits.

In manual-refresh mode, the graph browser keeps its displayed data until the user refreshes it. Actions that need current data can still request a fresh index.
