### PR TITLE
Scope background graph validation and guard result publication

### DIFF
--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/KaBindingGraph.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/KaBindingGraph.kt
@@ -37,6 +37,7 @@ import dev.zacsweers.metro.compiler.graph.toTraceSection
 import dev.zacsweers.metro.compiler.tracing.TraceScope
 import dev.zacsweers.metro.idea.model.BindingIndex
 import dev.zacsweers.metro.idea.model.BindingIndex.SourcePointerIdentity
+import dev.zacsweers.metro.idea.model.BindingResolutionSession
 import dev.zacsweers.metro.idea.model.GraphContext
 import dev.zacsweers.metro.idea.model.GraphQueryContext
 import dev.zacsweers.metro.idea.model.KaAnnotationSnapshot
@@ -76,6 +77,7 @@ private typealias KaSourcePointer = SmartPsiElementPointer<out PsiElement>
  */
 internal class KaBindingGraph(
   private val index: BindingIndex,
+  private val session: BindingResolutionSession,
   private val queryContext: GraphQueryContext,
   private val options: MetroOptions,
   /** Keys extension children delegate to this graph, validated here like the compiler does. */
@@ -89,7 +91,7 @@ internal class KaBindingGraph(
   private val context = queryContext.graphContext
   private val graph = context.graph
   private val graphName = graph.classId?.asFqNameString() ?: graph.name ?: "<unknown>"
-  private val graphConsumers = index.accessorsFor(queryContext)
+  private val graphConsumers = session.accessorsFor(queryContext)
   private val diagnostics = mutableListOf<KaGraphDiagnostic>()
   private var suspendKeys: Set<KaTypeKey> = emptySet()
   private val pendingEmptyMultibindings = mutableListOf<KaBinding.Multibinding>()
@@ -105,7 +107,7 @@ internal class KaBindingGraph(
 
   // Cleared once sealing completes so lookup state doesn't outlive the population phase.
   private var _bindingLookup: KaBindingLookup? =
-    KaBindingLookup(index, queryContext, options, resolveParentGraph)
+    KaBindingLookup(index, session, queryContext, options, resolveParentGraph)
     set(value) {
       if (value == null) {
         field?.clear()
@@ -133,6 +135,7 @@ internal class KaBindingGraph(
             reportDuplicateBindings(key, bindings, stack)
           }
         for (binding in resolved) {
+          ProgressManager.checkCanceled()
           // Explicit providers can terminate a growing factory chain. Only stop after the normal
           // graph lookup actually chooses the implicit factory whose expansion was bounded.
           if (binding is KaBinding.AssistedFactory) {
@@ -161,7 +164,7 @@ internal class KaBindingGraph(
 
   fun seal(): KaGraphValidationResult.Completed {
     val keeps = LinkedHashMap<KaContextualTypeKey, KaBindingStack.Entry>()
-    val extensions = index.extensionsOf(queryContext)
+    val extensions = session.extensionsOf(queryContext)
     if (extensions.isNotEmpty()) {
       // Extension children depend on this graph's instance and reserve its key in the compiler's
       // parent seal. Keep it explicitly so the instance joins the sorted root set and the
@@ -177,6 +180,7 @@ internal class KaBindingGraph(
       }
     }
     for (binding in bindingLookup.directExtensionBindings()) {
+      ProgressManager.checkCanceled()
       // Resolve the kept key through the normal lookup, where an explicit binding or an existing
       // graph-supertype alias wins over synthesizing a child instance.
       keeps[binding.contextualTypeKey] =
@@ -187,6 +191,7 @@ internal class KaBindingGraph(
         )
     }
     for (reservation in reservations) {
+      ProgressManager.checkCanceled()
       // The parent may not request this collection itself, so its synthetic element exists only
       // because a child requested it. Carry the original element into the parent's lookup.
       if (reservation.key.qualifier?.classId == MetroClassIds.multibindingElement) {
@@ -205,6 +210,7 @@ internal class KaBindingGraph(
 
     val roots = LinkedHashMap<KaContextualTypeKey, KaBindingStack.Entry>()
     for (consumer in graphConsumers) {
+      ProgressManager.checkCanceled()
       // hasDefault is what makes the shared core treat an absent optional binding as not missing.
       // Union with any default already on the key so a defaulted context key never turns required.
       val contextKey =
@@ -218,6 +224,7 @@ internal class KaBindingGraph(
     // FIR checks graph request sites independently, before missing-binding resolution. Keep each
     // accessor even when several request the same canonical key.
     for (consumer in graphConsumers) {
+      ProgressManager.checkCanceled()
       if (consumer.graphRequestKind == null) continue
       val contextKey = consumer.contextKey
       if (!contextKey.isWrappedInLazy) continue
@@ -229,6 +236,7 @@ internal class KaBindingGraph(
     }
 
     var reservedParentBindings: Map<KaTypeKey, KaBinding> = emptyMap()
+    var sealCompleted = false
     val topology =
       try {
         val topo =
@@ -236,18 +244,23 @@ internal class KaBindingGraph(
             roots = roots,
             keep = keeps,
             shrinkUnusedBindings = options.shrinkUnusedBindings,
+            ensureActive = ProgressManager::checkCanceled,
             validateBindings = ::validateBindings,
           )
         // The compiler stops before empty-multibinding reporting when the seal produced errors.
         if (diagnostics.none { it.severity == MetroSeverity.ERROR }) {
           reportEmptyMultibindings()
         }
+        sealCompleted = true
         topo
       } catch (_: SealAborted) {
+        sealCompleted = true
         null
       } finally {
-        // Capture the delegated bindings, then clear the lookup now that we're done.
-        reservedParentBindings = _bindingLookup?.reservedParentBindings?.toMap().orEmpty()
+        // Skip copying parent reservations when cancellation interrupts the seal.
+        if (sealCompleted) {
+          reservedParentBindings = _bindingLookup?.reservedParentBindings?.toMap().orEmpty()
+        }
         _bindingLookup = null
       }
 
@@ -293,6 +306,7 @@ internal class KaBindingGraph(
 
   private fun reportEmptyMultibindings() {
     for (multibinding in pendingEmptyMultibindings) {
+      ProgressManager.checkCanceled()
       report(emptyMultibindingDiagnostic(multibinding.typeKey), KaBindingStack(graph))
     }
   }
@@ -332,7 +346,7 @@ internal class KaBindingGraph(
       )
     bindings.forEachValue { binding ->
       ProgressManager.checkCanceled()
-      structuralValidator.validate(binding) { issue ->
+      structuralValidator.validate(binding, ProgressManager::checkCanceled) { issue ->
         reportStructuralIssue(issue, stack, diagnosticRoutes, rootsByTypeKey)
       }
     }
@@ -522,12 +536,14 @@ internal class KaBindingGraph(
   ) {
     var checkedRequests: MutableSet<KaContextualTypeKey>? = null
     for (dependency in dependencies) {
+      ProgressManager.checkCanceled()
       if (!dependency.isWrappedInLazy) continue
       val factory = assistedFactoryFor(dependency) ?: continue
       val checked = checkedRequests ?: HashSet<KaContextualTypeKey>().also { checkedRequests = it }
       if (!checked.add(dependency)) continue
       val sourcePointers = lazyRequestSources(dependency, requestingBinding)
       for (sourcePointer in sourcePointers) {
+        ProgressManager.checkCanceled()
         val diagnosticStack = stack.copy()
         diagnosticStack.push(KaBindingStack.Entry.injectedAt(dependency, requestingBinding))
         reportLazyAssistedFactory(
@@ -688,14 +704,18 @@ internal class KaBindingGraph(
     fallback: KaBindingStack,
   ): KaBindingStack {
     val route =
-      diagnosticRoutes.routeToRoot(key) { callingKey, dependencyKey ->
-        val callingBinding = checkNotNull(realGraph.bindings[callingKey])
-        val contextKey =
-          callingBinding.dependencies.first { dependency ->
-            dependency.typeKey == dependencyKey
-          }
-        KaBindingStack.Entry.injectedAt(contextKey, callingBinding)
-      }
+      diagnosticRoutes.routeToRoot(
+        key,
+        createDependencyEntry = { callingKey, dependencyKey ->
+          val callingBinding = checkNotNull(realGraph.bindings[callingKey])
+          val contextKey =
+            callingBinding.dependencies.first { dependency ->
+              dependency.typeKey == dependencyKey
+            }
+          KaBindingStack.Entry.injectedAt(contextKey, callingBinding)
+        },
+        ensureActive = ProgressManager::checkCanceled,
+      )
     if (route.isEmpty()) return fallback.copy()
     val result = KaBindingStack(graph)
     for (entry in route) {

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/KaBindingLookup.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/KaBindingLookup.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.progress.ProgressManager
 import dev.zacsweers.metro.compiler.MetroClassIds
 import dev.zacsweers.metro.compiler.MetroOptions
 import dev.zacsweers.metro.idea.model.BindingIndex
+import dev.zacsweers.metro.idea.model.BindingResolutionSession
 import dev.zacsweers.metro.idea.model.GraphComposition
 import dev.zacsweers.metro.idea.model.GraphContext
 import dev.zacsweers.metro.idea.model.GraphPath
@@ -26,6 +27,7 @@ import org.jetbrains.kotlin.name.Name
 /** The index and compiler options belonging to a parent graph's own declaration module. */
 internal class ParentGraphLookup(
   val index: BindingIndex,
+  val session: BindingResolutionSession,
   val queryContext: GraphQueryContext,
   val options: MetroOptions,
 )
@@ -40,11 +42,13 @@ internal class ParentGraphLookup(
  */
 internal class KaBindingLookup(
   private val index: BindingIndex,
+  private val session: BindingResolutionSession,
   private val queryContext: GraphQueryContext,
   private val options: MetroOptions,
   private val resolveParentGraph: (GraphContext) -> ParentGraphLookup? = { null },
 ) {
   private val graph: KaGraphDeclaration = queryContext.graphContext.graph
+  internal val queryPlan = session.validationPlan(queryContext)
 
   /**
    * Element bindings by their synthetic qualifier-swapped keys. A multibinding's dependencies use
@@ -72,10 +76,10 @@ internal class KaBindingLookup(
       buildSet {
         addAll(child.selfIds)
         addAll(child.supertypeIds)
-        for (supertype in index.graphComposition(queryContext).supertypeDeclarations) {
+        for (supertype in index.graphComposition(queryPlan).supertypeDeclarations) {
           add(supertype.classId)
         }
-        addAll(index.graphOwnContainers(child, queryContext))
+        addAll(index.graphOwnContainers(child, queryPlan))
       }
     }
 
@@ -122,7 +126,7 @@ internal class KaBindingLookup(
       return setOf(it)
     }
 
-    val candidates = index.bindingsForKey(typeKey, queryContext)
+    val candidates = index.bindingsForKey(typeKey, queryPlan)
     val explicit = mutableListOf<KaBinding>()
     val implicit = mutableListOf<KaBinding>()
     val optional = mutableListOf<KaBinding>()
@@ -170,7 +174,7 @@ internal class KaBindingLookup(
 
     val multibindingId = contextKey.multibindingId(options)
     if (multibindingId != null) {
-      val contributions = index.multibindingContributions(multibindingId, queryContext)
+      val contributions = index.multibindingContributions(multibindingId, queryPlan)
       if (contributions.isNotEmpty() || multibindingDeclarations.isNotEmpty()) {
         return synthesizeMultibinding(
           contextKey,
@@ -212,11 +216,11 @@ internal class KaBindingLookup(
     // Resolve that alias entirely in the parent, where its implementation remains visible.
     if (binding is KaBinding.Alias && !binding.isGraphPrivate) {
       val consumedKey = binding.consumedKey
-      val belongsToAncestor = !index.isBindingOwnedByCurrentGraph(binding, queryContext)
+      val belongsToAncestor = !index.isBindingOwnedByCurrentGraph(binding, queryPlan)
       if (
         belongsToAncestor &&
           consumedKey != null &&
-          index.hasPrivateAncestorBinding(consumedKey.typeKey, queryContext)
+          session.hasPrivateAncestorBinding(consumedKey.typeKey, queryContext)
       ) {
         return delegateToParent(binding, chain)
       }
@@ -247,7 +251,7 @@ internal class KaBindingLookup(
         if (includedContainerKey != null) {
           // Factory-included containers carry their concrete input key instead of a container ID.
           // Their graph ownership must survive synthetic multibinding element re-keying.
-          if (index.isBindingOwnedByCurrentGraph(binding, queryContext)) {
+          if (index.isBindingOwnedByCurrentGraph(binding, queryPlan)) {
             return binding
           }
         } else {
@@ -311,20 +315,26 @@ internal class KaBindingLookup(
         chain.drop(1).map { it.declarationId },
         queryContext.graphContext.dynamicGraph?.id,
       )
-    val parentContext = index.findContext(parentPath) ?: return null
+    val parentContext = session.findContext(parentPath) ?: return null
     val resolvedParent = resolveParentGraph(parentContext)
     val parent =
       if (resolvedParent != null) {
         resolvedParent
       } else {
-        val parentQueryContext = index.queryContext(parentContext) ?: return null
-        ParentGraphLookup(index, parentQueryContext, options)
+        val parentQueryContext = session.queryContext(parentContext) ?: return null
+        ParentGraphLookup(index, session, parentQueryContext, options)
       }
     if (!parent.options.enableSuspendProviders) {
       return null
     }
     val lookup =
-      KaBindingLookup(parent.index, parent.queryContext, parent.options, resolveParentGraph)
+      KaBindingLookup(
+        parent.index,
+        parent.session,
+        parent.queryContext,
+        parent.options,
+        resolveParentGraph,
+      )
     parentSuspendLookup = lookup
     val analysis = SuspendBindingAnalysis { key ->
       lookup.lookup(key.canonicalContextKey()) { _, _ -> }.firstOrNull { it.typeKey == key }
@@ -354,10 +364,10 @@ internal class KaBindingLookup(
       return emptyList()
     }
 
-    val composition = index.graphComposition(queryContext)
+    val composition = index.graphComposition(queryPlan)
     val activeGraphIds = queryContext.graphContext.graphIds
     val bindings = mutableListOf<KaBinding.GraphExtension>()
-    for (extension in index.extensionsOf(queryContext)) {
+    for (extension in index.extensionsOf(queryPlan)) {
       ProgressManager.checkCanceled()
       if (extension.declarationId in activeGraphIds) continue
       val classId = extension.classId ?: continue
@@ -381,7 +391,7 @@ internal class KaBindingLookup(
     for (owner in chain) {
       ProgressManager.checkCanceled()
       val ownerKey = owner.graphTypeKey() ?: continue
-      val composition = index.graphComposition(queryContext, owner)
+      val composition = index.graphComposition(queryPlan, owner)
       compositions[owner] = composition
       val consumedKey = ownerKey.canonicalContextKey()
       for (supertypeKey in composition.supertypeKeys) {

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/MetroGraphValidationService.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/MetroGraphValidationService.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.platform.ide.progress.withBackgroundProgress
@@ -21,22 +22,28 @@ import dev.zacsweers.metro.idea.MetroIdeProjectService
 import dev.zacsweers.metro.idea.index.MetroResolutionService
 import dev.zacsweers.metro.idea.index.retryCancelledIndexBuild
 import dev.zacsweers.metro.idea.model.BindingIndex
+import dev.zacsweers.metro.idea.model.BindingResolutionSession
 import dev.zacsweers.metro.idea.model.GraphContext
 import dev.zacsweers.metro.idea.model.GraphPath
 import dev.zacsweers.metro.idea.model.GraphQueryContext
+import dev.zacsweers.metro.idea.model.IndexGenerationToken
 import dev.zacsweers.metro.idea.model.KaGraphDeclaration
-import java.util.Collections
-import java.util.concurrent.ConcurrentHashMap
+import java.util.IdentityHashMap
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Consumer
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jetbrains.annotations.TestOnly
 
 /** A retained validation result plus whether the index changed since it was produced. */
 internal class CachedValidation(val result: KaGraphValidationResult, val stale: Boolean)
@@ -52,7 +59,49 @@ internal class MetroGraphValidationService(
   private val scope: CoroutineScope,
 ) {
 
-  private class CachedEntry(val result: KaGraphValidationResult, val index: BindingIndex)
+  private class CachedEntry(
+    val result: KaGraphValidationResult,
+    val generationToken: IndexGenerationToken,
+    val runVersion: Long,
+  )
+
+  private class PublishedResults(
+    val clearVersion: Long,
+    val entries: Map<GraphPath, CachedEntry>,
+  ) {
+    fun cleared(): PublishedResults = PublishedResults(clearVersion + 1, emptyMap())
+
+    fun with(bundle: ValidationResultBundle): PublishedResults {
+      if (bundle.clearVersion != clearVersion || bundle.entries.isEmpty()) return this
+
+      val updated = LinkedHashMap(entries)
+      for ((path, entry) in bundle.entries) {
+        val current = updated[path]
+        if (current != null && current.runVersion > entry.runVersion) continue
+        updated.remove(path)
+        updated[path] = entry
+      }
+      val iterator = updated.entries.iterator()
+      while (updated.size > MAX_CACHED_RESULTS && iterator.hasNext()) {
+        iterator.next()
+        iterator.remove()
+      }
+      return PublishedResults(clearVersion, updated.toMap())
+    }
+  }
+
+  private class ValidationResultBundle(
+    val clearVersion: Long,
+    val runVersion: Long,
+    val entries: Map<GraphPath, CachedEntry>,
+  )
+
+  /** A finished computation waiting to be added to the shared result cache. */
+  private class CompletedValidation<T>(
+    val requestPath: GraphPath,
+    val result: T,
+    val bundle: ValidationResultBundle,
+  )
 
   /** A current graph context interpreted using the compilation that owns it. */
   private class ValidationInput(
@@ -61,48 +110,111 @@ internal class MetroGraphValidationService(
     val context: GraphContext,
   )
 
-  private class ValidationTraversal(
-    val requestPath: GraphPath,
-    val inputs: List<ValidationInput>,
+  private class ValidationTraversal(val requestPath: GraphPath, val inputs: List<ValidationInput>)
+
+  /** Shares one resolution session per index within a validation run. */
+  private class ResolutionRun {
+    private val sessions = IdentityHashMap<BindingIndex, BindingResolutionSession>()
+
+    fun session(index: BindingIndex): BindingResolutionSession {
+      return sessions.getOrPut(index) { index.createResolutionSession() }
+    }
+  }
+
+  private class ValidationWorkspace(
+    private val initial: PublishedResults,
+    private val runVersion: Long,
+  ) {
+    val resolutionRun = ResolutionRun()
+    private val results = linkedMapOf<GraphPath, CachedEntry>()
+    private val publishableResults = linkedMapOf<GraphPath, CachedEntry>()
+
+    fun cached(path: GraphPath, generationToken: IndexGenerationToken): KaGraphValidationResult? {
+      val entry = results[path] ?: initial.entries[path]
+      return entry?.takeIf { it.generationToken === generationToken }?.result
+    }
+
+    fun cache(
+      path: GraphPath,
+      result: KaGraphValidationResult,
+      generationToken: IndexGenerationToken,
+    ) {
+      val entry = CachedEntry(result, generationToken, runVersion)
+      results[path] = entry
+      publishableResults.remove(path)
+      publishableResults[path] = entry
+      if (publishableResults.size > MAX_CACHED_RESULTS) {
+        val oldest = publishableResults.entries.iterator()
+        oldest.next()
+        oldest.remove()
+      }
+    }
+
+    fun finish(): ValidationResultBundle {
+      return ValidationResultBundle(
+        initial.clearVersion,
+        runVersion,
+        publishableResults.toMap(),
+      )
+    }
+  }
+
+  /** Tracks one validation request so replacements can suppress its results and callbacks. */
+  private class ValidationRequest(
+    val path: GraphPath,
+    val token: Any,
+    val publishProgress: (GraphValidationProgress) -> Unit,
   )
+
+  private class ActiveValidation(
+    val token: Any,
+    val job: Job,
+    val progress: GraphValidationProgress,
+  )
+
+  private class ValidationActivity(val byPath: Map<GraphPath, ActiveValidation>) {
+    fun starting(path: GraphPath, validation: ActiveValidation): ValidationActivity {
+      return ValidationActivity(byPath + (path to validation))
+    }
+
+    fun progressing(
+      path: GraphPath,
+      token: Any,
+      progress: GraphValidationProgress,
+    ): ValidationActivity {
+      val validation = byPath[path] ?: return this
+      if (validation.token !== token) return this
+      return ValidationActivity(
+        byPath + (path to ActiveValidation(token, validation.job, progress))
+      )
+    }
+
+    fun completed(path: GraphPath, token: Any): ValidationActivity {
+      val validation = byPath[path] ?: return this
+      if (validation.token !== token) return this
+      return ValidationActivity(byPath - path)
+    }
+  }
 
   private fun cacheKey(context: GraphContext): GraphPath? {
     val hasLocalGraph = context.path.segments.any { it.classId == null }
     return context.path.takeUnless { hasLocalGraph }
   }
 
-  /**
-   * Contexts visited during active traversals stay available until those traversals finish. The
-   * normal cache limit applies again afterward so one large graph does not raise it forever.
-   */
-  private val retainFloor = AtomicInteger(0)
-  private val activeTraversals = AtomicInteger(0)
-
-  // An access-ordered LinkedHashMap with removeEldestEntry as an LRU. The bound keeps a long
-  // browsing session from retaining every sealed graph forever. The synchronized wrapper is
-  // required because async validation seals on pooled threads and access ordering mutates
-  // internal links even on reads.
-  private val results: MutableMap<GraphPath, CachedEntry> =
-    Collections.synchronizedMap(
-      object : LinkedHashMap<GraphPath, CachedEntry>(8, 0.75f, true) {
-        override fun removeEldestEntry(
-          eldest: MutableMap.MutableEntry<GraphPath, CachedEntry>
-        ): Boolean = size > maxOf(MAX_CACHED_RESULTS, retainFloor.get())
-      }
-    )
-
-  /** In-flight validations by stable graph path, so repeat requests coalesce into one run. */
-  private val inFlight = ConcurrentHashMap<GraphPath, Job>()
-  private val validationProgress = ConcurrentHashMap<GraphPath, GraphValidationProgress>()
+  private val publishedResults = AtomicReference(PublishedResults(0, emptyMap()))
+  private val validationActivity = AtomicReference(ValidationActivity(emptyMap()))
+  private val validationRunVersion = AtomicLong()
+  /** Keeps asynchronous result publication atomic with request replacement. */
+  private val validationRequestLock = Any()
+  private val validationProgressNotificationPending = AtomicBoolean()
   private val validationProgressListeners =
     CopyOnWriteArrayList<(List<GraphValidationProgress>) -> Unit>()
+  private val beforeValidationPublicationObserver =
+    AtomicReference<((GraphPath, Long) -> Unit)?>(null)
 
   /** Drops all retained results. */
   fun clearResults() {
-    results.clear()
-    if (activeTraversals.get() == 0) {
-      retainFloor.set(0)
-    }
+    publishedResults.updateAndGet(PublishedResults::cleared)
   }
 
   internal fun addValidationProgressListener(
@@ -115,7 +227,13 @@ internal class MetroGraphValidationService(
   }
 
   internal fun isValidationRunning(path: GraphPath): Boolean {
-    return validationProgress.values.any { it.covers(path) }
+    return validationActivity.get().byPath.values.any { it.progress.covers(path) }
+  }
+
+  /** Lets tests pause after computation to control result publication order. */
+  @TestOnly
+  internal fun setBeforeValidationPublicationObserver(observer: ((GraphPath, Long) -> Unit)?) {
+    beforeValidationPublicationObserver.set(observer)
   }
 
   /**
@@ -125,10 +243,14 @@ internal class MetroGraphValidationService(
    */
   fun cachedResult(element: PsiElement, context: GraphContext): CachedValidation? {
     val key = cacheKey(context) ?: return null
-    val entry = results[key] ?: return null
+    val entry = publishedResults.get().entries[key] ?: return null
     val contextElement = context.contextPointer.element ?: element
-    val currentIndex = project.service<MetroResolutionService>().cachedIndex(contextElement)
-    return CachedValidation(entry.result, stale = entry.index !== currentIndex)
+    val resolutionService = project.service<MetroResolutionService>()
+    val presentationIndex = resolutionService.presentationIndex(contextElement)
+    val stale =
+      entry.generationToken !== presentationIndex.generationToken ||
+        !resolutionService.isCurrent(presentationIndex)
+    return CachedValidation(entry.result, stale)
   }
 
   /**
@@ -136,7 +258,18 @@ internal class MetroGraphValidationService(
    * Must be called under a read action.
    */
   fun validate(element: PsiElement, context: GraphContext): KaGraphValidationResult {
-    return validate(validationInput(element, context))
+    return publishCompletedValidation(computeValidation(element, context))
+  }
+
+  /** Keeps this computation's cache entries private until the caller publishes the result. */
+  private fun computeValidation(
+    element: PsiElement,
+    context: GraphContext,
+  ): CompletedValidation<KaGraphValidationResult> {
+    val workspace = validationWorkspace()
+    val input = validationInput(element, context, workspace.resolutionRun)
+    val result = validate(input, workspace)
+    return CompletedValidation(context.path, result, workspace.finish())
   }
 
   /**
@@ -146,32 +279,43 @@ internal class MetroGraphValidationService(
   fun <T> debugLookup(
     element: PsiElement,
     context: GraphContext,
-    block: (BindingIndex, GraphQueryContext, MetroOptions, KaBindingLookup) -> T,
+    block:
+      (
+        BindingIndex,
+        BindingResolutionSession,
+        GraphQueryContext,
+        MetroOptions,
+        KaBindingLookup,
+      ) -> T,
   ): T? {
-    val input = validationInputOrNull(element, context) ?: return null
-    val queryContext = input.index.queryContext(input.context) ?: return null
+    val resolutionRun = ResolutionRun()
+    val input = validationInputOrNull(element, context, resolutionRun) ?: return null
+    val session = resolutionRun.session(input.index)
+    val queryContext = session.queryContext(input.context) ?: return null
     val options = moduleOptions(input.contextElement)
     val lookup =
-      KaBindingLookup(input.index, queryContext, options) { parentContext ->
-        parentGraphLookup(input.contextElement, parentContext)
+      KaBindingLookup(input.index, session, queryContext, options) { parentContext ->
+        parentGraphLookup(input.contextElement, parentContext, resolutionRun)
       }
     return try {
-      block(input.index, queryContext, options, lookup)
+      block(input.index, session, queryContext, options, lookup)
     } finally {
       lookup.clear()
     }
   }
 
-  private fun validate(input: ValidationInput): KaGraphValidationResult {
+  private fun validate(
+    input: ValidationInput,
+    workspace: ValidationWorkspace,
+  ): KaGraphValidationResult {
     val index = input.index
+    val resolutionRun = workspace.resolutionRun
+    val session = resolutionRun.session(index)
     val context = input.context
     val key = cacheKey(context)
     if (key != null) {
-      results[key]
-        ?.takeIf { it.index === index }
-        ?.let {
-          return it.result
-        }
+      val cached = workspace.cached(key, index.generationToken)
+      if (cached != null) return cached
     }
 
     // Extension children seal first, mirroring the compiler's traversal, so any keys they
@@ -181,9 +325,11 @@ internal class MetroGraphValidationService(
     val reservations = mutableListOf<ReservedParentKey>()
     var childFailed = false
     var incompleteChild: KaGraphValidationResult.Incomplete? = null
-    for (extensionContext in index.extensionContextsOf(context)) {
-      val childInput = validationInputOrNull(input.contextElement, extensionContext) ?: continue
-      val childResult = validate(childInput)
+    for (extensionContext in session.extensionContextsOf(context)) {
+      ProgressManager.checkCanceled()
+      val childInput =
+        validationInputOrNull(input.contextElement, extensionContext, resolutionRun) ?: continue
+      val childResult = validate(childInput, workspace)
       when (childResult) {
         is KaGraphValidationResult.Completed -> {
           for ((reservedKey, binding) in childResult.parentReservations) {
@@ -214,11 +360,11 @@ internal class MetroGraphValidationService(
         runGraphValidation(context, graphName) {
           val options = moduleOptions(input.contextElement)
           val queryContext =
-            checkNotNull(index.queryContext(context)) {
+            checkNotNull(session.queryContext(context)) {
               "Graph declaration disappeared: $graphName"
             }
-          KaBindingGraph(index, queryContext, options, reservations) { parentContext ->
-              parentGraphLookup(input.contextElement, parentContext)
+          KaBindingGraph(index, session, queryContext, options, reservations) { parentContext ->
+              parentGraphLookup(input.contextElement, parentContext, resolutionRun)
             }
             .seal()
         }
@@ -227,7 +373,7 @@ internal class MetroGraphValidationService(
     // gutter refresh. Internal errors stay uncached so transient plugin failures can retry. A
     // parent sealed without a crashed child's reservations must also retry once the child does.
     if (key != null && result !is KaGraphValidationResult.InternalError && !childFailed) {
-      results[key] = CachedEntry(result, index)
+      workspace.cache(key, result, index.generationToken)
     }
     return result
   }
@@ -242,15 +388,31 @@ internal class MetroGraphValidationService(
     graph: KaGraphDeclaration,
     onProgress: (GraphValidationProgress) -> Unit = {},
   ): List<KaGraphValidationResult> {
+    return publishCompletedValidation(computeValidationWithExtensions(element, graph, onProgress))
+  }
+
+  /** Collects every extension result before the caller updates the shared cache. */
+  private fun computeValidationWithExtensions(
+    element: PsiElement,
+    graph: KaGraphDeclaration,
+    onProgress: (GraphValidationProgress) -> Unit,
+  ): CompletedValidation<List<KaGraphValidationResult>> {
     val declarationElement = graph.pointer.element ?: element
     val index = project.service<MetroResolutionService>().currentIndex(declarationElement)
     val currentGraph =
       index.graphFor(graph)
         ?: throw CancellationException("Metro graph declaration is no longer current")
+    val workspace = validationWorkspace()
     val requestPath = GraphPath(listOf(currentGraph.declarationId))
     val traversal =
-      validationTraversal(declarationElement, requestPath, index.contextsFor(currentGraph))
-    return validateTraversal(traversal, onProgress)
+      validationTraversal(
+        declarationElement,
+        requestPath,
+        workspace.resolutionRun.session(index).contextsFor(currentGraph),
+        workspace.resolutionRun,
+      )
+    val results = validateTraversal(traversal, workspace, onProgress)
+    return CompletedValidation(requestPath, results, workspace.finish())
   }
 
   /** Validates one concrete graph path and the extension paths it creates. */
@@ -259,84 +421,96 @@ internal class MetroGraphValidationService(
     context: GraphContext,
     onProgress: (GraphValidationProgress) -> Unit = {},
   ): List<KaGraphValidationResult> {
-    val traversal = validationTraversal(element, context.path, listOf(context))
-    return validateTraversal(traversal, onProgress)
+    return publishCompletedValidation(computeValidationWithExtensions(element, context, onProgress))
+  }
+
+  /** Collects results for this graph path and its extensions before updating the shared cache. */
+  private fun computeValidationWithExtensions(
+    element: PsiElement,
+    context: GraphContext,
+    onProgress: (GraphValidationProgress) -> Unit,
+  ): CompletedValidation<List<KaGraphValidationResult>> {
+    val workspace = validationWorkspace()
+    val traversal =
+      validationTraversal(element, context.path, listOf(context), workspace.resolutionRun)
+    val results = validateTraversal(traversal, workspace, onProgress)
+    return CompletedValidation(context.path, results, workspace.finish())
   }
 
   private fun validationTraversal(
     declarationFallback: PsiElement,
     requestPath: GraphPath,
     rootContexts: List<GraphContext>,
+    resolutionRun: ResolutionRun,
   ): ValidationTraversal {
     val inputs = mutableListOf<ValidationInput>()
     val visited = mutableSetOf<GraphPath>()
 
     fun visit(context: GraphContext) {
-      val input = validationInput(declarationFallback, context)
+      ProgressManager.checkCanceled()
+      val input = validationInput(declarationFallback, context, resolutionRun)
       if (!visited.add(input.context.path)) return
-      for (extension in input.index.extensionContextsOf(input.context)) {
+      for (extension in resolutionRun.session(input.index).extensionContextsOf(input.context)) {
         visit(extension)
       }
       inputs += input
     }
 
-    rootContexts.forEach(::visit)
+    for (context in rootContexts) {
+      ProgressManager.checkCanceled()
+      visit(context)
+    }
     return ValidationTraversal(requestPath, inputs)
   }
 
   private fun validateTraversal(
     traversal: ValidationTraversal,
+    workspace: ValidationWorkspace,
     onProgress: (GraphValidationProgress) -> Unit,
   ): List<KaGraphValidationResult> {
-    activeTraversals.incrementAndGet()
-    try {
-      val traversalResults = ArrayList<KaGraphValidationResult>(traversal.inputs.size)
-      for ((index, input) in traversal.inputs.withIndex()) {
-        val graphName =
-          input.context.graph.name ?: input.context.graph.classId?.asFqNameString() ?: "<unknown>"
-        onProgress(
-          GraphValidationProgress(
-            requestPath = traversal.requestPath,
-            graphName = graphName,
-            completed = index,
-            total = traversal.inputs.size,
-          )
+    val traversalResults = ArrayList<KaGraphValidationResult>(traversal.inputs.size)
+    for ((index, input) in traversal.inputs.withIndex()) {
+      ProgressManager.checkCanceled()
+      val graphName =
+        input.context.graph.name ?: input.context.graph.classId?.asFqNameString() ?: "<unknown>"
+      onProgress(
+        GraphValidationProgress(
+          requestPath = traversal.requestPath,
+          graphName = graphName,
+          completed = index,
+          total = traversal.inputs.size,
         )
-        traversalResults += validate(input)
-        retainFloor.updateAndGet { floor -> maxOf(floor, traversalResults.size + 1) }
-      }
-      return traversalResults
-    } finally {
-      if (activeTraversals.decrementAndGet() == 0) {
-        retainFloor.set(0)
-        synchronized(results) {
-          val entries = results.entries.iterator()
-          while (results.size > MAX_CACHED_RESULTS && entries.hasNext()) {
-            entries.next()
-            entries.remove()
-          }
-        }
-      }
+      )
+      traversalResults += validate(input, workspace)
     }
+    return traversalResults
   }
 
   /** Parent binding analysis follows the parent's own module, index, and compiler options. */
   private fun parentGraphLookup(
     declarationFallback: PsiElement,
     context: GraphContext,
+    resolutionRun: ResolutionRun,
   ): ParentGraphLookup? {
-    val input = validationInputOrNull(declarationFallback, context) ?: return null
-    val queryContext = input.index.queryContext(input.context) ?: return null
-    return ParentGraphLookup(input.index, queryContext, moduleOptions(input.contextElement))
+    val input = validationInputOrNull(declarationFallback, context, resolutionRun) ?: return null
+    val session = resolutionRun.session(input.index)
+    val queryContext = session.queryContext(input.context) ?: return null
+    return ParentGraphLookup(
+      input.index,
+      session,
+      queryContext,
+      moduleOptions(input.contextElement),
+    )
   }
 
   private fun validationInputOrNull(
     declarationFallback: PsiElement,
     context: GraphContext,
+    resolutionRun: ResolutionRun,
   ): ValidationInput? {
     val contextElement = context.contextPointer.element ?: declarationFallback
     val index = project.service<MetroResolutionService>().currentIndex(contextElement)
-    val currentContext = index.findContext(context.path) ?: return null
+    val currentContext = resolutionRun.session(index).findContext(context.path) ?: return null
     val currentContextElement = currentContext.contextPointer.element ?: return null
     return ValidationInput(currentContextElement, index, currentContext)
   }
@@ -344,11 +518,12 @@ internal class MetroGraphValidationService(
   private fun validationInput(
     declarationFallback: PsiElement,
     context: GraphContext,
+    resolutionRun: ResolutionRun,
   ): ValidationInput {
     val contextElement = context.contextPointer.element ?: declarationFallback
     val index = project.service<MetroResolutionService>().currentIndex(contextElement)
     val currentContext =
-      index.findContext(context.path)
+      resolutionRun.session(index).findContext(context.path)
         ?: throw CancellationException("Metro graph context is no longer current")
     val currentContextElement =
       currentContext.contextPointer.element
@@ -356,19 +531,22 @@ internal class MetroGraphValidationService(
     return ValidationInput(currentContextElement, index, currentContext)
   }
 
-  /** Runs [validate] for one context in a smart-mode read action and delivers it on the EDT. */
+  /**
+   * Validates under a cancellable read action. Results enter the cache after the read ends, and
+   * [onDone] runs on the EDT.
+   */
   fun validateAsync(
     element: PsiElement,
     context: GraphContext,
     onDone: Consumer<KaGraphValidationResult>,
-  ) {
-    launchCoalesced(context.path, context.graph) { publish ->
-      val result =
+  ): Job {
+    return launchLatestValidation(context.path, context.graph) { request ->
+      val completed =
         withBackgroundProgress(project, progressTitle(context.graph)) {
           reportRawProgress { reporter ->
             retryCancelledIndexBuild {
               smartReadAction(project) {
-                publish(
+                request.publishProgress(
                   GraphValidationProgress(
                     requestPath = context.path,
                     graphName = graphDisplayName(context.graph),
@@ -378,32 +556,40 @@ internal class MetroGraphValidationService(
                 )
                 reporter.details("Validating ${graphDisplayName(context.graph)}")
                 reporter.fraction(0.0)
-                validate(element, context)
+                computeValidation(element, context)
               }
             }
           }
         }
-      withContext(Dispatchers.EDT) { onDone.accept(result) }
+      if (publishCompletedValidationIfCurrent(request, completed)) {
+        withContext(Dispatchers.EDT) {
+          if (isCurrentValidation(request)) onDone.accept(completed.result)
+        }
+      }
     }
   }
 
-  /** Runs [validateWithExtensions] like [validateAsync]. */
+  /**
+   * Validates the graph and its extensions asynchronously. Results are cached after the read ends,
+   * and [onDone] runs on the EDT.
+   */
   fun validateWithExtensionsAsync(
-    element: PsiElement,
     graph: KaGraphDeclaration,
     onDone: Consumer<List<KaGraphValidationResult>>,
-  ) {
-    // Keyed by the root path so this coalesces with validateAsync for the same graph and stays
-    // stable across index rebuilds, unlike the declaration instance.
+  ): Job {
+    // Use the same path as validateAsync so either entry point replaces an older request.
     val requestPath = GraphPath(listOf(graph.declarationId))
-    launchCoalesced(requestPath, graph) { publish ->
-      val results =
+    return launchLatestValidation(requestPath, graph) { request ->
+      val completed =
         withBackgroundProgress(project, progressTitle(graph)) {
           reportRawProgress { reporter ->
             retryCancelledIndexBuild {
               smartReadAction(project) {
-                validateWithExtensions(element, graph) { progress ->
-                  publish(progress)
+                val element =
+                  graph.pointer.element
+                    ?: throw CancellationException("Metro graph is no longer available")
+                computeValidationWithExtensions(element, graph) { progress ->
+                  request.publishProgress(progress)
                   reporter.details(progress.message)
                   reporter.fraction(progress.fraction)
                 }
@@ -411,24 +597,33 @@ internal class MetroGraphValidationService(
             }
           }
         }
-      withContext(Dispatchers.EDT) { onDone.accept(results) }
+      if (publishCompletedValidationIfCurrent(request, completed)) {
+        withContext(Dispatchers.EDT) {
+          if (isCurrentValidation(request)) onDone.accept(completed.result)
+        }
+      }
     }
   }
 
-  /** Runs [validateWithExtensions] for one concrete graph path like [validateAsync]. */
+  /**
+   * Validates this graph path and its extensions asynchronously. Results are cached after the read
+   * ends, and [onDone] runs on the EDT.
+   */
   fun validateWithExtensionsAsync(
-    element: PsiElement,
     context: GraphContext,
     onDone: Consumer<List<KaGraphValidationResult>>,
-  ) {
-    launchCoalesced(context.path, context.graph) { publish ->
-      val results =
+  ): Job {
+    return launchLatestValidation(context.path, context.graph) { request ->
+      val completed =
         withBackgroundProgress(project, progressTitle(context.graph)) {
           reportRawProgress { reporter ->
             retryCancelledIndexBuild {
               smartReadAction(project) {
-                validateWithExtensions(element, context) { progress ->
-                  publish(progress)
+                val element =
+                  context.contextPointer.element
+                    ?: throw CancellationException("Metro graph context is no longer available")
+                computeValidationWithExtensions(element, context) { progress ->
+                  request.publishProgress(progress)
                   reporter.details(progress.message)
                   reporter.fraction(progress.fraction)
                 }
@@ -436,7 +631,11 @@ internal class MetroGraphValidationService(
             }
           }
         }
-      withContext(Dispatchers.EDT) { onDone.accept(results) }
+      if (publishCompletedValidationIfCurrent(request, completed)) {
+        withContext(Dispatchers.EDT) {
+          if (isCurrentValidation(request)) onDone.accept(completed.result)
+        }
+      }
     }
   }
 
@@ -447,16 +646,20 @@ internal class MetroGraphValidationService(
     return graph.name ?: graph.classId?.asFqNameString() ?: "<unknown>"
   }
 
-  /** Launches [block], cancelling any in-flight run for the same graph request. */
-  private fun launchCoalesced(
+  private fun launchLatestValidation(
     key: GraphPath,
     graph: KaGraphDeclaration,
-    block: suspend CoroutineScope.((GraphValidationProgress) -> Unit) -> Unit,
-  ) {
+    block: suspend CoroutineScope.(ValidationRequest) -> Unit,
+  ): Job {
+    val token = Any()
     val job =
       scope.launch(start = CoroutineStart.LAZY) {
         try {
-          block { progress -> publishValidationProgress(key, progress) }
+          block(
+            ValidationRequest(key, token) { progress ->
+              publishValidationProgress(key, token, progress)
+            }
+          )
         } catch (e: ProcessCanceledException) {
           throw e
         } catch (e: CancellationException) {
@@ -465,39 +668,108 @@ internal class MetroGraphValidationService(
           logger<MetroGraphValidationService>().warn("Metro graph validation failed", e)
         }
       }
-    inFlight.put(key, job)?.cancel()
-    publishValidationProgress(
-      key,
-      GraphValidationProgress(requestPath = key, graphName = graphDisplayName(graph)),
-    )
+    val validation =
+      ActiveValidation(
+        token,
+        job,
+        GraphValidationProgress(requestPath = key, graphName = graphDisplayName(graph)),
+      )
+    val previous = startValidation(key, validation)
+    previous?.job?.cancel()
+    scheduleValidationProgressNotification()
     job.invokeOnCompletion {
-      if (inFlight.remove(key, job)) {
-        publishValidationProgress(key, null)
+      if (completeValidation(key, token)) {
+        scheduleValidationProgressNotification()
       }
     }
     job.start()
+    return job
   }
 
-  private fun publishValidationProgress(key: GraphPath, progress: GraphValidationProgress?) {
-    if (progress == null) {
-      validationProgress.remove(key)
-    } else {
-      validationProgress[key] = progress
+  private fun startValidation(
+    path: GraphPath,
+    validation: ActiveValidation,
+  ): ActiveValidation? {
+    return synchronized(validationRequestLock) {
+      val previous = validationActivity.getAndUpdate { it.starting(path, validation) }
+      previous.byPath[path]
     }
-    notifyValidationProgressListeners()
   }
 
-  private fun notifyValidationProgressListeners() {
-    val application = ApplicationManager.getApplication()
-    if (!application.isDispatchThread) {
-      application.invokeLater {
-        if (!project.isDisposed) notifyValidationProgressListeners()
+  private fun completeValidation(path: GraphPath, token: Any): Boolean {
+    val previous = validationActivity.getAndUpdate { it.completed(path, token) }
+    return previous.byPath[path]?.token === token
+  }
+
+  private fun publishValidationProgress(
+    path: GraphPath,
+    token: Any,
+    progress: GraphValidationProgress,
+  ) {
+    val previous = validationActivity.getAndUpdate { it.progressing(path, token, progress) }
+    val changed = previous.byPath[path]?.token === token
+    if (changed) scheduleValidationProgressNotification()
+  }
+
+  private fun isCurrentValidation(request: ValidationRequest): Boolean {
+    return validationActivity.get().byPath[request.path]?.token === request.token
+  }
+
+  /** Adds a completed result to the cache before returning it. */
+  private fun <T> publishCompletedValidation(completed: CompletedValidation<T>): T {
+    beforeValidationPublicationObserver
+      .get()
+      ?.invoke(completed.requestPath, completed.bundle.runVersion)
+    publish(completed.bundle)
+    return completed.result
+  }
+
+  /** Only the latest active request may update the result cache. */
+  private suspend fun publishCompletedValidationIfCurrent(
+    request: ValidationRequest,
+    completed: CompletedValidation<*>,
+  ): Boolean {
+    val coroutineContext = currentCoroutineContext()
+    coroutineContext.ensureActive()
+    beforeValidationPublicationObserver
+      .get()
+      ?.invoke(completed.requestPath, completed.bundle.runVersion)
+    coroutineContext.ensureActive()
+    val published =
+      synchronized(validationRequestLock) {
+        coroutineContext.ensureActive()
+        if (!isCurrentValidation(request)) {
+          false
+        } else {
+          publish(completed.bundle)
+          true
+        }
       }
-      return
-    }
-    val snapshot = validationProgress.values.sortedBy { it.requestPath.toString() }
-    for (listener in validationProgressListeners.toList()) {
-      listener(snapshot)
+    coroutineContext.ensureActive()
+    return published && isCurrentValidation(request)
+  }
+
+  private fun publish(bundle: ValidationResultBundle) {
+    if (bundle.entries.isEmpty()) return
+    publishedResults.updateAndGet { it.with(bundle) }
+  }
+
+  private fun validationWorkspace(): ValidationWorkspace {
+    return ValidationWorkspace(publishedResults.get(), validationRunVersion.incrementAndGet())
+  }
+
+  /** Queues one EDT update for the latest progress, even when a traversal reports many graphs. */
+  private fun scheduleValidationProgressNotification() {
+    if (validationProgressListeners.isEmpty()) return
+    if (!validationProgressNotificationPending.compareAndSet(false, true)) return
+    ApplicationManager.getApplication().invokeLater {
+      // Clear first so completion during listener callbacks can still queue an update.
+      validationProgressNotificationPending.set(false)
+      if (project.isDisposed) return@invokeLater
+      val snapshot = validationProgressSnapshot()
+      for (listener in validationProgressListeners.toList()) {
+        listener(snapshot)
+      }
     }
   }
 
@@ -512,7 +784,13 @@ internal class MetroGraphValidationService(
       return
     }
     if (listener in validationProgressListeners) {
-      listener(validationProgress.values.sortedBy { it.requestPath.toString() })
+      listener(validationProgressSnapshot())
+    }
+  }
+
+  private fun validationProgressSnapshot(): List<GraphValidationProgress> {
+    return validationActivity.get().byPath.values.map(ActiveValidation::progress).sortedBy {
+      it.requestPath.toString()
     }
   }
 

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroGraphDebugExporter.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroGraphDebugExporter.kt
@@ -29,6 +29,7 @@ import dev.zacsweers.metro.idea.graph.KaGraphValidationResult
 import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
 import dev.zacsweers.metro.idea.index.retryCancelledIndexBuild
 import dev.zacsweers.metro.idea.model.BindingIndex
+import dev.zacsweers.metro.idea.model.BindingResolutionSession
 import dev.zacsweers.metro.idea.model.ContributionEntry
 import dev.zacsweers.metro.idea.model.GraphContext
 import dev.zacsweers.metro.idea.model.GraphDeclarationId
@@ -130,11 +131,11 @@ internal class MetroGraphDebugExporter(
   fun report(context: GraphContext): String? {
     val element = context.contextPointer.element ?: return null
     val service = project.service<MetroGraphValidationService>()
-    return service.debugLookup(element, context) { index, queryContext, options, lookup ->
+    return service.debugLookup(element, context) { index, session, queryContext, options, lookup ->
       val currentContext = queryContext.graphContext
       val declaration = currentContext.graph.pointer.element ?: element
       val cached = service.cachedResult(declaration, currentContext)
-      GraphDebugReport(project, index, queryContext, options, cached, lookup).render()
+      GraphDebugReport(project, index, session, queryContext, options, cached, lookup).render()
     }
   }
 
@@ -161,6 +162,7 @@ internal fun writeGraphDebugReport(directory: Path, report: String): Path {
 private class GraphDebugReport(
   private val project: Project,
   private val index: BindingIndex,
+  private val session: BindingResolutionSession,
   private val queryContext: GraphQueryContext,
   private val options: MetroOptions,
   private val cachedValidation: CachedValidation?,
@@ -203,6 +205,7 @@ private class GraphDebugReport(
     field("suppressUnusedWarnings", settings.suppressUnusedWarnings)
     field("suppressKaptConfigurationWarning", settings.suppressKaptConfigurationWarning)
     field("enableBindingResolution", settings.enableBindingResolution)
+    field("automaticallyRefreshGraphData", settings.automaticallyRefreshGraphData)
     field("resolveFromLibraries", settings.resolveFromLibraries)
     field("assistedParameterInlays", settings.assistedParameterInlays)
 
@@ -237,8 +240,8 @@ private class GraphDebugReport(
     }
 
     section("Contributions")
-    val ownContributions = index.contributionsFor(queryContext)
-    val inheritedContributions = index.inheritedContributionsFor(queryContext)
+    val ownContributions = session.contributionsFor(queryContext)
+    val inheritedContributions = session.inheritedContributionsFor(queryContext)
     field("own", ownContributions.size)
     val contributionOrder =
       compareBy<ContributionEntry>(
@@ -260,7 +263,7 @@ private class GraphDebugReport(
     }
 
     val requests =
-      index
+      session
         .accessorsFor(queryContext)
         .sortedWith(
           compareBy({ pointerSortKey(it.pointer) }, { it.contextKey.render(short = false) })
@@ -271,7 +274,7 @@ private class GraphDebugReport(
       "bindingKinds",
       index.bindings.groupingBy { it.javaClass.simpleName }.eachCount().toSortedMap(),
     )
-    field("bindingsInContext", index.bindingsInContext(queryContext).size)
+    field("bindingsInContext", session.bindingsInContext(queryContext).size)
     field("consumers", index.consumers.size)
     field("graphs", index.graphs.size)
     field("contributions", index.contributions.size)
@@ -291,7 +294,9 @@ private class GraphDebugReport(
         request.contextKey.withDefault(request.isOptional || request.contextKey.hasDefault)
       val raw = rawCandidates.getOrPut(request.key.type) { index.bindingsWithType(request.key) }
       val inContext =
-        contextCandidates.getOrPut(request.key) { index.bindingsForKey(request.key, queryContext) }
+        contextCandidates.getOrPut(request.key) {
+          index.bindingsForKey(request.key, lookup.queryPlan)
+        }
       val selected = selectCandidates(requestKey)
       line("request ${number + 1}:")
       field("  location", location(request.pointer))
@@ -351,7 +356,7 @@ private class GraphDebugReport(
   }
 
   private fun writeGraph(graph: KaGraphDeclaration) {
-    val composition = index.graphComposition(queryContext, graph)
+    val composition = session.graphComposition(queryContext, graph)
     line("graph ${graphId(graph.declarationId)}:")
     field("  declaration", location(graph.pointer))
     field("  isExtension", graph.isExtension)

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/toolwindow/MetroToolWindowPanel.kt
@@ -287,15 +287,13 @@ internal class MetroToolWindowPanel(private val project: Project) :
   }
 
   private fun validateGraph(graph: KaGraphDeclaration) {
-    val element = graph.pointer.element ?: return
-    validationService.validateWithExtensionsAsync(element, graph) {
+    validationService.validateWithExtensionsAsync(graph) {
       validationFinished(validationVisitor(graph))
     }
   }
 
   private fun validateContext(context: GraphContext) {
-    val element = context.contextPointer.element ?: return
-    validationService.validateWithExtensionsAsync(element, context) {
+    validationService.validateWithExtensionsAsync(context) {
       validationFinished(validationVisitor(context))
     }
   }

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.metro.idea
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.psi.PsiDocumentManager
+import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.util.ui.UIUtil
 import dev.zacsweers.metro.compiler.MetroClassIds
 import dev.zacsweers.metro.compiler.diagnostics.MetroDiagnosticId
 import dev.zacsweers.metro.idea.graph.GraphValidationProgress
@@ -17,10 +20,19 @@ import dev.zacsweers.metro.idea.graph.MetroGraphValidationService
 import dev.zacsweers.metro.idea.graph.runGraphValidation
 import dev.zacsweers.metro.idea.index.MetroResolutionService
 import dev.zacsweers.metro.idea.index.retryCancelledIndexBuild
+import dev.zacsweers.metro.idea.model.BindingIndex
 import dev.zacsweers.metro.idea.model.DeclarationResolutionScope
 import dev.zacsweers.metro.idea.model.GraphQueryContext
 import dev.zacsweers.metro.idea.model.KaBinding
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtParameter
@@ -36,6 +48,12 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     // Results are retained across index invalidation by design, so they survive across tests
     // sharing this project. Start each test clean.
     project.service<MetroGraphValidationService>().clearResults()
+  }
+
+  private fun refreshedIndex(file: KtFile): BindingIndex {
+    val service = project.service<MetroResolutionService>()
+    service.refreshGraphData()
+    return service.awaitIndex(file)
   }
 
   private fun validate(
@@ -1181,7 +1199,9 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         queryContext.containers,
       )
 
-    val result = KaBindingGraph(index, countedContext, file.metroIdeState().options).seal()
+    val result = index.withResolutionSession { session ->
+      KaBindingGraph(index, session, countedContext, file.metroIdeState().options).seal()
+    }
     val diagnostics = result.diagnostics.filter { it.id == MetroDiagnosticId.INVALID_BINDING }
     val parameters = diagnostics.map { it.stack.first().pointer?.element as? KtParameter }
 
@@ -2630,6 +2650,33 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     assertTrue(result.topology!!.sortedKeys.any { it.renderedType == "test.RealRepo" })
   }
 
+  fun testReplacementFromInactiveScopeDoesNotRemoveContribution() {
+    val result =
+      validate(
+        """
+        object OtherScope
+        interface Repo
+
+        @Inject @ContributesBinding(AppScope::class)
+        class RealRepo : Repo
+
+        @Inject
+        @ContributesBinding(OtherScope::class, replaces = [RealRepo::class])
+        class OtherRepo : Repo
+
+        @DependencyGraph(AppScope::class)
+        interface AppGraph {
+          val repo: Repo
+        }
+        """
+      )
+
+    assertTrue(result.diagnostics.joinToString { it.render() }, result.diagnostics.isEmpty())
+    val repoBinding =
+      result.bindings.asMap().values.single { it.typeKey.renderedType == "test.Repo" }
+    assertEquals("RealRepo", repoBinding.implementationName)
+  }
+
   fun testContributesBindingWithTypeUseQualifier() {
     val result =
       validate(
@@ -2943,6 +2990,38 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     assertTrue(serviceBinding is KaBinding.Provided)
     assertEquals("HigherService", serviceBinding.implementationName)
     assertEquals(100, serviceBinding.priority)
+  }
+
+  fun testContributionPriorityIgnoresInactiveScopes() {
+    project.setMetroOptions("custom-contributes-binding" to "test/PrioritizedBinding")
+
+    val result =
+      validate(
+        """
+        import kotlin.reflect.KClass
+
+        annotation class PrioritizedBinding(val scope: KClass<*>, val priority: Int)
+
+        object OtherScope
+        interface Service
+
+        @Inject @PrioritizedBinding(OtherScope::class, priority = 100)
+        class OtherService : Service
+
+        @Inject @PrioritizedBinding(AppScope::class, priority = 10)
+        class AppService : Service
+
+        @DependencyGraph(AppScope::class)
+        interface AppGraph {
+          val service: Service
+        }
+        """
+      )
+
+    assertTrue(result.diagnostics.joinToString { it.render() }, result.diagnostics.isEmpty())
+    val serviceBinding =
+      result.bindings.asMap().values.single { it.typeKey.renderedType == "test.Service" }
+    assertEquals("AppService", serviceBinding.implementationName)
   }
 
   fun testContributedAssistedFactoryRetainsItsTargetsNonAssistedDependencies() {
@@ -4207,6 +4286,240 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     assertSame(first, second)
   }
 
+  fun testSupersededAsyncValidationDoesNotPublishOrDeliverItsResult() {
+    val file = myFixture.configureMetroFile("@DependencyGraph interface AppGraph")
+    val index = refreshedIndex(file)
+    val context = index.contextsFor(index.graphs.single()).single()
+    val validationService = project.service<MetroGraphValidationService>()
+    val firstReady = CompletableFuture<Unit>()
+    val releaseFirst = CountDownLatch(1)
+    val publicationAttempts = AtomicInteger()
+    val firstResult = CompletableFuture<KaGraphValidationResult>()
+    val secondResult = CompletableFuture<KaGraphValidationResult>()
+    var firstJob: Job? = null
+    var secondJob: Job? = null
+
+    validationService.setBeforeValidationPublicationObserver { _, _ ->
+      if (publicationAttempts.incrementAndGet() == 1) {
+        firstReady.complete(Unit)
+        releaseFirst.await()
+      }
+    }
+    try {
+      val startedFirstJob =
+        validationService.validateAsync(file, context) { firstResult.complete(it) }
+      firstJob = startedFirstJob
+      startedFirstJob.invokeOnCompletion { failure ->
+        if (failure != null) firstReady.completeExceptionally(failure)
+      }
+      PlatformTestUtil.waitForFuture(firstReady, 30_000)
+
+      val startedSecondJob =
+        validationService.validateAsync(file, context) { secondResult.complete(it) }
+      secondJob = startedSecondJob
+      startedSecondJob.invokeOnCompletion { failure ->
+        if (failure != null) secondResult.completeExceptionally(failure)
+      }
+      val published = PlatformTestUtil.waitForFuture(secondResult, 30_000)
+      releaseFirst.countDown()
+
+      val firstCompleted = CompletableFuture<Unit>()
+      startedFirstJob.invokeOnCompletion { firstCompleted.complete(Unit) }
+      val secondCompleted = CompletableFuture<Unit>()
+      startedSecondJob.invokeOnCompletion { secondCompleted.complete(Unit) }
+      PlatformTestUtil.waitForFuture(firstCompleted, 30_000)
+      PlatformTestUtil.waitForFuture(secondCompleted, 30_000)
+      UIUtil.dispatchAllInvocationEvents()
+
+      assertEquals(2, publicationAttempts.get())
+      assertFalse(firstResult.isDone)
+      assertSame(published, validationService.cachedResult(file, context)!!.result)
+    } finally {
+      releaseFirst.countDown()
+      firstJob?.cancel()
+      secondJob?.cancel()
+      validationService.setBeforeValidationPublicationObserver(null)
+    }
+  }
+
+  fun testClearDuringAsyncValidationPreventsRetainingTheCompletedResult() {
+    val file = myFixture.configureMetroFile("@DependencyGraph interface AppGraph")
+    val index = refreshedIndex(file)
+    val context = index.contextsFor(index.graphs.single()).single()
+    val validationService = project.service<MetroGraphValidationService>()
+    val publicationReady = CompletableFuture<Unit>()
+    val releasePublication = CountDownLatch(1)
+    val delivered = CompletableFuture<KaGraphValidationResult>()
+    val publicationHeldReadAccess = AtomicBoolean()
+    var job: Job? = null
+
+    validationService.setBeforeValidationPublicationObserver { _, _ ->
+      publicationHeldReadAccess.set(ApplicationManager.getApplication().isReadAccessAllowed)
+      publicationReady.complete(Unit)
+      releasePublication.await()
+    }
+    try {
+      val startedJob = validationService.validateAsync(file, context) { delivered.complete(it) }
+      job = startedJob
+      PlatformTestUtil.waitForFuture(publicationReady, 30_000)
+      validationService.clearResults()
+      releasePublication.countDown()
+
+      PlatformTestUtil.waitForFuture(delivered, 30_000)
+      val completed = CompletableFuture<Unit>()
+      startedJob.invokeOnCompletion { completed.complete(Unit) }
+      PlatformTestUtil.waitForFuture(completed, 30_000)
+      UIUtil.dispatchAllInvocationEvents()
+
+      assertFalse(publicationHeldReadAccess.get())
+      assertNull(validationService.cachedResult(file, context))
+    } finally {
+      releasePublication.countDown()
+      job?.cancel()
+      validationService.setBeforeValidationPublicationObserver(null)
+    }
+  }
+
+  fun testReverseValidationCompletionKeepsTheNewerResult() {
+    val file = myFixture.configureMetroFile("@DependencyGraph interface AppGraph")
+    val index = refreshedIndex(file)
+    val context = index.contextsFor(index.graphs.single()).single()
+    val validationService = project.service<MetroGraphValidationService>()
+    val publicationAttempts = AtomicInteger()
+    val firstReady = CompletableFuture<Long>()
+    val secondReady = CompletableFuture<Long>()
+    val releaseFirst = CountDownLatch(1)
+    val releaseSecond = CountDownLatch(1)
+    val executor = Executors.newFixedThreadPool(2)
+
+    validationService.setBeforeValidationPublicationObserver { _, runVersion ->
+      when (publicationAttempts.incrementAndGet()) {
+        1 -> {
+          firstReady.complete(runVersion)
+          releaseFirst.await()
+        }
+        2 -> {
+          secondReady.complete(runVersion)
+          releaseSecond.await()
+        }
+      }
+    }
+    try {
+      fun validateInBackground(): CompletableFuture<KaGraphValidationResult> {
+        return CompletableFuture.supplyAsync(
+          {
+            runBlocking {
+              retryCancelledIndexBuild {
+                ApplicationManager.getApplication().runReadAction<KaGraphValidationResult> {
+                  validationService.validate(file, context)
+                }
+              }
+            }
+          },
+          executor,
+        )
+      }
+
+      val first = validateInBackground()
+      first.whenComplete { _, failure ->
+        if (failure != null) firstReady.completeExceptionally(failure)
+      }
+      val firstRunVersion = PlatformTestUtil.waitForFuture(firstReady, 30_000)
+      val second = validateInBackground()
+      second.whenComplete { _, failure ->
+        if (failure != null) secondReady.completeExceptionally(failure)
+      }
+      val secondRunVersion = PlatformTestUtil.waitForFuture(secondReady, 30_000)
+      assertTrue(firstRunVersion < secondRunVersion)
+
+      releaseSecond.countDown()
+      val secondResult = PlatformTestUtil.waitForFuture(second, 30_000)
+      releaseFirst.countDown()
+      val firstResult = PlatformTestUtil.waitForFuture(first, 30_000)
+
+      assertNotSame(firstResult, secondResult)
+      assertSame(secondResult, validationService.cachedResult(file, context)!!.result)
+    } finally {
+      releaseFirst.countDown()
+      releaseSecond.countDown()
+      executor.shutdownNow()
+      validationService.setBeforeValidationPublicationObserver(null)
+    }
+  }
+
+  fun testAsyncValidationProgressCoalescesAndStillDeliversRemoval() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        @GraphExtension
+        interface ChildGraph
+
+        @DependencyGraph
+        interface AppGraph {
+          val child: ChildGraph
+        }
+        """
+      )
+    val index = refreshedIndex(file)
+    val graph = index.graphs.single { it.name == "AppGraph" }
+    val validationService = project.service<MetroGraphValidationService>()
+    val snapshots = mutableListOf<List<GraphValidationProgress>>()
+    val sawActive = AtomicBoolean()
+    val terminal = CompletableFuture<Unit>()
+    validationService.addValidationProgressListener(testRootDisposable) { progress ->
+      snapshots += progress
+      if (progress.isEmpty()) {
+        if (sawActive.get()) terminal.complete(Unit)
+      } else {
+        sawActive.set(true)
+      }
+    }
+    UIUtil.dispatchAllInvocationEvents()
+    snapshots.clear()
+
+    val publicationReady = CountDownLatch(1)
+    val startupFailure = AtomicReference<Throwable?>()
+    val releasePublication = CountDownLatch(1)
+    val delivered = CompletableFuture<List<KaGraphValidationResult>>()
+    var job: Job? = null
+    validationService.setBeforeValidationPublicationObserver { _, _ ->
+      publicationReady.countDown()
+      releasePublication.await()
+    }
+    try {
+      val startedJob =
+        validationService.validateWithExtensionsAsync(graph) { delivered.complete(it) }
+      job = startedJob
+      startedJob.invokeOnCompletion { failure ->
+        if (failure != null) startupFailure.set(failure)
+        publicationReady.countDown()
+      }
+      assertTrue(publicationReady.await(30, TimeUnit.SECONDS))
+      startupFailure.get()?.let { throw AssertionError(it) }
+      UIUtil.dispatchAllInvocationEvents()
+
+      assertEquals(1, snapshots.size)
+      val active = snapshots.single().single()
+      assertEquals(1, active.completed)
+      assertEquals(2, active.total)
+
+      releasePublication.countDown()
+      PlatformTestUtil.waitForFuture(delivered, 30_000)
+      PlatformTestUtil.waitForFuture(terminal, 30_000)
+      val completed = CompletableFuture<Unit>()
+      startedJob.invokeOnCompletion { completed.complete(Unit) }
+      PlatformTestUtil.waitForFuture(completed, 30_000)
+      UIUtil.dispatchAllInvocationEvents()
+
+      assertEquals(2, snapshots.size)
+      assertTrue(snapshots.last().isEmpty())
+    } finally {
+      releasePublication.countDown()
+      job?.cancel()
+      validationService.setBeforeValidationPublicationObserver(null)
+    }
+  }
+
   fun testResultsSurviveIndexInvalidationAsStale() {
     val file =
       myFixture.configureMetroFile(
@@ -4222,14 +4535,26 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
     val result = validationService.validate(file, context)
     assertFalse(validationService.cachedResult(file, context)!!.stale)
 
-    // Any PSI change invalidates the index; the result must stay visible, flagged stale
-    myFixture.openFileInEditor(file.virtualFile)
-    myFixture.type(" ")
+    // A new binding invalidates the index while the previous validation stays visible as stale.
+    val document = checkNotNull(PsiDocumentManager.getInstance(project).getDocument(file))
+    WriteCommandAction.runWriteCommandAction(project) {
+      document.insertString(document.textLength, "\n\n@Inject class AddedBinding")
+    }
     PsiDocumentManager.getInstance(project).commitAllDocuments()
-    project.service<MetroResolutionService>().awaitIndex(file)
     val cached = validationService.cachedResult(file, context)!!
     assertSame(result, cached.result)
     assertTrue(cached.stale)
+
+    val rebuiltIndex = project.service<MetroResolutionService>().awaitIndex(file)
+    assertNotSame(index.generationToken, rebuiltIndex.generationToken)
+    val rebuiltGraph = rebuiltIndex.graphs.single()
+    val rebuiltContext = rebuiltIndex.contextsFor(rebuiltGraph).single()
+    val rebuiltResult = validationService.validate(file, rebuiltContext)
+    assertNotSame(result, rebuiltResult)
+    assertSame(rebuiltResult, validationService.validate(file, rebuiltContext))
+    val rebuiltCached = validationService.cachedResult(file, rebuiltContext)!!
+    assertSame(rebuiltResult, rebuiltCached.result)
+    assertFalse(rebuiltCached.stale)
   }
 
   fun testValidationCancelsWhenRetainedGraphDisappears() {


### PR DESCRIPTION
Cancel an earlier validation when another request starts for the same graph, and discard results if the index changed while validation was running. This prevents an old validation result from replacing a newer one.

Keep lookup caches within each validation run and release them when it finishes. Use the same approach when exporting graph debug data.
