### PR TITLE
Beef up IrAnnotation equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changelog
 - **[IR]** Fix a runtime crash when an assisted-injected class with no assisted parameters is used across modules with IR class generation.
 - **[IR]** Fix missing bindings for internal contributed objects across modules when `generateContributionProviders`, `generateClassesInIr`, and `contributesAsInject` are enabled together.
 - **[IR]** Report missing required graph bindings even when an `@OptionalBinding` accessor requests the same type, regardless of declaration order.
+- **[IR]** Compare annotation values structurally so hash collisions don't merge distinct bindings.
+- **[IR]** Preserve JVM array component types and dimensions in source class-literal qualifiers.
+- **[IR]** Resolve JVM binary annotation defaults on Kotlin `2.3.0` and `2.3.10`.
 - **[IR/interop]** Fix `Class`-keyed maps wrapped in providers or lazy values when `KClass`/`Class` interop is enabled.
 - **[IR/interop]** Fix a runtime `ClassCastException` when a `Class`-keyed map is injected into a provider-created class across modules with `KClass`/`Class` interop enabled.
 - **[IR/interop]** Respect `@GraphPrivate` on Dagger `@BindsOptionalOf` declarations inherited by graph extensions, while preserving public declarations for the same key.
@@ -28,6 +31,7 @@ Changelog
 
 ### Changes
 
+- **[IR]** Annotation default matching is limited for KLIB dependencies on Kotlin `2.3.0` and `2.3.10`. We recommend upgrading to Kotlin `2.3.20` or newer.
 - Test Kotlin `2.4.20-RC2`.
 - Test Kotlin `2.4.20-RC3`.
 - Update embedded Okio dependency to `3.18.2`.

--- a/compiler-tests/src/test/data/box/dependencygraph/ArrayClassQualifiers.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/ArrayClassQualifiers.kt
@@ -1,0 +1,34 @@
+// METRO_JVM_ONLY
+
+import kotlin.reflect.KClass
+
+@Qualifier
+annotation class ArrayClass(val value: KClass<*>)
+
+@BindingContainer
+object ArrayValues {
+  @Provides @ArrayClass(Array<String>::class) fun strings(): String = "strings"
+  @Provides @ArrayClass(Array<Int?>::class) fun ints(): String = "ints"
+  @Provides @ArrayClass(Array<Array<String>>::class) fun nested(): String = "nested"
+  @Provides @ArrayClass(IntArray::class) fun primitives(): String = "primitives"
+  @Provides @ArrayClass(Array<IntArray>::class) fun nestedPrimitives(): String = "nested primitives"
+  @Provides @ArrayClass(Array<Any>::class) fun any(): String = "any"
+}
+
+// JVM array class qualifiers keep their component types and dimensions.
+@DependencyGraph(bindingContainers = [ArrayValues::class])
+interface AppGraph {
+  @ArrayClass(Array<String>::class) val strings: String
+  @ArrayClass(Array<Int>::class) val ints: String
+  @ArrayClass(Array<Array<String>>::class) val nested: String
+  @ArrayClass(IntArray::class) val primitives: String
+  @ArrayClass(Array<IntArray>::class) val nestedPrimitives: String
+  @ArrayClass(Array<Any>::class) val any: String
+}
+
+fun box(): String {
+  val expected = listOf("strings", "ints", "nested", "primitives", "nested primitives", "any")
+  val graph = createGraph<AppGraph>()
+  assertEquals(expected, listOf(graph.strings, graph.ints, graph.nested, graph.primitives, graph.nestedPrimitives, graph.any))
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/dependencygraph/ArrayClassQualifiersJs.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/ArrayClassQualifiersJs.kt
@@ -1,0 +1,31 @@
+// TARGET_BACKEND: JS_IR
+
+import kotlin.reflect.KClass
+
+@Qualifier
+annotation class ArrayClass(val value: KClass<*>)
+
+typealias Strings = Array<String>
+typealias Ints = Array<Int>
+typealias StringMatrix = Array<Array<String>>
+
+@BindingContainer
+object ArrayValues {
+  @Provides @ArrayClass(Strings::class) fun value(): String = "value"
+}
+
+// JavaScript uses one Array class for every component type and dimension.
+@DependencyGraph(bindingContainers = [ArrayValues::class])
+interface AppGraph {
+  @ArrayClass(Ints::class) val differentComponent: String
+  @ArrayClass(StringMatrix::class) val differentDimension: String
+}
+
+fun box(): String {
+  assertEquals<KClass<*>>(Strings::class, Ints::class)
+  assertEquals<KClass<*>>(Strings::class, StringMatrix::class)
+  val graph = createGraph<AppGraph>()
+  assertEquals("value", graph.differentComponent)
+  assertEquals("value", graph.differentDimension)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/dependencygraph/QualifierArrayDefaultsAcrossModules.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/QualifierArrayDefaultsAcrossModules.kt
@@ -1,0 +1,48 @@
+// MIN_JS_COMPILER_VERSION: 2.3.20
+// Kotlin 2.3.0 and 2.3.10 replace omitted array arguments with empty arrays in KLIB metadata.
+// MODULE: lib
+// FILE: Values.kt
+
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.Qualifier
+
+@Qualifier
+annotation class ArrayKey(val names: Array<String> = ["first", "second"], val numbers: IntArray = [1, 2])
+
+@BindingContainer
+object Values {
+  @Provides @ArrayKey fun array(): String = "array"
+  @Provides @ArrayKey(["second", "first"]) fun otherArray(): String = "other array"
+  @Provides @ArrayKey([], []) fun emptyArrays(): String = "empty arrays"
+  @Provides @ArrayKey(names = []) fun emptyNames(): String = "empty names"
+  @Provides @ArrayKey(numbers = []) fun emptyNumbers(): String = "empty numbers"
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.createGraph
+import kotlin.test.assertEquals
+
+@DependencyGraph(bindingContainers = [Values::class])
+interface AppGraph {
+  @ArrayKey(["first", "second"], [1, 2]) val array: String
+  @ArrayKey val omittedArray: String
+  @ArrayKey(["second", "first"], [1, 2]) val otherArray: String
+  @ArrayKey([], []) val emptyArrays: String
+  @ArrayKey([], [1, 2]) val emptyNames: String
+  @ArrayKey(["first", "second"], []) val emptyNumbers: String
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertEquals("array", graph.array)
+  assertEquals(graph.array, graph.omittedArray)
+  assertEquals("other array", graph.otherArray)
+  assertEquals("empty arrays", graph.emptyArrays)
+  assertEquals("empty names", graph.emptyNames)
+  assertEquals("empty numbers", graph.emptyNumbers)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/dependencygraph/QualifierDefaultsAcrossModules.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/QualifierDefaultsAcrossModules.kt
@@ -1,0 +1,108 @@
+// MIN_JS_COMPILER_VERSION: 2.3.20
+// MODULE: lib
+// FILE: Qualifiers.kt
+
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.Qualifier
+import kotlin.reflect.KClass
+
+enum class Choice { FIRST, SECOND }
+
+annotation class Nested(val value: String = "nested")
+
+@Qualifier
+annotation class ScalarKey(val text: String = "", val count: Int = 0, val enabled: Boolean = false)
+
+@Qualifier
+annotation class EnumKey(val value: Choice = Choice.FIRST)
+
+@Qualifier
+annotation class NestedKey(val value: Nested = Nested())
+
+@Qualifier
+annotation class ArrayKey(val names: Array<String> = ["first", "second"], val numbers: IntArray = [1, 2])
+
+@Qualifier
+annotation class ClassKey(val value: KClass<*> = String::class)
+
+@Qualifier
+annotation class NothingKey(val value: KClass<*> = Nothing::class)
+
+@BindingContainer
+object Values {
+  @Provides @ScalarKey fun scalar(): String = "scalar"
+  @Provides @ScalarKey(count = 1) fun otherScalar(): String = "other scalar"
+  @Provides @EnumKey fun enum(): String = "enum"
+  @Provides @EnumKey(Choice.SECOND) fun otherEnum(): String = "other enum"
+  @Provides @NestedKey fun nested(): String = "nested"
+  @Provides @NestedKey(Nested("other")) fun otherNested(): String = "other nested"
+  @Provides @ClassKey fun classLiteral(): String = "class"
+  @Provides @NothingKey fun nothingLiteral(): String = "nothing"
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.createGraph
+import kotlin.test.assertEquals
+
+// Kotlin 2.3.0 replaces omitted array arguments with empty arrays in KLIB metadata.
+@BindingContainer
+object ArrayValues {
+  @Provides @ArrayKey fun array(): String = "array"
+  @Provides @ArrayKey(["second", "first"]) fun otherArray(): String = "other array"
+  @Provides @ArrayKey([], []) fun emptyArrays(): String = "empty arrays"
+  @Provides @ArrayKey(names = []) fun emptyNames(): String = "empty names"
+  @Provides @ArrayKey(numbers = []) fun emptyNumbers(): String = "empty numbers"
+}
+
+@DependencyGraph(bindingContainers = [Values::class, ArrayValues::class])
+interface AppGraph {
+  @ScalarKey("", 0, false) val scalar: String
+  @ScalarKey val omittedScalar: String
+  @ScalarKey("", 1, false) val otherScalar: String
+  @EnumKey(Choice.FIRST) val enum: String
+  @EnumKey val omittedEnum: String
+  @EnumKey(Choice.SECOND) val otherEnum: String
+  @NestedKey(Nested("nested")) val nested: String
+  @NestedKey val omittedNested: String
+  @NestedKey(Nested("other")) val otherNested: String
+  @ArrayKey(["first", "second"], [1, 2]) val array: String
+  @ArrayKey val omittedArray: String
+  @ArrayKey(["second", "first"], [1, 2]) val otherArray: String
+  @ArrayKey([], []) val emptyArrays: String
+  @ArrayKey([], [1, 2]) val emptyNames: String
+  @ArrayKey(["first", "second"], []) val emptyNumbers: String
+  @ClassKey(String::class) val classLiteral: String
+  @ClassKey val omittedClassLiteral: String
+  @NothingKey(Nothing::class) val nothingLiteral: String
+  @NothingKey val omittedNothingLiteral: String
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertEquals("scalar", graph.scalar)
+  assertEquals(graph.scalar, graph.omittedScalar)
+  assertEquals("other scalar", graph.otherScalar)
+  assertEquals("enum", graph.enum)
+  assertEquals(graph.enum, graph.omittedEnum)
+  assertEquals("other enum", graph.otherEnum)
+  assertEquals("nested", graph.nested)
+  assertEquals(graph.nested, graph.omittedNested)
+  assertEquals("other nested", graph.otherNested)
+  assertEquals("array", graph.array)
+  assertEquals(graph.array, graph.omittedArray)
+  assertEquals("other array", graph.otherArray)
+  assertEquals("empty arrays", graph.emptyArrays)
+  assertEquals("empty names", graph.emptyNames)
+  assertEquals("empty numbers", graph.emptyNumbers)
+  assertEquals("class", graph.classLiteral)
+  assertEquals(graph.classLiteral, graph.omittedClassLiteral)
+  assertEquals("nothing", graph.nothingLiteral)
+  assertEquals(graph.nothingLiteral, graph.omittedNothingLiteral)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/dependencygraph/QualifierDefaultsFromSource.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/QualifierDefaultsFromSource.kt
@@ -1,0 +1,47 @@
+@Qualifier
+annotation class ScalarKey(val text: String = "", val count: Int = 0, val enabled: Boolean = false)
+
+annotation class Nested(val value: String = "nested", vararg val names: String)
+
+@Qualifier
+annotation class NestedKey(val value: Nested = Nested())
+
+@Qualifier
+annotation class ArrayKey(val names: Array<String> = ["first", "second"], val numbers: IntArray = [1, 2])
+
+@BindingContainer
+object Values {
+  @Provides @ScalarKey fun scalar(): String = "scalar"
+  @Provides @ScalarKey(count = 1) fun otherScalar(): String = "other scalar"
+  @Provides @NestedKey fun nested(): String = "nested"
+  @Provides @NestedKey(Nested(names = ["name"])) fun namedNested(): String = "named nested"
+  @Provides @ArrayKey fun array(): String = "array"
+  @Provides @ArrayKey([], []) fun emptyArrays(): String = "empty arrays"
+}
+
+@DependencyGraph(bindingContainers = [Values::class])
+interface AppGraph {
+  @ScalarKey("", 0, false) val scalar: String
+  @ScalarKey val omittedScalar: String
+  @ScalarKey("", 1, false) val otherScalar: String
+  @NestedKey(Nested("nested", names = [])) val nested: String
+  @NestedKey val omittedNested: String
+  @NestedKey(Nested("nested", "name")) val namedNested: String
+  @ArrayKey(["first", "second"], [1, 2]) val array: String
+  @ArrayKey val omittedArray: String
+  @ArrayKey([], []) val emptyArrays: String
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertEquals("scalar", graph.scalar)
+  assertEquals(graph.scalar, graph.omittedScalar)
+  assertEquals("other scalar", graph.otherScalar)
+  assertEquals("nested", graph.nested)
+  assertEquals(graph.nested, graph.omittedNested)
+  assertEquals("named nested", graph.namedNested)
+  assertEquals("array", graph.array)
+  assertEquals(graph.array, graph.omittedArray)
+  assertEquals("empty arrays", graph.emptyArrays)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/dependencygraph/QualifierExplicitValuesAcrossModules.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/QualifierExplicitValuesAcrossModules.kt
@@ -1,0 +1,77 @@
+// MODULE: lib
+// FILE: Values.kt
+
+import kotlin.reflect.KClass
+
+enum class Choice { FIRST, SECOND }
+
+annotation class Nested(val value: String = "nested")
+
+@Qualifier
+annotation class ScalarKey(val text: String = "", val count: Int = 0, val enabled: Boolean = false)
+
+@Qualifier
+annotation class EnumKey(val value: Choice = Choice.FIRST)
+
+@Qualifier
+annotation class StructuredKey(
+  val value: Nested = Nested(),
+  val names: Array<String> = ["Aa", "BB"],
+  val numbers: IntArray = [1, 2],
+)
+
+@Qualifier
+annotation class ClassKey(val value: KClass<*> = String::class)
+
+// Explicit values keep these keys usable when the dependency's defaults aren't available.
+@BindingContainer
+object Values {
+  @Provides @ScalarKey("", 0, false) fun scalar(): String = "scalar"
+  @Provides @ScalarKey("", 1, false) fun otherScalar(): String = "other scalar"
+  @Provides @EnumKey(Choice.FIRST) fun enum(): String = "enum"
+  @Provides @EnumKey(Choice.SECOND) fun otherEnum(): String = "other enum"
+
+  @Provides @StructuredKey(Nested("Aa"), ["Aa", "BB"], [1, 2])
+  fun first(): String = "first"
+
+  @Provides @StructuredKey(Nested("BB"), ["Aa", "BB"], [1, 2])
+  fun hashCollision(): String = "hash collision"
+
+  @Provides @StructuredKey(Nested("Aa"), ["BB", "Aa"], [1, 2])
+  fun arrayOrder(): String = "array order"
+
+  @Provides @StructuredKey(Nested("Aa"), [], [])
+  fun emptyArrays(): String = "empty arrays"
+
+  @Provides @ClassKey(String::class) fun classLiteral(): String = "class"
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+
+@DependencyGraph(bindingContainers = [Values::class])
+interface AppGraph {
+  @ScalarKey("", 0, false) val scalar: String
+  @ScalarKey("", 1, false) val otherScalar: String
+  @EnumKey(Choice.FIRST) val enum: String
+  @EnumKey(Choice.SECOND) val otherEnum: String
+  @StructuredKey(Nested("Aa"), ["Aa", "BB"], [1, 2]) val first: String
+  @StructuredKey(Nested("BB"), ["Aa", "BB"], [1, 2]) val hashCollision: String
+  @StructuredKey(Nested("Aa"), ["BB", "Aa"], [1, 2]) val arrayOrder: String
+  @StructuredKey(Nested("Aa"), [], []) val emptyArrays: String
+  @ClassKey(String::class) val classLiteral: String
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertEquals("scalar", graph.scalar)
+  assertEquals("other scalar", graph.otherScalar)
+  assertEquals("enum", graph.enum)
+  assertEquals("other enum", graph.otherEnum)
+  assertEquals("first", graph.first)
+  assertEquals("hash collision", graph.hashCollision)
+  assertEquals("array order", graph.arrayOrder)
+  assertEquals("empty arrays", graph.emptyArrays)
+  assertEquals("class", graph.classLiteral)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/dependencygraph/QualifierHashCollisions.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/QualifierHashCollisions.kt
@@ -1,0 +1,57 @@
+// MIN_JS_COMPILER_VERSION: 2.3.20
+// MODULE: lib
+@Qualifier
+annotation class NamedValue(val value: String)
+
+annotation class NestedValue(val value: String)
+
+@Qualifier
+annotation class StructuredValue(
+  val nested: NestedValue,
+  val names: Array<String>,
+  val suffix: String = "default",
+)
+
+@BindingContainer
+object Values {
+  @Provides @NamedValue("Aa") fun first(): String = "first"
+  @Provides @NamedValue("BB") fun second(): String = "second"
+
+  @Provides
+  @StructuredValue(NestedValue("Aa"), ["Aa", "BB"])
+  fun nestedFirst(): String = "nested first"
+
+  @Provides
+  @StructuredValue(NestedValue("BB"), ["Aa", "BB"])
+  fun nestedSecond(): String = "nested second"
+
+  @Provides
+  @StructuredValue(NestedValue("Aa"), ["BB", "Aa"])
+  fun arrayOrder(): String = "array order"
+}
+
+// MODULE: main(lib)
+@DependencyGraph(bindingContainers = [Values::class])
+interface AppGraph {
+  @NamedValue("Aa") val first: String
+  @NamedValue("BB") val second: String
+
+  @StructuredValue(NestedValue("Aa"), ["Aa", "BB"], "default")
+  val nestedFirst: String
+
+  @StructuredValue(NestedValue("BB"), ["Aa", "BB"])
+  val nestedSecond: String
+
+  @StructuredValue(NestedValue("Aa"), ["BB", "Aa"])
+  val arrayOrder: String
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertEquals("first", graph.first)
+  assertEquals("second", graph.second)
+  assertEquals("nested first", graph.nestedFirst)
+  assertEquals("nested second", graph.nestedSecond)
+  assertEquals("array order", graph.arrayOrder)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/box/dependencygraph/QualifierOmittedDefaultsAcrossModules.kt
+++ b/compiler-tests/src/test/data/box/dependencygraph/QualifierOmittedDefaultsAcrossModules.kt
@@ -1,0 +1,39 @@
+// MODULE: lib
+// FILE: Values.kt
+
+@Qualifier
+annotation class ScalarKey(val value: String = "default")
+
+annotation class Nested(val value: String = "nested")
+
+@Qualifier
+annotation class NestedKey(val value: Nested)
+
+@BindingContainer
+object Values {
+  @Provides @ScalarKey fun binary(): String = "binary"
+  @Provides @NestedKey(Nested()) fun nested(): Long = 42L
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+
+// Matching omissions remain usable when dependency defaults aren't available.
+@DependencyGraph(bindingContainers = [Values::class])
+interface AppGraph {
+  @ScalarKey val binary: String
+  @ScalarKey val source: Int
+  @NestedKey(Nested()) val nested: Long
+
+  companion object {
+    @Provides @ScalarKey fun source(): Int = 1
+  }
+}
+
+fun box(): String {
+  val graph = createGraph<AppGraph>()
+  assertEquals("binary", graph.binary)
+  assertEquals(1, graph.source)
+  assertEquals(42L, graph.nested)
+  return "OK"
+}

--- a/compiler-tests/src/test/data/diagnostic/aggregation/EqualMapContributionPriorities.ir.diag.txt
+++ b/compiler-tests/src/test/data/diagnostic/aggregation/EqualMapContributionPriorities.ir.diag.txt
@@ -1,13 +1,13 @@
 /EqualMapContributionPriorities.kt:19:7: error: [Metro/DuplicateMapKeys] Duplicate map keys found for multibinding Map<String, Service>
 
   The following bindings contribute the same map key '@dev.zacsweers.metro.StringKey("shared")'
-      EqualMapContributionPriorities.kt:7:1
-        FirstService contributes a binding of Service
-        ~~~~~~~~~~~~                          ~~~~~~~
-
       EqualMapContributionPriorities.kt:12:1
         SecondService contributes a binding of Service
         ~~~~~~~~~~~~~                          ~~~~~~~
+
+      EqualMapContributionPriorities.kt:7:1
+        FirstService contributes a binding of Service
+        ~~~~~~~~~~~~                          ~~~~~~~
 
   trace (in AppGraph):
       Map<String, Service> is requested at AppGraph.services

--- a/compiler-tests/src/test/data/diagnostic/ideaParity/_reports/AggregationGraph/graph-metadata/graph-parity-aggregation-AppGraph.json.txt
+++ b/compiler-tests/src/test/data/diagnostic/ideaParity/_reports/AggregationGraph/graph-metadata/graph-parity-aggregation-AppGraph.json.txt
@@ -216,7 +216,7 @@
       "nameHint": "setOfEmptyElement",
       "dependencies": [],
       "isSynthetic": false,
-      "declaration": "emptyElements4205200196",
+      "declaration": "emptyElements995712408",
       "multibinding": {
         "type": "SET",
         "allowEmpty": true,
@@ -474,13 +474,13 @@
       "outcome": "selected",
       "candidates": [
         {
-          "id": "55:kotlin.collections.Set<parity.aggregation.EmptyElement>|167:parity.aggregation.AggregateBindings.BindsMirror.emptyElements4205200196(parity.aggregation.AggregateBindings): kotlin.collections.Set<parity.aggregation.EmptyElement>",
+          "id": "55:kotlin.collections.Set<parity.aggregation.EmptyElement>|166:parity.aggregation.AggregateBindings.BindsMirror.emptyElements995712408(parity.aggregation.AggregateBindings): kotlin.collections.Set<parity.aggregation.EmptyElement>",
           "key": "kotlin.collections.Set<parity.aggregation.EmptyElement>",
           "status": "selected",
           "reason": "selected_multibinding",
           "declaration": {
-            "id": "parity.aggregation.AggregateBindings.BindsMirror.emptyElements4205200196(parity.aggregation.AggregateBindings): kotlin.collections.Set<parity.aggregation.EmptyElement>",
-            "label": "parity.aggregation.AggregateBindings.BindsMirror.emptyElements4205200196"
+            "id": "parity.aggregation.AggregateBindings.BindsMirror.emptyElements995712408(parity.aggregation.AggregateBindings): kotlin.collections.Set<parity.aggregation.EmptyElement>",
+            "label": "parity.aggregation.AggregateBindings.BindsMirror.emptyElements995712408"
           },
           "relatedDeclarations": [],
           "details": []

--- a/compiler-tests/src/test/data/dump/ir/aggregation/ImplicitClassKeyPopulatedOnCopy.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/aggregation/ImplicitClassKeyPopulatedOnCopy.kt.txt
@@ -57,8 +57,8 @@ class ExplicitKeyImpl : Base {
       @Binds
       @IntoMap
       @ClassKey(value = Base::class)
-      @CallableMetadata(callableName = "bindIntoMapAsBase855602051", propertyName = "", startOffset = -1, endOffset = -1)
-      fun bindIntoMapAsBase855602051855602051_intomap(instance: ExplicitKeyImpl): Base {
+      @CallableMetadata(callableName = "bindIntoMapAsBase413204625", propertyName = "", startOffset = -1, endOffset = -1)
+      fun bindIntoMapAsBase413204625413204625_intomap(instance: ExplicitKeyImpl): Base {
         return error(message = "Never called")
       }
 
@@ -68,7 +68,7 @@ class ExplicitKeyImpl : Base {
     @Binds
     @ClassKey(value = Base::class)
     @ComptimeOnly
-    fun bindIntoMapAsBase855602051(instance: ExplicitKeyImpl): Base {
+    fun bindIntoMapAsBase413204625(instance: ExplicitKeyImpl): Base {
       return error(message = "Never called")
     }
 
@@ -139,8 +139,8 @@ class ImplicitKeyImpl : Base {
       @Binds
       @IntoMap
       @ClassKey(value = ImplicitKeyImpl::class)
-      @CallableMetadata(callableName = "bindIntoMapAsBase4194623803", propertyName = "", startOffset = -1, endOffset = -1)
-      fun bindIntoMapAsBase41946238031920108602_intomap(instance: ImplicitKeyImpl): Base {
+      @CallableMetadata(callableName = "bindIntoMapAsBase3780519993", propertyName = "", startOffset = -1, endOffset = -1)
+      fun bindIntoMapAsBase37805199931477711176_intomap(instance: ImplicitKeyImpl): Base {
         return error(message = "Never called")
       }
 
@@ -150,7 +150,7 @@ class ImplicitKeyImpl : Base {
     @Binds
     @ClassKey(value = ImplicitKeyImpl::class)
     @ComptimeOnly
-    fun bindIntoMapAsBase4194623803(instance: ImplicitKeyImpl): Base {
+    fun bindIntoMapAsBase3780519993(instance: ImplicitKeyImpl): Base {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/cycles/CycleMapGraph.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/cycles/CycleMapGraph.kt.txt
@@ -138,7 +138,7 @@ interface CycleMapGraph {
     @IntoMap
     @StringKey(value = "X")
     @CallableMetadata(callableName = "<get-x>", propertyName = "x", startOffset = 287, endOffset = 297)
-    fun X.x_property3540965534_intomap(): X {
+    fun X.x_property283785070_intomap(): X {
       return error(message = "Never called")
     }
 
@@ -146,7 +146,7 @@ interface CycleMapGraph {
     @IntoMap
     @StringKey(value = "Y")
     @CallableMetadata(callableName = "<get-y>", propertyName = "y", startOffset = 333, endOffset = 343)
-    fun Y.y_property3540965535_intomap(): Y {
+    fun Y.y_property283785101_intomap(): Y {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/dependencygraph/EmptyMapMultibindingsUseEmptyMap.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/dependencygraph/EmptyMapMultibindingsUseEmptyMap.kt.txt
@@ -11,7 +11,7 @@ interface AppGraph {
 
     @Multibinds(allowEmpty = true)
     @CallableMetadata(callableName = "<get-ints>", propertyName = "ints", startOffset = 135, endOffset = 161)
-    fun ints_property4205200196(): Map<String, Int> {
+    fun ints_property995712408(): Map<String, Int> {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/dependencygraph/MapBuildersUseInlineInstantiation.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/dependencygraph/MapBuildersUseInlineInstantiation.kt.txt
@@ -57,8 +57,8 @@ class IntHolderImpl : IntHolder {
       @Binds
       @IntoMap
       @IntKey(value = 3)
-      @CallableMetadata(callableName = "bindIntoMapAsIntHolder4013004651", propertyName = "", startOffset = -1, endOffset = -1)
-      fun bindIntoMapAsIntHolder40130046514013004651_intomap(instance: IntHolderImpl): IntHolder {
+      @CallableMetadata(callableName = "bindIntoMapAsIntHolder3311390791", propertyName = "", startOffset = -1, endOffset = -1)
+      fun bindIntoMapAsIntHolder33113907913311390791_intomap(instance: IntHolderImpl): IntHolder {
         return error(message = "Never called")
       }
 
@@ -68,7 +68,7 @@ class IntHolderImpl : IntHolder {
     @Binds
     @IntKey(value = 3)
     @ComptimeOnly
-    fun bindIntoMapAsIntHolder4013004651(instance: IntHolderImpl): IntHolder {
+    fun bindIntoMapAsIntHolder3311390791(instance: IntHolderImpl): IntHolder {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/dependencygraph/MapsUseMapBuilderIfNoProvider.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/dependencygraph/MapsUseMapBuilderIfNoProvider.kt.txt
@@ -11,7 +11,7 @@ interface AppGraph {
 
     @Multibinds
     @CallableMetadata(callableName = "<get-ints>", propertyName = "ints", startOffset = 83, endOffset = 106)
-    fun ints_property4205198935(): Map<Int, Int> {
+    fun ints_property3898158243(): Map<Int, Int> {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/dependencygraph/MixedUseFactoryAcrossMultipleNestedMiddleMultis.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/dependencygraph/MixedUseFactoryAcrossMultipleNestedMiddleMultis.kt.txt
@@ -74,7 +74,7 @@ interface AppGraph {
     @ElementsIntoSet
     @Named(name = "second")
     @CallableMetadata(callableName = "bindFirstAsSecond", propertyName = "", startOffset = 367, endOffset = 432)
-    fun bindFirstAsSecond1587700901_elementsintoset(@Named(name = "first") second: Set<Int>): Set<Int> {
+    fun bindFirstAsSecond1164059783_elementsintoset(@Named(name = "first") second: Set<Int>): Set<Int> {
       return error(message = "Never called")
     }
 
@@ -82,7 +82,7 @@ interface AppGraph {
     @IntoSet
     @Named(name = "first")
     @CallableMetadata(callableName = "bindIntAsFirstSet", propertyName = "", startOffset = 279, endOffset = 315)
-    fun bindIntAsFirstSet2591421153_intoset(int: Int): Int {
+    fun bindIntAsFirstSet2214616523_intoset(int: Int): Int {
       return error(message = "Never called")
     }
 
@@ -90,7 +90,7 @@ interface AppGraph {
     @ElementsIntoSet
     @Named(name = "final")
     @CallableMetadata(callableName = "bindSecondAsFinal", propertyName = "", startOffset = 483, endOffset = 549)
-    fun bindSecondAsFinal2591416743_elementsintoset(@Named(name = "second") second: Set<Int>): Set<Int> {
+    fun bindSecondAsFinal2214479813_elementsintoset(@Named(name = "second") second: Set<Int>): Set<Int> {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/multibindings/MapProvidersParticipateInProviderRefcounting.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/multibindings/MapProvidersParticipateInProviderRefcounting.kt.txt
@@ -22,7 +22,7 @@ interface AppGraph {
     @IntoMap
     @IntKey(value = 3)
     @CallableMetadata(callableName = "bindInt", propertyName = "", startOffset = 163, endOffset = 185)
-    fun Int.bindInt4013004651_intomap(): Int {
+    fun Int.bindInt3311390791_intomap(): Int {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/multibindings/MultibindingInParentMemberInjectedClass.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/multibindings/MultibindingInParentMemberInjectedClass.kt.txt
@@ -122,8 +122,8 @@ class AFragmentInjector : Injector {
       @Binds
       @IntoMap
       @ClassKey(value = AFragment::class)
-      @CallableMetadata(callableName = "bindIntoMapAsInjector3288387779", propertyName = "", startOffset = -1, endOffset = -1)
-      fun bindIntoMapAsInjector32883877793288387779_intomap(instance: AFragmentInjector): Injector {
+      @CallableMetadata(callableName = "bindIntoMapAsInjector2845990353", propertyName = "", startOffset = -1, endOffset = -1)
+      fun bindIntoMapAsInjector28459903532845990353_intomap(instance: AFragmentInjector): Injector {
         return error(message = "Never called")
       }
 
@@ -133,7 +133,7 @@ class AFragmentInjector : Injector {
     @Binds
     @ClassKey(value = AFragment::class)
     @ComptimeOnly
-    fun bindIntoMapAsInjector3288387779(instance: AFragmentInjector): Injector {
+    fun bindIntoMapAsInjector2845990353(instance: AFragmentInjector): Injector {
       return error(message = "Never called")
     }
 
@@ -204,8 +204,8 @@ class AViewModel : ViewModel {
       @Binds
       @IntoMap
       @ClassKey(value = AViewModel::class)
-      @CallableMetadata(callableName = "bindIntoMapAsViewModel2182965618", propertyName = "", startOffset = -1, endOffset = -1)
-      fun bindIntoMapAsViewModel21829656184203417713_intomap(instance: AViewModel): ViewModel {
+      @CallableMetadata(callableName = "bindIntoMapAsViewModel1768861808", propertyName = "", startOffset = -1, endOffset = -1)
+      fun bindIntoMapAsViewModel17688618083761020287_intomap(instance: AViewModel): ViewModel {
         return error(message = "Never called")
       }
 
@@ -215,7 +215,7 @@ class AViewModel : ViewModel {
     @Binds
     @ClassKey(value = AViewModel::class)
     @ComptimeOnly
-    fun bindIntoMapAsViewModel2182965618(instance: AViewModel): ViewModel {
+    fun bindIntoMapAsViewModel1768861808(instance: AViewModel): ViewModel {
       return error(message = "Never called")
     }
 
@@ -360,8 +360,8 @@ class BFragmentInjector : Injector {
       @Binds
       @IntoMap
       @ClassKey(value = BFragment::class)
-      @CallableMetadata(callableName = "bindIntoMapAsInjector3091874274", propertyName = "", startOffset = -1, endOffset = -1)
-      fun bindIntoMapAsInjector30918742743091874274_intomap(instance: BFragmentInjector): Injector {
+      @CallableMetadata(callableName = "bindIntoMapAsInjector2649476848", propertyName = "", startOffset = -1, endOffset = -1)
+      fun bindIntoMapAsInjector26494768482649476848_intomap(instance: BFragmentInjector): Injector {
         return error(message = "Never called")
       }
 
@@ -371,7 +371,7 @@ class BFragmentInjector : Injector {
     @Binds
     @ClassKey(value = BFragment::class)
     @ComptimeOnly
-    fun bindIntoMapAsInjector3091874274(instance: BFragmentInjector): Injector {
+    fun bindIntoMapAsInjector2649476848(instance: BFragmentInjector): Injector {
       return error(message = "Never called")
     }
 
@@ -442,8 +442,8 @@ class BViewModel : ViewModel {
       @Binds
       @IntoMap
       @ClassKey(value = BViewModel::class)
-      @CallableMetadata(callableName = "bindIntoMapAsViewModel386014259", propertyName = "", startOffset = -1, endOffset = -1)
-      fun bindIntoMapAsViewModel3860142592406466354_intomap(instance: BViewModel): ViewModel {
+      @CallableMetadata(callableName = "bindIntoMapAsViewModel4266877745", propertyName = "", startOffset = -1, endOffset = -1)
+      fun bindIntoMapAsViewModel42668777451964068928_intomap(instance: BViewModel): ViewModel {
         return error(message = "Never called")
       }
 
@@ -453,7 +453,7 @@ class BViewModel : ViewModel {
     @Binds
     @ClassKey(value = BViewModel::class)
     @ComptimeOnly
-    fun bindIntoMapAsViewModel386014259(instance: BViewModel): ViewModel {
+    fun bindIntoMapAsViewModel4266877745(instance: BViewModel): ViewModel {
       return error(message = "Never called")
     }
 
@@ -683,8 +683,8 @@ interface AppGraph {
       private get(): Provider<Map<KClass<*>, Injector>> {
         return { // BLOCK
           val tmp0_builder: MapFactory.Builder<KClass<*>, Injector> = MapFactory/* companion */.builder<KClass<*>, Injector>(size = 2)
-          tmp0_builder.put(key = BFragment::class, providerOfValue = BFragmentInjector.MetroFactory/* companion */.create(memberInjector = InstanceFactory/* companion */.invoke<MembersInjector<BFragment>>(value = BFragment.MetroMembersInjector/* companion */.create(viewModelFactory = <this>.#viewModelFactoryProvider))))
           tmp0_builder.put(key = AFragment::class, providerOfValue = AFragmentInjector.MetroFactory/* companion */.create(memberInjector = InstanceFactory/* companion */.invoke<MembersInjector<AFragment>>(value = AFragment.MetroMembersInjector/* companion */.create(viewModelFactory = <this>.#viewModelFactoryProvider))))
+          tmp0_builder.put(key = BFragment::class, providerOfValue = BFragmentInjector.MetroFactory/* companion */.create(memberInjector = InstanceFactory/* companion */.invoke<MembersInjector<BFragment>>(value = BFragment.MetroMembersInjector/* companion */.create(viewModelFactory = <this>.#viewModelFactoryProvider))))
           tmp0_builder.build()
         }
       }

--- a/compiler-tests/src/test/data/dump/ir/multibindings/MultibindingProviderAccessPropagatesRefCount.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/multibindings/MultibindingProviderAccessPropagatesRefCount.kt.txt
@@ -425,7 +425,7 @@ interface TestGraph {
     @IntoMap
     @IntKey(value = 1)
     @CallableMetadata(callableName = "bindB", propertyName = "", startOffset = 976, endOffset = 992)
-    fun B.bindB4013004649_intomap(): B {
+    fun B.bindB3311390729_intomap(): B {
       return error(message = "Never called")
     }
 
@@ -433,7 +433,7 @@ interface TestGraph {
     @IntoMap
     @IntKey(value = 1)
     @CallableMetadata(callableName = "bindC", propertyName = "", startOffset = 1077, endOffset = 1093)
-    fun C.bindC4013004649_intomap(): C {
+    fun C.bindC3311390729_intomap(): C {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/multibindings/SingletonMapFactory.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/multibindings/SingletonMapFactory.kt.txt
@@ -13,7 +13,7 @@ interface AppGraph {
     @IntoMap
     @IntKey(value = 1)
     @CallableMetadata(callableName = "bindValue", propertyName = "", startOffset = 292, endOffset = 316)
-    fun Int.bindValue4013004649_intomap(): Int {
+    fun Int.bindValue3311390729_intomap(): Int {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/multibindings/SingletonMapLazyFactory.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/multibindings/SingletonMapLazyFactory.kt.txt
@@ -13,7 +13,7 @@ interface AppGraph {
     @IntoMap
     @IntKey(value = 1)
     @CallableMetadata(callableName = "bindValue", propertyName = "", startOffset = 302, endOffset = 326)
-    fun Int.bindValue4013004649_intomap(): Int {
+    fun Int.bindValue3311390729_intomap(): Int {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/multibindings/SingletonMapProviderFactory.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/multibindings/SingletonMapProviderFactory.kt.txt
@@ -13,7 +13,7 @@ interface AppGraph {
     @IntoMap
     @IntKey(value = 1)
     @CallableMetadata(callableName = "bindValue", propertyName = "", startOffset = 310, endOffset = 334)
-    fun Int.bindValue4013004649_intomap(): Int {
+    fun Int.bindValue3311390729_intomap(): Int {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/data/dump/ir/multibindings/SingletonMapProviderLazyFactory.kt.txt
+++ b/compiler-tests/src/test/data/dump/ir/multibindings/SingletonMapProviderLazyFactory.kt.txt
@@ -13,7 +13,7 @@ interface AppGraph {
     @IntoMap
     @IntKey(value = 1)
     @CallableMetadata(callableName = "bindValue", propertyName = "", startOffset = 320, endOffset = 344)
-    fun Int.bindValue4013004649_intomap(): Int {
+    fun Int.bindValue3311390729_intomap(): Int {
       return error(message = "Never called")
     }
 

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/BoxTestGenerated.java
@@ -1343,6 +1343,18 @@ public class BoxTestGenerated extends AbstractBoxTest {
     }
 
     @Test
+    @TestMetadata("ArrayClassQualifiers.kt")
+    public void testArrayClassQualifiers() {
+      run("ArrayClassQualifiers.kt");
+    }
+
+    @Test
+    @TestMetadata("ArrayClassQualifiersJs.kt")
+    public void testArrayClassQualifiersJs() {
+      run("ArrayClassQualifiersJs.kt");
+    }
+
+    @Test
     @TestMetadata("ContributedAccessorsCanBeLazy.kt")
     public void testContributedAccessorsCanBeLazy() {
       run("ContributedAccessorsCanBeLazy.kt");
@@ -1568,6 +1580,42 @@ public class BoxTestGenerated extends AbstractBoxTest {
     @TestMetadata("ProvidingMapsDirectly.kt")
     public void testProvidingMapsDirectly() {
       run("ProvidingMapsDirectly.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierArrayDefaultsAcrossModules.kt")
+    public void testQualifierArrayDefaultsAcrossModules() {
+      run("QualifierArrayDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsAcrossModules.kt")
+    public void testQualifierDefaultsAcrossModules() {
+      run("QualifierDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsFromSource.kt")
+    public void testQualifierDefaultsFromSource() {
+      run("QualifierDefaultsFromSource.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierExplicitValuesAcrossModules.kt")
+    public void testQualifierExplicitValuesAcrossModules() {
+      run("QualifierExplicitValuesAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierHashCollisions.kt")
+    public void testQualifierHashCollisions() {
+      run("QualifierHashCollisions.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierOmittedDefaultsAcrossModules.kt")
+    public void testQualifierOmittedDefaultsAcrossModules() {
+      run("QualifierOmittedDefaultsAcrossModules.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/ContributionProvidersBoxTestGenerated.java
@@ -1343,6 +1343,18 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     }
 
     @Test
+    @TestMetadata("ArrayClassQualifiers.kt")
+    public void testArrayClassQualifiers() {
+      run("ArrayClassQualifiers.kt");
+    }
+
+    @Test
+    @TestMetadata("ArrayClassQualifiersJs.kt")
+    public void testArrayClassQualifiersJs() {
+      run("ArrayClassQualifiersJs.kt");
+    }
+
+    @Test
     @TestMetadata("ContributedAccessorsCanBeLazy.kt")
     public void testContributedAccessorsCanBeLazy() {
       run("ContributedAccessorsCanBeLazy.kt");
@@ -1568,6 +1580,42 @@ public class ContributionProvidersBoxTestGenerated extends AbstractContributionP
     @TestMetadata("ProvidingMapsDirectly.kt")
     public void testProvidingMapsDirectly() {
       run("ProvidingMapsDirectly.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierArrayDefaultsAcrossModules.kt")
+    public void testQualifierArrayDefaultsAcrossModules() {
+      run("QualifierArrayDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsAcrossModules.kt")
+    public void testQualifierDefaultsAcrossModules() {
+      run("QualifierDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsFromSource.kt")
+    public void testQualifierDefaultsFromSource() {
+      run("QualifierDefaultsFromSource.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierExplicitValuesAcrossModules.kt")
+    public void testQualifierExplicitValuesAcrossModules() {
+      run("QualifierExplicitValuesAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierHashCollisions.kt")
+    public void testQualifierHashCollisions() {
+      run("QualifierHashCollisions.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierOmittedDefaultsAcrossModules.kt")
+    public void testQualifierOmittedDefaultsAcrossModules() {
+      run("QualifierOmittedDefaultsAcrossModules.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/FastInitBoxTestGenerated.java
@@ -1343,6 +1343,18 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("ArrayClassQualifiers.kt")
+    public void testArrayClassQualifiers() {
+      run("ArrayClassQualifiers.kt");
+    }
+
+    @Test
+    @TestMetadata("ArrayClassQualifiersJs.kt")
+    public void testArrayClassQualifiersJs() {
+      run("ArrayClassQualifiersJs.kt");
+    }
+
+    @Test
     @TestMetadata("ContributedAccessorsCanBeLazy.kt")
     public void testContributedAccessorsCanBeLazy() {
       run("ContributedAccessorsCanBeLazy.kt");
@@ -1568,6 +1580,42 @@ public class FastInitBoxTestGenerated extends AbstractFastInitBoxTest {
     @TestMetadata("ProvidingMapsDirectly.kt")
     public void testProvidingMapsDirectly() {
       run("ProvidingMapsDirectly.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierArrayDefaultsAcrossModules.kt")
+    public void testQualifierArrayDefaultsAcrossModules() {
+      run("QualifierArrayDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsAcrossModules.kt")
+    public void testQualifierDefaultsAcrossModules() {
+      run("QualifierDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsFromSource.kt")
+    public void testQualifierDefaultsFromSource() {
+      run("QualifierDefaultsFromSource.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierExplicitValuesAcrossModules.kt")
+    public void testQualifierExplicitValuesAcrossModules() {
+      run("QualifierExplicitValuesAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierHashCollisions.kt")
+    public void testQualifierHashCollisions() {
+      run("QualifierHashCollisions.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierOmittedDefaultsAcrossModules.kt")
+    public void testQualifierOmittedDefaultsAcrossModules() {
+      run("QualifierOmittedDefaultsAcrossModules.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/IrOnlyClassesBoxTestGenerated.java
@@ -1343,6 +1343,18 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
     }
 
     @Test
+    @TestMetadata("ArrayClassQualifiers.kt")
+    public void testArrayClassQualifiers() {
+      run("ArrayClassQualifiers.kt");
+    }
+
+    @Test
+    @TestMetadata("ArrayClassQualifiersJs.kt")
+    public void testArrayClassQualifiersJs() {
+      run("ArrayClassQualifiersJs.kt");
+    }
+
+    @Test
     @TestMetadata("ContributedAccessorsCanBeLazy.kt")
     public void testContributedAccessorsCanBeLazy() {
       run("ContributedAccessorsCanBeLazy.kt");
@@ -1568,6 +1580,42 @@ public class IrOnlyClassesBoxTestGenerated extends AbstractIrOnlyClassesBoxTest 
     @TestMetadata("ProvidingMapsDirectly.kt")
     public void testProvidingMapsDirectly() {
       run("ProvidingMapsDirectly.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierArrayDefaultsAcrossModules.kt")
+    public void testQualifierArrayDefaultsAcrossModules() {
+      run("QualifierArrayDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsAcrossModules.kt")
+    public void testQualifierDefaultsAcrossModules() {
+      run("QualifierDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsFromSource.kt")
+    public void testQualifierDefaultsFromSource() {
+      run("QualifierDefaultsFromSource.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierExplicitValuesAcrossModules.kt")
+    public void testQualifierExplicitValuesAcrossModules() {
+      run("QualifierExplicitValuesAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierHashCollisions.kt")
+    public void testQualifierHashCollisions() {
+      run("QualifierHashCollisions.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierOmittedDefaultsAcrossModules.kt")
+    public void testQualifierOmittedDefaultsAcrossModules() {
+      run("QualifierOmittedDefaultsAcrossModules.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsBoxTestGenerated.java
@@ -1009,6 +1009,18 @@ public class JsBoxTestGenerated extends AbstractJsBoxTest {
     }
 
     @Test
+    @TestMetadata("ArrayClassQualifiers.kt")
+    public void testArrayClassQualifiers() {
+      run("ArrayClassQualifiers.kt");
+    }
+
+    @Test
+    @TestMetadata("ArrayClassQualifiersJs.kt")
+    public void testArrayClassQualifiersJs() {
+      run("ArrayClassQualifiersJs.kt");
+    }
+
+    @Test
     @TestMetadata("ContributedAccessorsCanBeLazy.kt")
     public void testContributedAccessorsCanBeLazy() {
       run("ContributedAccessorsCanBeLazy.kt");
@@ -1234,6 +1246,42 @@ public class JsBoxTestGenerated extends AbstractJsBoxTest {
     @TestMetadata("ProvidingMapsDirectly.kt")
     public void testProvidingMapsDirectly() {
       run("ProvidingMapsDirectly.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierArrayDefaultsAcrossModules.kt")
+    public void testQualifierArrayDefaultsAcrossModules() {
+      run("QualifierArrayDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsAcrossModules.kt")
+    public void testQualifierDefaultsAcrossModules() {
+      run("QualifierDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsFromSource.kt")
+    public void testQualifierDefaultsFromSource() {
+      run("QualifierDefaultsFromSource.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierExplicitValuesAcrossModules.kt")
+    public void testQualifierExplicitValuesAcrossModules() {
+      run("QualifierExplicitValuesAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierHashCollisions.kt")
+    public void testQualifierHashCollisions() {
+      run("QualifierHashCollisions.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierOmittedDefaultsAcrossModules.kt")
+    public void testQualifierOmittedDefaultsAcrossModules() {
+      run("QualifierOmittedDefaultsAcrossModules.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsContributionProvidersBoxTestGenerated.java
@@ -1009,6 +1009,18 @@ public class JsContributionProvidersBoxTestGenerated extends AbstractJsContribut
     }
 
     @Test
+    @TestMetadata("ArrayClassQualifiers.kt")
+    public void testArrayClassQualifiers() {
+      run("ArrayClassQualifiers.kt");
+    }
+
+    @Test
+    @TestMetadata("ArrayClassQualifiersJs.kt")
+    public void testArrayClassQualifiersJs() {
+      run("ArrayClassQualifiersJs.kt");
+    }
+
+    @Test
     @TestMetadata("ContributedAccessorsCanBeLazy.kt")
     public void testContributedAccessorsCanBeLazy() {
       run("ContributedAccessorsCanBeLazy.kt");
@@ -1234,6 +1246,42 @@ public class JsContributionProvidersBoxTestGenerated extends AbstractJsContribut
     @TestMetadata("ProvidingMapsDirectly.kt")
     public void testProvidingMapsDirectly() {
       run("ProvidingMapsDirectly.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierArrayDefaultsAcrossModules.kt")
+    public void testQualifierArrayDefaultsAcrossModules() {
+      run("QualifierArrayDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsAcrossModules.kt")
+    public void testQualifierDefaultsAcrossModules() {
+      run("QualifierDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsFromSource.kt")
+    public void testQualifierDefaultsFromSource() {
+      run("QualifierDefaultsFromSource.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierExplicitValuesAcrossModules.kt")
+    public void testQualifierExplicitValuesAcrossModules() {
+      run("QualifierExplicitValuesAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierHashCollisions.kt")
+    public void testQualifierHashCollisions() {
+      run("QualifierHashCollisions.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierOmittedDefaultsAcrossModules.kt")
+    public void testQualifierOmittedDefaultsAcrossModules() {
+      run("QualifierOmittedDefaultsAcrossModules.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/JsFastInitBoxTestGenerated.java
@@ -1009,6 +1009,18 @@ public class JsFastInitBoxTestGenerated extends AbstractJsFastInitBoxTest {
     }
 
     @Test
+    @TestMetadata("ArrayClassQualifiers.kt")
+    public void testArrayClassQualifiers() {
+      run("ArrayClassQualifiers.kt");
+    }
+
+    @Test
+    @TestMetadata("ArrayClassQualifiersJs.kt")
+    public void testArrayClassQualifiersJs() {
+      run("ArrayClassQualifiersJs.kt");
+    }
+
+    @Test
     @TestMetadata("ContributedAccessorsCanBeLazy.kt")
     public void testContributedAccessorsCanBeLazy() {
       run("ContributedAccessorsCanBeLazy.kt");
@@ -1234,6 +1246,42 @@ public class JsFastInitBoxTestGenerated extends AbstractJsFastInitBoxTest {
     @TestMetadata("ProvidingMapsDirectly.kt")
     public void testProvidingMapsDirectly() {
       run("ProvidingMapsDirectly.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierArrayDefaultsAcrossModules.kt")
+    public void testQualifierArrayDefaultsAcrossModules() {
+      run("QualifierArrayDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsAcrossModules.kt")
+    public void testQualifierDefaultsAcrossModules() {
+      run("QualifierDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsFromSource.kt")
+    public void testQualifierDefaultsFromSource() {
+      run("QualifierDefaultsFromSource.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierExplicitValuesAcrossModules.kt")
+    public void testQualifierExplicitValuesAcrossModules() {
+      run("QualifierExplicitValuesAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierHashCollisions.kt")
+    public void testQualifierHashCollisions() {
+      run("QualifierHashCollisions.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierOmittedDefaultsAcrossModules.kt")
+    public void testQualifierOmittedDefaultsAcrossModules() {
+      run("QualifierOmittedDefaultsAcrossModules.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/OmitRedundantMirrorsIrOnlyClassesBoxTestGenerated.java
+++ b/compiler-tests/src/test/java/dev/zacsweers/metro/compiler/OmitRedundantMirrorsIrOnlyClassesBoxTestGenerated.java
@@ -1343,6 +1343,18 @@ public class OmitRedundantMirrorsIrOnlyClassesBoxTestGenerated extends AbstractO
     }
 
     @Test
+    @TestMetadata("ArrayClassQualifiers.kt")
+    public void testArrayClassQualifiers() {
+      run("ArrayClassQualifiers.kt");
+    }
+
+    @Test
+    @TestMetadata("ArrayClassQualifiersJs.kt")
+    public void testArrayClassQualifiersJs() {
+      run("ArrayClassQualifiersJs.kt");
+    }
+
+    @Test
     @TestMetadata("ContributedAccessorsCanBeLazy.kt")
     public void testContributedAccessorsCanBeLazy() {
       run("ContributedAccessorsCanBeLazy.kt");
@@ -1568,6 +1580,42 @@ public class OmitRedundantMirrorsIrOnlyClassesBoxTestGenerated extends AbstractO
     @TestMetadata("ProvidingMapsDirectly.kt")
     public void testProvidingMapsDirectly() {
       run("ProvidingMapsDirectly.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierArrayDefaultsAcrossModules.kt")
+    public void testQualifierArrayDefaultsAcrossModules() {
+      run("QualifierArrayDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsAcrossModules.kt")
+    public void testQualifierDefaultsAcrossModules() {
+      run("QualifierDefaultsAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierDefaultsFromSource.kt")
+    public void testQualifierDefaultsFromSource() {
+      run("QualifierDefaultsFromSource.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierExplicitValuesAcrossModules.kt")
+    public void testQualifierExplicitValuesAcrossModules() {
+      run("QualifierExplicitValuesAcrossModules.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierHashCollisions.kt")
+    public void testQualifierHashCollisions() {
+      run("QualifierHashCollisions.kt");
+    }
+
+    @Test
+    @TestMetadata("QualifierOmittedDefaultsAcrossModules.kt")
+    public void testQualifierOmittedDefaultsAcrossModules() {
+      run("QualifierOmittedDefaultsAcrossModules.kt");
     }
 
     @Test

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroDirectives.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroDirectives.kt
@@ -15,6 +15,8 @@ object MetroDirectives : SimpleDirectivesContainer() {
   val DISABLE_METRO by directive("Disables metro entirely on this module compilation if present.")
   val COMPILER_VERSION by stringDirective("Target kotlin compiler version, if any")
   val MIN_COMPILER_VERSION by stringDirective("Minimum kotlin compiler version (inclusive), if any")
+  val MIN_JS_COMPILER_VERSION by
+    stringDirective("Minimum Kotlin compiler version for the JS backend (inclusive), if any")
   val MAX_COMPILER_VERSION by stringDirective("Maximum kotlin compiler version (inclusive), if any")
   // TODO eventually support multiple outputs
   val CUSTOM_TEST_DATA_PER_COMPILER_VERSION by

--- a/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroTestConfigurator.kt
+++ b/compiler-tests/src/test/kotlin/dev/zacsweers/metro/compiler/MetroTestConfigurator.kt
@@ -94,14 +94,15 @@ class MetroTestConfigurator(testServices: TestServices) : MetaTestConfigurator(t
     ) {
       return true
     }
+    val minimumVersions = directives[MetroDirectives.MIN_COMPILER_VERSION].toMutableList()
+    if (testServices.isJsBackend()) {
+      minimumVersions += directives[MetroDirectives.MIN_JS_COMPILER_VERSION]
+    }
     return shouldSkipForCompilerVersion(
       compilerVersion = COMPILER_VERSION,
       compilerToolingVersion = KotlinToolingVersion(COMPILER_TOOLING_VERSION),
       targetVersion = directives[MetroDirectives.COMPILER_VERSION].firstOrNull(),
-      minVersion =
-        directives[MetroDirectives.MIN_COMPILER_VERSION].maxByOrNull {
-          toolingVersionDirective(it).first
-        },
+      minVersion = minimumVersions.maxByOrNull { toolingVersionDirective(it).first },
       maxVersion = directives[MetroDirectives.MAX_COMPILER_VERSION].firstOrNull(),
     )
   }

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrAnnotation.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/IrAnnotation.kt
@@ -6,53 +6,198 @@ import dev.zacsweers.metro.compiler.appendIterableWith
 import dev.zacsweers.metro.compiler.memoize
 import dev.zacsweers.metro.compiler.reportCompilerBug
 import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrValueParameter
 import org.jetbrains.kotlin.ir.expressions.IrClassReference
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrConstKind
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
+import org.jetbrains.kotlin.ir.expressions.IrErrorExpression
+import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetEnumValue
+import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.IrVararg
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.types.typeOrNull
 import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.classIdOrFail
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.util.properties
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.StandardClassIds
+import org.jetbrains.kotlin.platform.jvm.isJvm
 
-internal class IrAnnotation(val ir: IrConstructorCall) : Comparable<IrAnnotation> {
-  private val cachedHashKey by memoize { ir.computeAnnotationHash() }
+private val JAVA_VOID_CLASS_ID = ClassId.topLevel(FqName("java.lang.Void"))
+
+/**
+ * An annotation key with platform-specific class-literal identity and source IR for diagnostics.
+ */
+internal class IrAnnotation
+private constructor(val ir: IrConstructorCall, context: IrMetroContext) : Comparable<IrAnnotation> {
+  private val identity by memoize {
+    ir.annotationIdentity(context.platform.isJvm())
+  }
+  private val cachedHashKey by memoize { identity.hashCode() }
   private val cachedToString by memoize { render(short = true) }
 
   override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
+    if (this === other) {
+      return true
+    }
+    if (other !is IrAnnotation) {
+      return false
+    }
 
-    other as IrAnnotation
-
-    return cachedHashKey == other.cachedHashKey
+    return cachedHashKey == other.cachedHashKey && identity == other.identity
   }
 
   override fun hashCode(): Int = cachedHashKey
 
   override fun toString() = cachedToString
 
-  override fun compareTo(other: IrAnnotation): Int = cachedToString.compareTo(other.cachedToString)
+  override fun compareTo(other: IrAnnotation): Int = identity.compareTo(other.identity)
 
   fun render(
     short: Boolean = true,
     useSiteTarget: String? = null,
     useRelativeClassNames: Boolean = false,
-  ): String {
-    return buildString {
-      append('@')
-      useSiteTarget?.let {
-        append(it)
-        append(":")
-      }
-      renderAsAnnotation(ir, short, useRelativeClassNames)
+  ): String = ir.renderAnnotation(short, useSiteTarget, useRelativeClassNames)
+
+  companion object {
+    /** Array class literals retain component types and dimensions on the JVM. */
+    context(context: IrMetroContext)
+    operator fun invoke(ir: IrConstructorCall): IrAnnotation {
+      return IrAnnotation(ir, context)
     }
   }
 }
 
+context(context: IrMetroContext)
 internal fun IrConstructorCall.asIrAnnotation() = IrAnnotation(this)
+
+/** Binds the compiler context for annotation factory references. */
+internal fun IrMetroContext.createIrAnnotation(ir: IrConstructorCall): IrAnnotation =
+  with(this) { IrAnnotation(ir) }
+
+/** Renders annotations without constructing their platform-specific identity. */
+internal fun IrConstructorCall.renderAnnotation(
+  short: Boolean = true,
+  useSiteTarget: String? = null,
+  useRelativeClassNames: Boolean = false,
+): String = buildString {
+  append('@')
+  useSiteTarget?.let {
+    append(it)
+    append(":")
+  }
+  renderAsAnnotation(this@renderAnnotation, short, useRelativeClassNames)
+}
+
+/**
+ * Keeps argument boundaries and kinds in annotation identity. Hash collisions and punctuation
+ * inside string values don't merge distinct qualifiers. Ordering uses the same structure.
+ */
+private data class AnnotationIdentity(
+  val kind: String,
+  val value: String = "",
+  val elements: List<AnnotationIdentity> = emptyList(),
+) : Comparable<AnnotationIdentity> {
+  override fun compareTo(other: AnnotationIdentity): Int {
+    val kindOrder = kind.compareTo(other.kind)
+    if (kindOrder != 0) {
+      return kindOrder
+    }
+    val valueOrder = value.compareTo(other.value)
+    if (valueOrder != 0) {
+      return valueOrder
+    }
+    for (index in 0 until minOf(elements.size, other.elements.size)) {
+      val elementOrder = elements[index].compareTo(other.elements[index])
+      if (elementOrder != 0) {
+        return elementOrder
+      }
+    }
+    return elements.size.compareTo(other.elements.size)
+  }
+}
+
+private fun IrConstructorCall.annotationIdentity(isJvm: Boolean): AnnotationIdentity {
+  val parameters = symbol.owner.parameters
+  val values = arguments.mapIndexed { index, argument ->
+    // Available defaults give explicit and omitted arguments the same identity.
+    val value = argument ?: annotationDefaultValue(parameters[index])
+    value.annotationArgumentIdentity(isJvm)
+  }
+  return AnnotationIdentity("annotation", annotationClass.classIdOrFail.asString(), values)
+}
+
+/** Reads constructor or property defaults when the compiler makes them available. */
+private fun IrConstructorCall.annotationDefaultValue(parameter: IrValueParameter): IrExpression? {
+  val parameterDefault = parameter.defaultValue?.expression
+  if (parameterDefault != null && parameterDefault !is IrErrorExpression) {
+    return parameterDefault
+  }
+
+  val property = annotationClass.properties.firstOrNull { it.name == parameter.name }
+  val initializer = property?.backingField?.initializer?.expression
+  val propertyDefault =
+    if (initializer is IrGetValue) {
+      val sourceParameter = initializer.symbol.owner as? IrValueParameter
+      sourceParameter?.defaultValue?.expression
+    } else {
+      initializer
+    }
+  if (propertyDefault != null && propertyDefault !is IrErrorExpression) {
+    return propertyDefault
+  }
+
+  // Unavailable Kotlin 2.3 KLIB defaults keep their omitted-value identity.
+  return null
+}
+
+private fun IrElement?.annotationArgumentIdentity(isJvm: Boolean): AnnotationIdentity =
+  when (this) {
+    null -> AnnotationIdentity("absent")
+    is IrConst -> AnnotationIdentity("constant:${kind}", value.toString())
+    is IrConstructorCall -> annotationIdentity(isJvm)
+    is IrVararg ->
+      AnnotationIdentity(
+        "array",
+        elements = elements.map { it.annotationArgumentIdentity(isJvm) },
+      )
+    is IrClassReference -> classType.annotationClassIdentity(isJvm)
+    is IrGetEnumValue ->
+      AnnotationIdentity(
+        "enum",
+        symbol.owner.parentAsClass.classIdOrFail.asString(),
+        listOf(AnnotationIdentity("entry", symbol.owner.name.asString())),
+      )
+    else ->
+      reportCompilerBug("Unrecognized annotation argument type: $this (type ${this::class.java})")
+  }
+
+private fun IrType.annotationClassIdentity(isJvm: Boolean): AnnotationIdentity {
+  val classId = classOrNull!!.owner.classIdOrFail
+  if (isJvm && classId == JAVA_VOID_CLASS_ID) {
+    // JVM annotation defaults can represent Nothing::class as java.lang.Void.
+    return AnnotationIdentity("class", StandardClassIds.Nothing.asString())
+  }
+  if (isJvm && classId == StandardClassIds.Array) {
+    // JVM array class literals retain their component types at runtime.
+    val componentType = (this as IrSimpleType).arguments.singleOrNull()?.typeOrNull
+    val componentIdentity =
+      if (componentType != null) {
+        componentType.annotationClassIdentity(isJvm)
+      } else {
+        AnnotationIdentity("class", StandardClassIds.Any.asString())
+      }
+    return AnnotationIdentity("class", classId.asString(), listOf(componentIdentity))
+  }
+  return AnnotationIdentity("class", classId.asString())
+}
 
 private fun StringBuilder.renderAsAnnotation(
   irAnnotation: IrConstructorCall,

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/ir.kt
@@ -37,7 +37,6 @@ import dev.zacsweers.metro.compiler.symbols.GuiceSymbols
 import dev.zacsweers.metro.compiler.symbols.Symbols
 import dev.zacsweers.metro.compiler.toSafeIdentifier
 import java.io.File
-import java.util.Objects
 import kotlin.io.path.name
 import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -111,7 +110,6 @@ import org.jetbrains.kotlin.ir.expressions.IrConstKind
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
-import org.jetbrains.kotlin.ir.expressions.IrGetEnumValue
 import org.jetbrains.kotlin.ir.expressions.IrMemberAccessExpression
 import org.jetbrains.kotlin.ir.expressions.IrStatementOrigin
 import org.jetbrains.kotlin.ir.expressions.IrVararg
@@ -165,7 +163,6 @@ import org.jetbrains.kotlin.ir.util.defaultType
 import org.jetbrains.kotlin.ir.util.dumpKotlinLike
 import org.jetbrains.kotlin.ir.util.file
 import org.jetbrains.kotlin.ir.util.fileOrNull
-import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.functions
 import org.jetbrains.kotlin.ir.util.getPackageFragment
 import org.jetbrains.kotlin.ir.util.getSimpleFunction
@@ -530,45 +527,6 @@ internal fun IrBuilderWithScope.irTemporaryVariable(
     )
   value?.let { temporary.initializer = it }
   return temporary
-}
-
-/**
- * Computes a hash key for this annotation instance composed of its underlying type and value
- * arguments.
- */
-internal fun IrConstructorCall.computeAnnotationHash(): Int {
-  return Objects.hash(
-    type.rawType().classIdOrFail,
-    arguments
-      .filterNotNull()
-      .map { arg ->
-        arg.computeHashSource()
-          ?: reportCompilerBug(
-            "Unknown annotation argument type: ${arg::class.java}. Annotation: ${dumpKotlinLike()}"
-          )
-      }
-      .toTypedArray()
-      .contentDeepHashCode(),
-  )
-}
-
-private fun IrExpression.computeHashSource(): Any? {
-  return when (this) {
-    is IrConst -> value
-    is IrClassReference -> classType.classOrNull?.owner?.classId
-    is IrGetEnumValue -> symbol.owner.fqNameWhenAvailable
-    is IrConstructorCall -> computeAnnotationHash()
-    is IrVararg -> {
-      elements.map {
-        when (it) {
-          is IrExpression -> it.computeHashSource()
-          else -> it
-        }
-      }
-    }
-
-    else -> null
-  }
 }
 
 // TODO create an instance of this that caches lookups?
@@ -1621,7 +1579,7 @@ internal fun IrType.renderTo(
   val type = this
   if (includeAnnotations && type.annotations.isNotEmpty()) {
     type.annotations.joinTo(appendable, separator = " ", postfix = " ") {
-      IrAnnotation(it).render(short, useRelativeClassNames = useRelativeClassNames)
+      it.renderAnnotation(short, useRelativeClassNames = useRelativeClassNames)
     }
   }
   when (type) {
@@ -2274,11 +2232,13 @@ internal fun IrConstructorCall.priority(): Int {
 
 context(context: IrMetroContext)
 internal fun IrProperty?.qualifierAnnotation(): IrAnnotation? {
-  if (this == null) return null
+  if (this == null) {
+    return null
+  }
   return allAnnotations
     .annotationsAnnotatedWith(context.metroSymbols.qualifierAnnotations)
     .singleOrNull()
-    ?.let(::IrAnnotation)
+    ?.let(context::createIrAnnotation)
 }
 
 context(context: IrMetroContext)
@@ -2289,22 +2249,25 @@ internal fun IrAnnotationContainer?.qualifierAnnotation() =
       // Guice's `@Assisted` annoyingly annotates itself as a qualifier too, so we catch that here
       it.annotationClass.classId != GuiceSymbols.ClassIds.assisted
     }
-    ?.let(::IrAnnotation)
+    ?.let(context::createIrAnnotation)
 
 context(context: IrMetroContext)
 internal fun IrAnnotationContainer?.scopeAnnotations() =
-  annotationsAnnotatedWith(context.metroSymbols.scopeAnnotations).mapToSet(::IrAnnotation)
+  annotationsAnnotatedWith(context.metroSymbols.scopeAnnotations)
+    .mapToSet(context::createIrAnnotation)
 
 /** Returns the `@MapKey` annotation itself, not any annotations annotated _with_ `@MapKey`. */
 context(context: IrMetroContext)
 internal fun IrAnnotationContainer.explicitMapKeyAnnotation() =
-  annotationsIn(context.metroSymbols.mapKeyAnnotations).singleOrNull()?.let(::IrAnnotation)
+  annotationsIn(context.metroSymbols.mapKeyAnnotations)
+    .singleOrNull()
+    ?.let(context::createIrAnnotation)
 
 context(context: IrMetroContext)
 internal fun IrAnnotationContainer.mapKeyAnnotation() =
   annotationsAnnotatedWith(context.metroSymbols.mapKeyAnnotations)
     .singleOrNull()
-    ?.let(::IrAnnotation)
+    ?.let(context::createIrAnnotation)
 
 private fun IrAnnotationContainer?.annotationsAnnotatedWith(
   annotationsToLookFor: Collection<ClassId>

--- a/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/MembersInjectorTransformer.kt
+++ b/compiler/src/main/kotlin/dev/zacsweers/metro/compiler/ir/transformers/MembersInjectorTransformer.kt
@@ -26,6 +26,7 @@ import dev.zacsweers.metro.compiler.ir.annotationClass
 import dev.zacsweers.metro.compiler.ir.annotationsCompat
 import dev.zacsweers.metro.compiler.ir.asContextualTypeKey
 import dev.zacsweers.metro.compiler.ir.assignConstructorParamsToFields
+import dev.zacsweers.metro.compiler.ir.createIrAnnotation
 import dev.zacsweers.metro.compiler.ir.createIrBuilder
 import dev.zacsweers.metro.compiler.ir.declaredCallableMembers
 import dev.zacsweers.metro.compiler.ir.deepRemapperFor
@@ -893,7 +894,7 @@ internal class MembersInjectorTransformer(context: IrMetroContext, traceScope: T
     return annotationsCompat()
       .asSequence()
       .filterNot { it.annotationClass.classId in metroSymbols.classIds.optionalBindingAnnotations }
-      .map(::IrAnnotation)
+      .map(this@MembersInjectorTransformer::createIrAnnotation)
       .distinct()
       .singleOrNull()
   }

--- a/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AggregationTest.kt
+++ b/compiler/src/test/kotlin/dev/zacsweers/metro/compiler/fir/AggregationTest.kt
@@ -3323,7 +3323,7 @@ class AggregationTest : MetroCompilerTest() {
     val expectedDeclarationContext =
       if (usesDirectBindingDeclarations) {
         """
-        Encountered while processing declaration 'feature.TestClass.MetroContributionToAppScope.bindIntoMapAsCloseable1854383119' (no source location available)
+        Encountered while processing declaration 'feature.TestClass.MetroContributionToAppScope.bindIntoMapAsCloseable967577644' (no source location available)
         - This is Metro-generated code that contributes 'feature.TestClass' (where the problem is) to AppScope.
         """
           .trimIndent()

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -57,6 +57,14 @@ Pre-release versions are normally only tested during their development cycle. Af
 
 Some releases may introduce prohibitively difficult breaking changes that require companion release, so check Metro's open PRs for one targeting that Kotlin version for details. There is a tested versions table at the bottom of this page that is updated with each Metro release.
 
+## Annotation Defaults in KLIB Dependencies
+
+Kotlin `2.3.0` and `2.3.10` can leave annotation defaults unavailable to compiler plugins when the annotation class comes from a KLIB dependency. Metro keeps these values omitted during annotation comparison. An explicit value might fail to match an equivalent omitted default, including defaults inside nested annotations. This can affect binding lookup and duplicate detection. Source annotation defaults, explicit argument values, and JVM binary defaults remain supported.
+
+We recommend upgrading to Kotlin `2.3.20` or newer. If you're staying on an affected version, supply the values explicitly at every affected annotation use, including nested annotations. Update affected annotation uses in dependencies too and rebuild those binaries.
+
+Kotlin `2.3.0` and `2.3.10` also serialize omitted array arguments as empty arrays, even when their defaults are nonempty. That metadata is indistinguishable from an explicit empty array. Metro can't recover the original default from it. Rebuild affected dependencies with Kotlin `2.3.20` or newer, or supply the array values explicitly before rebuilding.
+
 ## IDE Support
 
 IDEs have their own compatibility story with Kotlin versions. The Kotlin IDE plugin embeds Kotlin versions built from source, so Metro's IDE support selects the nearest compatible version and tries to support the latest stable IntelliJ and Android Studio releases + the next IntelliJ EAP release.


### PR DESCRIPTION
Previously we were using just a hash of its values, but this isn't ideal and we wanna move to structural equality. This also revealed some annoying compat issues with <2.3.20, but that's old enough now that I'm good with just documented it and calling it a day there.