### PR TITLE
Fix false errors in IDE graph validation

### DIFF
--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/KaBindingLookup.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/graph/KaBindingLookup.kt
@@ -171,6 +171,12 @@ internal class KaBindingLookup(
     if (chain.none { scope in it.scopingAnnotations }) {
       return binding
     }
+    if (binding is KaBinding.Alias && binding.isClassContribution) {
+      // The implementation lookup owns a local class alias's lifetime.
+      if (index.isBindingOwnedByCurrentGraph(binding, queryPlan)) {
+        return binding.copy(scope = null)
+      }
+    }
     // Everything the child itself declares or wires stays local even when its scope names an
     // ancestor, like the compiler's locally declared keys. Class-derived bindings have no local
     // owner and always delegate by scope.
@@ -363,27 +369,34 @@ private fun KaBinding.withElementKey(elementKey: KaTypeKey): KaBinding {
         hintAvailability = hintAvailability,
         isGraphPrivate = isGraphPrivate,
       )
-    is KaBinding.Alias ->
-      KaBinding.Alias(
-        pointer = pointer,
-        typeKey = elementKey,
-        consumedKey = consumedKey,
-        scope = scope,
-        implementationName = implementationName,
-        multibindingId = multibindingId,
-        mapKeyValue = mapKeyValue,
-        originClassId = originClassId,
-        containerId = containerId,
-        ownerGraphId = ownerGraphId,
-        includedContainerKey = includedContainerKey,
-        replaces = replaces,
-        contributionScopes = contributionScopes,
-        priority = priority,
-        priorityFromAnvilRank = priorityFromAnvilRank,
-        isClassContribution = isClassContribution,
-        hintAvailability = hintAvailability,
-        isGraphPrivate = isGraphPrivate,
-      )
+    is KaBinding.Alias -> copy(typeKey = elementKey)
     else -> error("Unexpected multibinding contribution: ${javaClass.simpleName} for $typeKey")
   }
+}
+
+/** Copies an alias view while retaining its declaration and implementation dependency. */
+private fun KaBinding.Alias.copy(
+  typeKey: KaTypeKey = this.typeKey,
+  scope: KaAnnotationSnapshot? = this.scope,
+): KaBinding.Alias {
+  return KaBinding.Alias(
+    pointer = pointer,
+    typeKey = typeKey,
+    consumedKey = consumedKey,
+    scope = scope,
+    implementationName = implementationName,
+    multibindingId = multibindingId,
+    mapKeyValue = mapKeyValue,
+    originClassId = originClassId,
+    containerId = containerId,
+    ownerGraphId = ownerGraphId,
+    includedContainerKey = includedContainerKey,
+    replaces = replaces,
+    contributionScopes = contributionScopes,
+    priority = priority,
+    priorityFromAnvilRank = priorityFromAnvilRank,
+    isClassContribution = isClassContribution,
+    hintAvailability = hintAvailability,
+    isGraphPrivate = isGraphPrivate,
+  )
 }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/IndexModels.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/IndexModels.kt
@@ -9,9 +9,9 @@ import dev.zacsweers.metro.idea.model.BindingContainerEntry
 import dev.zacsweers.metro.idea.model.ConsumerEntry
 import dev.zacsweers.metro.idea.model.ContributionEntry
 import dev.zacsweers.metro.idea.model.DynamicGraphCall
-import dev.zacsweers.metro.idea.model.GraphDefaultImplementation
 import dev.zacsweers.metro.idea.model.GraphExtensionFactoryAccessor
 import dev.zacsweers.metro.idea.model.GraphInterfaceContribution
+import dev.zacsweers.metro.idea.model.GraphMemberOverride
 import dev.zacsweers.metro.idea.model.GraphReference
 import dev.zacsweers.metro.idea.model.KaAnnotationSnapshot
 import dev.zacsweers.metro.idea.model.KaBinding
@@ -131,7 +131,7 @@ internal class GraphInterfaceSurface(
   val extensionCreations: Set<GraphReference>,
   val extensionFactories: List<GraphExtensionFactoryAccessor>,
   val injectedMemberOwnerIds: Set<ClassId>,
-  val defaultImplementations: List<GraphDefaultImplementation> = emptyList(),
+  val memberOverrides: List<GraphMemberOverride> = emptyList(),
 ) {
   fun forGraph(graph: KaGraphDeclaration): GraphInterfaceContribution {
     val graphBindings = bindings.map { binding ->
@@ -153,7 +153,7 @@ internal class GraphInterfaceSurface(
       bindings = graphBindings,
       consumers = consumers.map { it.withGraphOwner(graph.declarationId, contribution) },
       injectedMemberOwnerIds = injectedMemberOwnerIds,
-      defaultImplementations = defaultImplementations,
+      memberOverrides = memberOverrides,
     )
   }
 }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/graph/GraphDeclarationExtractor.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/graph/GraphDeclarationExtractor.kt
@@ -186,7 +186,7 @@ internal class GraphDeclarationExtractor(
         supertypeKeys = supertypeKeys,
         supertypeDeclarations = supertypeDeclarations,
         extensionFactories = extensionFactories,
-        defaultImplementations = memberTarget.defaultImplementations,
+        memberOverrides = memberTarget.memberOverrides,
       )
     }
 

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/graph/GraphMemberExtractor.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/graph/GraphMemberExtractor.kt
@@ -29,8 +29,8 @@ import dev.zacsweers.metro.idea.model.ContributionEntry
 import dev.zacsweers.metro.idea.model.GraphCallableReference
 import dev.zacsweers.metro.idea.model.GraphCallableSignature
 import dev.zacsweers.metro.idea.model.GraphDeclarationId
-import dev.zacsweers.metro.idea.model.GraphDefaultImplementation
 import dev.zacsweers.metro.idea.model.GraphExtensionFactoryAccessor
+import dev.zacsweers.metro.idea.model.GraphMemberOverride
 import dev.zacsweers.metro.idea.model.GraphReference
 import dev.zacsweers.metro.idea.model.KaBinding
 import dev.zacsweers.metro.idea.model.KaContextualTypeKey
@@ -81,7 +81,7 @@ internal class GraphMemberExtractor(
     return pointerManager.createSmartPsiElementPointer(element)
   }
 
-  /** Records a written member and the declarations its implementation overrides. */
+  /** Records a written member and the declarations it overrides. */
   fun indexDeclaredMember(
     session: KaSession,
     view: CallableBindingView,
@@ -89,7 +89,7 @@ internal class GraphMemberExtractor(
     target: GraphMemberTarget,
   ) =
     with(session) {
-      recordGraphDefaultImplementation(view, psi, target)
+      recordGraphMemberOverride(view, psi, target)
       // Binary graph declarations have no project-source annotation sweep for their providers.
       if (view.symbol.origin == KaSymbolOrigin.LIBRARY && psi is KtDeclaration) {
         val ownerDependency = target.factoryContext?.let { typeKey(it, null).canonicalContextKey() }
@@ -191,7 +191,7 @@ internal class GraphMemberExtractor(
         extensionCreations,
         extensionFactories,
         injectedMemberOwnerIds,
-        defaultImplementations = target.defaultImplementations,
+        memberOverrides = target.memberOverrides,
       )
     }
 
@@ -220,7 +220,7 @@ internal class GraphMemberExtractor(
         callable.psi?.containingFile?.let(onDeclarationFile)
         recordAnnotations(this, callable, callable.psi)
         val psi = callable.psi as? KtElement ?: continue
-        recordGraphDefaultImplementation(view, psi, target)
+        recordGraphMemberOverride(view, psi, target)
         if (callable.hasAnyAnnotation(bindingCallableIds)) {
           if (target.bindingTemplates != null || isLibrary || hasSpecializedTypes(view)) {
             (callable.psi as? KtDeclaration)?.let { declaration ->
@@ -236,18 +236,22 @@ internal class GraphMemberExtractor(
     }
 
   /**
-   * Keep the real override relation even though a concrete member is not itself a graph request.
-   * The contributing interface may be excluded later, so its implementation cannot suppress the
-   * abstract declaration until the graph's path-specific contribution selection is known.
+   * Records exact overrides before graph contribution selection. An abstract override keeps its own
+   * request. A concrete override supplies the member implementation. Excluding a contributed
+   * interface also removes its overrides.
    */
-  private fun KaSession.recordGraphDefaultImplementation(
+  private fun KaSession.recordGraphMemberOverride(
     view: CallableBindingView,
     psi: KtElement,
     target: GraphMemberTarget,
   ) {
     val callable = view.symbol
-    if (callable !is KaNamedFunctionSymbol && callable !is KaPropertySymbol) return
-    if (view.receiver != null || callable.modality == KaSymbolModality.ABSTRACT) return
+    if (callable !is KaNamedFunctionSymbol && callable !is KaPropertySymbol) {
+      return
+    }
+    if (view.receiver != null) {
+      return
+    }
 
     val overriddenDeclarations = mutableListOf<GraphCallableReference>()
     val seenDeclarations = HashSet<KtElement>()
@@ -255,20 +259,24 @@ internal class GraphMemberExtractor(
       checkCanceled()
       val original = overridden.fakeOverrideOriginal
       val declaration = original.psi as? KtElement ?: continue
-      if (!seenDeclarations.add(declaration)) continue
+      if (!seenDeclarations.add(declaration)) {
+        continue
+      }
       declaration.containingFile?.let(onDeclarationFile)
       recordAnnotations(this, original, declaration)
       overriddenDeclarations += graphCallableReference(callableBindingView(original), declaration)
     }
-    // Most concrete providers override nothing. They cannot satisfy another abstract declaration
-    // and need no extra surface metadata or composition work.
-    if (overriddenDeclarations.isEmpty()) return
+    // Members that override nothing need no extra surface metadata or composition work.
+    if (overriddenDeclarations.isEmpty()) {
+      return
+    }
 
-    target.defaultImplementations +=
-      GraphDefaultImplementation(
+    target.memberOverrides +=
+      GraphMemberOverride(
         declaration = graphCallableReference(view, psi),
         overriddenDeclarations = overriddenDeclarations,
         isOptional = callable.isOptionalConsumer(options),
+        isAbstract = callable.modality == KaSymbolModality.ABSTRACT,
       )
   }
 

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/graph/GraphMemberTarget.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/graph/GraphMemberTarget.kt
@@ -5,8 +5,8 @@ package dev.zacsweers.metro.idea.index.graph
 import dev.zacsweers.metro.idea.index.GraphInterfaceBinding
 import dev.zacsweers.metro.idea.model.ConsumerEntry
 import dev.zacsweers.metro.idea.model.GraphDeclarationId
-import dev.zacsweers.metro.idea.model.GraphDefaultImplementation
 import dev.zacsweers.metro.idea.model.GraphExtensionFactoryAccessor
+import dev.zacsweers.metro.idea.model.GraphMemberOverride
 import dev.zacsweers.metro.idea.model.GraphReference
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.name.ClassId
@@ -21,5 +21,5 @@ internal class GraphMemberTarget(
   val bindingTemplates: MutableList<GraphInterfaceBinding>? = null,
   /** The session-local receiver preserves an inherited factory SAM's annotated subtype. */
   val factoryContext: KaClassType? = null,
-  val defaultImplementations: MutableList<GraphDefaultImplementation> = mutableListOf(),
+  val memberOverrides: MutableList<GraphMemberOverride> = mutableListOf(),
 )

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/snapshot/ResolutionInputCapture.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/snapshot/ResolutionInputCapture.kt
@@ -98,9 +98,9 @@ internal class ResolutionInputCapture(
       for (graph in graphs) {
         capture(graph.pointer, captureAnchorSignature = true)
         for (factory in graph.extensionFactories) capture(factory.pointer)
-        for (implementation in graph.defaultImplementations) {
-          capture(implementation.declaration.pointer)
-          for (overridden in implementation.overriddenDeclarations) capture(overridden.pointer)
+        for (memberOverride in graph.memberOverrides) {
+          capture(memberOverride.declaration.pointer)
+          for (overridden in memberOverride.overriddenDeclarations) capture(overridden.pointer)
         }
         for (contribution in graph.contributedInterfaces) {
           capture(contribution.contribution.pointer)
@@ -109,9 +109,9 @@ internal class ResolutionInputCapture(
             capture(consumer.pointer, captureAnchorSignature = true)
           }
           for (factory in contribution.extensionFactories) capture(factory.pointer)
-          for (implementation in contribution.defaultImplementations) {
-            capture(implementation.declaration.pointer)
-            for (overridden in implementation.overriddenDeclarations) capture(overridden.pointer)
+          for (memberOverride in contribution.memberOverrides) {
+            capture(memberOverride.declaration.pointer)
+            for (overridden in memberOverride.overriddenDeclarations) capture(overridden.pointer)
           }
         }
       }

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/snapshot/SourceLibrarySignatures.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/index/snapshot/SourceLibrarySignatures.kt
@@ -14,8 +14,8 @@ import dev.zacsweers.metro.idea.model.DynamicGraphId
 import dev.zacsweers.metro.idea.model.GraphCallableReference
 import dev.zacsweers.metro.idea.model.GraphCallableSignature
 import dev.zacsweers.metro.idea.model.GraphDeclarationId
-import dev.zacsweers.metro.idea.model.GraphDefaultImplementation
 import dev.zacsweers.metro.idea.model.GraphExtensionFactoryAccessor
+import dev.zacsweers.metro.idea.model.GraphMemberOverride
 import dev.zacsweers.metro.idea.model.GraphReference
 import dev.zacsweers.metro.idea.model.KaAnnotationSnapshot
 import dev.zacsweers.metro.idea.model.KaBinding
@@ -50,7 +50,7 @@ private fun FileShard.librarySignature(): SourceLibraryShardSignature {
         graph.supertypeDeclarations,
         graph.extensionCreations,
         graph.extensionFactories.map(::extensionFactoryLibrarySignature),
-        graph.defaultImplementations.map(::defaultImplementationLibrarySignature),
+        graph.memberOverrides.map(::memberOverrideLibrarySignature),
         graph.injectedMemberOwnerIds,
         graph.daggerAnvilInteropEnabled,
         graph.pointer.element != null,
@@ -138,13 +138,15 @@ private fun callableLibrarySignature(
   )
 }
 
-private fun defaultImplementationLibrarySignature(
-  implementation: GraphDefaultImplementation
-): GraphDefaultImplementationLibrarySignature {
-  return GraphDefaultImplementationLibrarySignature(
-    callableLibrarySignature(implementation.declaration),
-    implementation.overriddenDeclarations.map(::callableLibrarySignature),
-    implementation.isOptional,
+/** Tracks override shape and modality when source declarations replace library declarations. */
+private fun memberOverrideLibrarySignature(
+  memberOverride: GraphMemberOverride
+): GraphMemberOverrideLibrarySignature {
+  return GraphMemberOverrideLibrarySignature(
+    callableLibrarySignature(memberOverride.declaration),
+    memberOverride.overriddenDeclarations.map(::callableLibrarySignature),
+    memberOverride.isOptional,
+    memberOverride.isAbstract,
   )
 }
 
@@ -186,7 +188,7 @@ private fun graphInterfaceLibrarySignature(
     surface.consumers.map(::consumerLibrarySignature),
     surface.extensionCreations,
     surface.extensionFactories.map(::extensionFactoryLibrarySignature),
-    surface.defaultImplementations.map(::defaultImplementationLibrarySignature),
+    surface.memberOverrides.map(::memberOverrideLibrarySignature),
     surface.injectedMemberOwnerIds,
   )
 }
@@ -276,7 +278,7 @@ private data class GraphLibrarySignature(
   val supertypeDeclarations: Set<GraphReference>,
   val extensionCreations: Set<GraphReference>,
   val extensionFactories: List<ExtensionFactoryLibrarySignature>,
-  val defaultImplementations: List<GraphDefaultImplementationLibrarySignature>,
+  val memberOverrides: List<GraphMemberOverrideLibrarySignature>,
   val injectedMemberOwnerIds: Set<ClassId>,
   val daggerAnvilInteropEnabled: Boolean,
   val pointerIsValid: Boolean,
@@ -325,10 +327,11 @@ private data class GraphCallableLibrarySignature(
   val pointerIsValid: Boolean,
 )
 
-private data class GraphDefaultImplementationLibrarySignature(
+private data class GraphMemberOverrideLibrarySignature(
   val declaration: GraphCallableLibrarySignature,
   val overriddenDeclarations: List<GraphCallableLibrarySignature>,
   val isOptional: Boolean,
+  val isAbstract: Boolean,
 )
 
 private data class GraphInterfaceLibrarySignature(
@@ -339,7 +342,7 @@ private data class GraphInterfaceLibrarySignature(
   val consumers: List<ConsumerLibrarySignature>,
   val extensionCreations: Set<GraphReference>,
   val extensionFactories: List<ExtensionFactoryLibrarySignature>,
-  val defaultImplementations: List<GraphDefaultImplementationLibrarySignature>,
+  val memberOverrides: List<GraphMemberOverrideLibrarySignature>,
   val injectedMemberOwnerIds: Set<ClassId>,
 )
 

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndex.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingIndex.kt
@@ -353,18 +353,20 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
       val bindingIdentities = hashSetOf<Any>()
       val accessors = mutableListOf<ConsumerEntry>()
       val accessorIdentities = hashSetOf<Any>()
-      var implementedDeclarations: MutableSet<SourcePointerIdentity>? = null
+      var supersededDeclarations: MutableSet<SourcePointerIdentity>? = null
 
-      fun addDefaultImplementations(implementations: List<GraphDefaultImplementation>) {
-        if (implementations.isEmpty()) return
+      fun addMemberOverrides(overrides: List<GraphMemberOverride>) {
+        if (overrides.isEmpty()) {
+          return
+        }
         val identities =
-          implementedDeclarations
+          supersededDeclarations
             ?: HashSet<SourcePointerIdentity>().also {
-              implementedDeclarations = it
+              supersededDeclarations = it
             }
-        for (implementation in implementations) {
+        for (memberOverride in overrides) {
           ProgressManager.checkCanceled()
-          val declaration = implementation.declaration
+          val declaration = memberOverride.declaration
           if (
             !isVisibleFrom(
               declaration.pointer,
@@ -373,12 +375,15 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
               module,
               resolutionScope,
             )
-          )
+          ) {
             continue
-          // A fake override can still point at the concrete declaration itself. Its optional
-          // request, if any, is retained by isImplementedGraphRequest below.
-          declaration.sourceIdentity?.let(identities::add)
-          for (overridden in implementation.overriddenDeclarations) {
+          }
+          // A fake override can still point at the concrete declaration itself.
+          if (!memberOverride.isAbstract) {
+            declaration.sourceIdentity?.let(identities::add)
+          }
+          // Abstract overrides retain their own request with its narrowed type and qualifiers.
+          for (overridden in memberOverride.overriddenDeclarations) {
             overridden.sourceIdentity?.let(identities::add)
           }
         }
@@ -406,7 +411,7 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
         checkCanceledEvery(index)
         if (consumer.graphContribution == null) addAccessor(consumer)
       }
-      addDefaultImplementations(graph.defaultImplementations)
+      addMemberOverrides(graph.memberOverrides)
       for (candidate in graph.contributedInterfaces) {
         ProgressManager.checkCanceled()
         val reference = candidate.contribution.declarationId ?: continue
@@ -421,7 +426,7 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
         creations += candidate.extensionCreations
         factories += candidate.extensionFactories
         memberOwners += candidate.injectedMemberOwnerIds
-        addDefaultImplementations(candidate.defaultImplementations)
+        addMemberOverrides(candidate.memberOverrides)
         for ((bindingIndex, binding) in candidate.bindings.withIndex()) {
           checkCanceledEvery(bindingIndex)
           if (hasWrittenBinding(binding, graph)) continue
@@ -442,9 +447,9 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
           addAccessor(consumer)
         }
       }
-      val implementedRequests = implementedDeclarations.orEmpty()
-      if (implementedRequests.isNotEmpty()) {
-        accessors.removeAll { isImplementedGraphRequest(it, implementedRequests) }
+      val supersededRequests = supersededDeclarations.orEmpty()
+      if (supersededRequests.isNotEmpty()) {
+        accessors.removeAll { isSupersededGraphRequest(it, supersededRequests) }
       }
       SelectedGraphComposition(
         GraphComposition(
@@ -459,7 +464,7 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
         selection,
         contributionIds.toSet(),
         selectedBindings.toSet(),
-        implementedRequests.toSet(),
+        supersededRequests.toSet(),
       )
     }
   }
@@ -1114,10 +1119,22 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
   private fun isBindingOwnedByCurrentGraph(
     binding: KaBinding,
     structure: GraphQueryStructure,
+  ): Boolean = isBindingOwnedByGraph(binding, structure.queryContext.graphContext.graph, structure)
+
+  /** Checks declaration and aggregation ownership at one graph in the selected parent path. */
+  internal fun isBindingOwnedByGraph(
+    binding: KaBinding,
+    graph: KaGraphDeclaration,
+    plan: GraphQueryPlan,
+  ): Boolean = isBindingOwnedByGraph(binding, graph, plan.structure)
+
+  private fun isBindingOwnedByGraph(
+    binding: KaBinding,
+    graph: KaGraphDeclaration,
+    structure: GraphQueryStructure,
   ): Boolean {
     val queryContext = structure.queryContext
     val context = queryContext.graphContext
-    val graph = context.graph
     val ownerGraphId = binding.ownerGraphId
     if (ownerGraphId != null) {
       if (binding is KaBinding.BoundInstance) {
@@ -1127,7 +1144,9 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
     }
     val includedContainerKey = binding.includedContainerKey
     if (includedContainerKey != null) {
-      if (includedContainerKey in graph.includedBindingContainers) return true
+      if (includedContainerKey in graph.includedBindingContainers) {
+        return true
+      }
       val isDynamicRoot = graph.declarationId == context.rootGraph.declarationId
       return isDynamicRoot && includedContainerKey in context.dynamicGraph?.containerKeys.orEmpty()
     }
@@ -1138,7 +1157,7 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
         checkNotNull(selectedGraphComposition(structure, graph.declarationId)).composition
       return containerId in graph.selfIds ||
         composition.supertypeDeclarations.any { it.classId == containerId } ||
-        containerId in structure.currentOwnerOwnContainers
+        containerId in graphOwnContainers(graph, structure)
     }
 
     if (binding.contributionScopes.isNotEmpty()) {
@@ -1317,7 +1336,7 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
       if (graphId !in context.graphIds) return false
       if (consumer.graphRequestKind == null || consumer.isOptional) return true
       val selected = selectedGraphComposition(structure, graphId) ?: return false
-      return !isImplementedGraphRequest(consumer, selected.implementedRequests)
+      return !isSupersededGraphRequest(consumer, selected.supersededRequests)
     }
 
     val memberOwnerClassId = consumer.memberOwnerClassId
@@ -1544,14 +1563,19 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
   }
 
   /** Uses the same precomputed selection for graph roots and source/library dependency seeding. */
-  private fun isImplementedGraphRequest(
+  private fun isSupersededGraphRequest(
     consumer: ConsumerEntry,
-    implementedRequests: Set<SourcePointerIdentity>,
+    supersededRequests: Set<SourcePointerIdentity>,
   ): Boolean {
-    if (consumer.graphRequestKind == null || consumer.isOptional) return false
-    if (implementedRequests.isEmpty()) return false
+    // Optional concrete accessors remain eligible for a binding that replaces their default.
+    if (consumer.graphRequestKind == null || consumer.isOptional) {
+      return false
+    }
+    if (supersededRequests.isEmpty()) {
+      return false
+    }
     val source = consumer.sourceIdentity ?: return false
-    return source in implementedRequests
+    return source in supersededRequests
   }
 
   private fun isGraphMemberContainer(
@@ -1787,7 +1811,7 @@ internal class BindingIndex private constructor(data: FrozenBindingIndexData) {
     val selection: ContributionSelection,
     val contributionIds: Set<GraphReference>,
     val bindings: Set<KaBinding>,
-    val implementedRequests: Set<SourcePointerIdentity>,
+    val supersededRequests: Set<SourcePointerIdentity>,
   )
 
   internal class GraphQueryStructure(

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingModel.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/BindingModel.kt
@@ -171,8 +171,8 @@ internal class KaGraphDeclaration(
   val extensionFactories: List<GraphExtensionFactoryAccessor> = emptyList(),
   /** Scope-matched candidates; visibility and removal are selected for each concrete graph path. */
   val contributedInterfaces: List<GraphInterfaceContribution> = emptyList(),
-  /** Concrete members from the written graph hierarchy that satisfy inherited abstract requests. */
-  val defaultImplementations: List<GraphDefaultImplementation> = emptyList(),
+  /** Written member overrides that determine which inherited graph requests remain active. */
+  val memberOverrides: List<GraphMemberOverride> = emptyList(),
 ) {
   val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
   val declarationId: GraphDeclarationId = GraphDeclarationId(classId, pointer.virtualFile)
@@ -204,7 +204,7 @@ internal class KaGraphDeclaration(
       supertypeDeclarations = supertypeDeclarations,
       extensionFactories = extensionFactories,
       contributedInterfaces = interfaces,
-      defaultImplementations = defaultImplementations,
+      memberOverrides = memberOverrides,
     )
   }
 }
@@ -294,11 +294,12 @@ internal class GraphCallableReference(
   val sourceIdentity: BindingIndex.SourcePointerIdentity? = sourcePointerIdentity(pointer)
 }
 
-/** A concrete graph member and the real declarations that it overrides. */
-internal class GraphDefaultImplementation(
+/** A graph member and its overridden declarations. Abstract members keep their own requests. */
+internal class GraphMemberOverride(
   val declaration: GraphCallableReference,
   val overriddenDeclarations: List<GraphCallableReference>,
   val isOptional: Boolean,
+  val isAbstract: Boolean,
 )
 
 /** A real graph accessor whose result is an extension factory. */
@@ -321,7 +322,7 @@ internal class GraphInterfaceContribution(
   val bindings: List<KaBinding>,
   val consumers: List<ConsumerEntry>,
   val injectedMemberOwnerIds: Set<ClassId>,
-  val defaultImplementations: List<GraphDefaultImplementation> = emptyList(),
+  val memberOverrides: List<GraphMemberOverride> = emptyList(),
 )
 
 /** The effective interface surface of one graph in a concrete parent path and root module. */

--- a/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/KaBindingSelection.kt
+++ b/idea-plugin/src/main/kotlin/dev/zacsweers/metro/idea/model/KaBindingSelection.kt
@@ -51,7 +51,8 @@ internal fun BindingIndex.selectBindingsForKey(
     registered = registered@{
         if (indexedTier == BindingTier.EXPLICIT) {
           val explicit = candidates.filter { it.selectionTier(unqualified) == BindingTier.EXPLICIT }
-          return@registered KaBindingSelection(BindingTier.EXPLICIT, explicit)
+          val nearest = nearestExplicitBindings(explicit, plan)
+          return@registered KaBindingSelection(BindingTier.EXPLICIT, nearest)
         }
         val generated = plan.generatedBindings.forKey(typeKey) ?: return@registered null
         KaBindingSelection(BindingTier.GENERATED_GRAPH, listOf(generated))
@@ -87,6 +88,43 @@ internal fun BindingIndex.selectBindingsForKey(
         KaBindingSelection(BindingTier.IMPLICIT, implicit)
       },
   )
+}
+
+/**
+ * Keeps explicit declarations from the closest graph that owns this key. All bindings at that graph
+ * survive so validation can report duplicates.
+ */
+private fun BindingIndex.nearestExplicitBindings(
+  candidates: List<KaBinding>,
+  plan: BindingIndex.GraphQueryPlan,
+): List<KaBinding> {
+  val chain = plan.structure.queryContext.graphContext.chain
+  if (candidates.size < 2 || chain.size < 2) {
+    return candidates
+  }
+
+  // Included dependency accessors retain the compiler's duplicate checks against inherited
+  // bindings.
+  val allDirectDeclarations = candidates.all {
+    when (it) {
+      is KaBinding.Provided,
+      is KaBinding.Alias -> true
+      is KaBinding.BoundInstance -> !it.isGraphInput && !it.isBindingContainerInput
+      else -> false
+    }
+  }
+  if (!allDirectDeclarations) {
+    return candidates
+  }
+
+  for ((graphIndex, graph) in chain.withIndex()) {
+    checkCanceledEvery(graphIndex)
+    val owned = candidates.filter { isBindingOwnedByGraph(it, graph, plan) }
+    if (owned.isNotEmpty()) {
+      return owned
+    }
+  }
+  return candidates
 }
 
 private fun KaBinding.selectionTier(unqualified: Boolean): BindingTier {

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroGraphValidationTest.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
@@ -659,6 +660,294 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
         it is KaBinding.Alias && it.typeKey.renderedType == "test.Service"
       }
     assertEquals(result.graph.declarationId, childBinding.ownerGraphId)
+  }
+
+  /** The account graph owns the loader requested through its descendant's ViewModel map. */
+  fun testGrandchildUsesNearestAncestorContributedProvides() {
+    module.addKotlinStdlibLibrary()
+    val file =
+      myFixture.configureMetroFile(
+        """
+        import kotlin.reflect.KClass
+
+        abstract class AccountScope
+        abstract class ViewModelScope
+        interface ImageLoader
+        class RealImageLoader : ImageLoader
+        interface ViewModel
+
+        @ContributesTo(AppScope::class)
+        interface AppImageLoaderModule {
+          @Provides @SingleIn(AppScope::class)
+          fun appImageLoader(): ImageLoader = RealImageLoader()
+        }
+
+        @ContributesTo(AccountScope::class)
+        interface AccountImageLoaderModule {
+          @Provides @SingleIn(AccountScope::class)
+          fun accountImageLoader(): ImageLoader = RealImageLoader()
+        }
+
+        @ContributesIntoMap(ViewModelScope::class)
+        @ClassKey
+        @Inject class AvatarCropperViewModel(val imageLoader: ImageLoader) : ViewModel
+
+        @GraphExtension(ViewModelScope::class)
+        interface ViewModelGraph {
+          val viewModels: Map<KClass<*>, ViewModel>
+        }
+
+        @GraphExtension(AccountScope::class)
+        interface AccountGraph {
+          val viewModels: ViewModelGraph
+        }
+
+        @DependencyGraph(AppScope::class)
+        interface AppGraph {
+          val account: AccountGraph
+        }
+        """
+      )
+
+    val binding =
+      assertNearestAncestorSelection(
+        file,
+        "imageLoader",
+        file.declarationsIncludingNested().function("accountImageLoader"),
+      )
+    assertTrue(binding is KaBinding.Provided)
+  }
+
+  /** A contributed alias keeps its account scope when a descendant requests the shared API. */
+  fun testGrandchildUsesNearestAncestorContributedBinding() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        abstract class AccountScope
+        abstract class ViewModelScope
+        interface FileServiceApi
+
+        @ContributesBinding(AppScope::class)
+        @SingleIn(AppScope::class)
+        @Inject class AppFileServiceApi : FileServiceApi
+
+        @ContributesBinding(AccountScope::class)
+        @SingleIn(AccountScope::class)
+        @Inject class AccountFileServiceApi : FileServiceApi
+
+        @Inject class FileViewModel(val files: FileServiceApi)
+
+        @GraphExtension(ViewModelScope::class)
+        interface ViewModelGraph {
+          val viewModel: FileViewModel
+        }
+
+        @GraphExtension(AccountScope::class)
+        interface AccountGraph {
+          val viewModels: ViewModelGraph
+        }
+
+        @DependencyGraph(AppScope::class)
+        interface AppGraph {
+          val account: AccountGraph
+        }
+        """
+      )
+
+    val binding =
+      assertNearestAncestorSelection(
+        file,
+        "files",
+        file.declarationsIncludingNested().klass("AccountFileServiceApi"),
+      )
+    assertTrue(binding is KaBinding.Alias)
+    assertEquals(
+      "test.AccountFileServiceApi",
+      (binding as KaBinding.Alias).consumedKey?.typeKey?.renderedType,
+    )
+  }
+
+  /** The closest graph's bindings take precedence even without a scoped lifetime. */
+  fun testGrandchildUsesNearestAncestorUnscopedAlias() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        interface ImageLoader
+        class AppImageLoader : ImageLoader
+        @Inject class AccountImageLoader : ImageLoader
+        @Inject class ViewModel(val imageLoader: ImageLoader)
+
+        @GraphExtension
+        interface ViewModelGraph {
+          val viewModel: ViewModel
+        }
+
+        @GraphExtension
+        interface AccountGraph {
+          val viewModels: ViewModelGraph
+
+          @Binds fun accountImageLoader(loader: AccountImageLoader): ImageLoader
+        }
+
+        @DependencyGraph
+        interface AppGraph {
+          val account: AccountGraph
+
+          @Provides fun appImageLoader(): ImageLoader = AppImageLoader()
+        }
+        """
+      )
+
+    val binding =
+      assertNearestAncestorSelection(
+        file,
+        "imageLoader",
+        file.declarationsIncludingNested().function("accountImageLoader"),
+        isScoped = false,
+      )
+    assertTrue(binding is KaBinding.Alias)
+    assertEquals(
+      "test.AccountImageLoader",
+      (binding as KaBinding.Alias).consumedKey?.typeKey?.renderedType,
+    )
+  }
+
+  /** Refresh and validation must select the same binding and retain its account graph owner. */
+  private fun assertNearestAncestorSelection(
+    file: KtFile,
+    parameterName: String,
+    expectedDeclaration: KtDeclaration,
+    isScoped: Boolean = true,
+  ): KaBinding {
+    val index = refreshedIndex(file)
+    val leaf = index.graphs.single { it.name == "ViewModelGraph" }
+    val context = index.contextsFor(leaf).single()
+    val queryContext = checkNotNull(index.queryContext(context))
+    val consumer =
+      checkNotNull(
+        index.consumerEntryAt(file.declarationsIncludingNested().parameter(parameterName))
+      )
+    val selected = index.bindingsFor(consumer, queryContext)
+    assertEquals(1, selected.size)
+    assertSame(expectedDeclaration, selected.single().pointer.element)
+
+    val app = index.graphs.single { it.name == "AppGraph" }
+    val results =
+      project.service<MetroGraphValidationService>().validateWithExtensions(file, app).map {
+        it.requireCompleted()
+      }
+    assertEquals(
+      listOf("ViewModelGraph", "AccountGraph", "AppGraph"),
+      results.map { it.graph.name },
+    )
+    for (result in results) {
+      assertTrue(result.diagnostics.joinToString { it.render() }, result.diagnostics.isEmpty())
+    }
+    val leafBinding = checkNotNull(results.first().bindings[consumer.key])
+    if (isScoped) {
+      assertTrue(leafBinding is KaBinding.GraphDependency)
+      leafBinding as KaBinding.GraphDependency
+      assertTrue(leafBinding.isParentScoped)
+      assertEquals("test.AccountGraph", leafBinding.ownerKey.renderedType)
+      val accountBinding = checkNotNull(results[1].bindings[consumer.key])
+      assertSame(expectedDeclaration, accountBinding.pointer.element)
+      return accountBinding
+    }
+    assertSame(expectedDeclaration, leafBinding.pointer.element)
+    assertEquals(results[1].graph.classId, leafBinding.containerId)
+    return leafBinding
+  }
+
+  /** Ancestor precedence preserves conflicts between providers owned by the same graph. */
+  fun testNearestAncestorDuplicateProvidesAreReported() {
+    val file =
+      myFixture.configureMetroFile(
+        """
+        abstract class AccountScope
+        abstract class ViewModelScope
+        class ImageLoader
+
+        @GraphExtension(ViewModelScope::class)
+        interface ViewModelGraph {
+          val imageLoader: ImageLoader
+        }
+
+        @GraphExtension(AccountScope::class)
+        interface AccountGraph {
+          val viewModels: ViewModelGraph
+
+          @Provides @SingleIn(AccountScope::class)
+          fun firstAccountLoader(): ImageLoader = ImageLoader()
+
+          @Provides @SingleIn(AccountScope::class)
+          fun secondAccountLoader(): ImageLoader = ImageLoader()
+        }
+
+        @DependencyGraph(AppScope::class)
+        interface AppGraph {
+          val account: AccountGraph
+
+          @Provides @SingleIn(AppScope::class)
+          fun appLoader(): ImageLoader = ImageLoader()
+        }
+        """
+      )
+    val index = refreshedIndex(file)
+    val declarations = file.declarationsIncludingNested()
+    val consumer = checkNotNull(index.consumerEntryAt(declarations.property("imageLoader")))
+    val leaf = index.graphs.single { it.name == "ViewModelGraph" }
+    val context = index.contextsFor(leaf).single()
+    val selected = index.bindingsFor(consumer, checkNotNull(index.queryContext(context)))
+    val expectedDeclarations =
+      setOf(
+        declarations.function("firstAccountLoader"),
+        declarations.function("secondAccountLoader"),
+      )
+    assertEquals(expectedDeclarations, selected.map { it.pointer.element }.toSet())
+
+    val result =
+      project.service<MetroGraphValidationService>().validate(file, context).requireCompleted()
+    val diagnostic = result.diagnostics.single()
+    assertEquals(MetroDiagnosticId.DUPLICATE_BINDING, diagnostic.id)
+    assertEquals(expectedDeclarations, diagnostic.related.map { it.pointer.element }.toSet())
+  }
+
+  /** Included dependency accessors participate in duplicate checks with ancestor providers. */
+  fun testChildIncludedAccessorStillConflictsWithParentProvides() {
+    val result =
+      validate(
+        """
+        class ImageLoader
+
+        interface ExternalDependency {
+          val imageLoader: ImageLoader
+        }
+
+        @GraphExtension
+        interface ChildGraph {
+          val imageLoader: ImageLoader
+
+          @GraphExtension.Factory
+          interface Factory {
+            fun create(@Includes dependency: ExternalDependency): ChildGraph
+          }
+        }
+
+        @DependencyGraph
+        interface AppGraph {
+          val child: ChildGraph.Factory
+
+          @Provides fun appImageLoader(): ImageLoader = ImageLoader()
+        }
+        """,
+        graphName = "ChildGraph",
+      )
+
+    val diagnostic = result.diagnostics.single()
+    assertEquals(MetroDiagnosticId.DUPLICATE_BINDING, diagnostic.id)
+    assertEquals(2, diagnostic.related.size)
+    assertEquals(1, diagnostic.related.filterIsInstance<KaBinding.GraphDependency>().size)
+    assertEquals(1, diagnostic.related.filterIsInstance<KaBinding.Provided>().size)
   }
 
   fun testDifferentInheritedGenericProvidersInOneGraphRemainDuplicates() {
@@ -2003,6 +2292,180 @@ class MetroGraphValidationTest : BasePlatformTestCase() {
       assertTrue(childElement.isParentScoped)
       assertEquals("test.AppGraph", childElement.ownerKey.renderedType)
     }
+  }
+
+  /** A child can collect a class whose instance belongs to its parent scope. */
+  fun testChildContributedSetElementUsesAncestorScope() {
+    assertChildContributionScope()
+  }
+
+  /** The map entry stays in the child while its exposed implementation belongs to the parent. */
+  fun testChildContributedMapElementUsesAncestorScope() {
+    assertChildContributionScope(isMap = true)
+  }
+
+  /** A child provider can supply an implementation whose constructor belongs to a parent scope. */
+  fun testChildContributedAliasUsesExplicitImplementationProvider() {
+    assertChildContributionScope(provideImplementationLocally = true)
+  }
+
+  /** A generated set provider must use a scope supported by the graph that aggregates it. */
+  fun testChildGeneratedSetElementWithAncestorScopeStaysLocal() {
+    assertChildContributionScope(exposeImplementation = false)
+  }
+
+  /** A generated map provider must use a scope supported by the graph that aggregates it. */
+  fun testChildGeneratedMapElementWithAncestorScopeStaysLocal() {
+    assertChildContributionScope(isMap = true, exposeImplementation = false)
+  }
+
+  /** Checks the lifetime of class contributions aggregated by a child graph. */
+  private fun assertChildContributionScope(
+    isMap: Boolean = false,
+    exposeImplementation: Boolean = true,
+    provideImplementationLocally: Boolean = false,
+  ) {
+    module.addKotlinStdlibLibrary()
+    project.setMetroOptions("generate-contribution-providers" to "true")
+    val implementationExposure =
+      if (exposeImplementation) {
+        "@ExposeImplBinding"
+      } else {
+        ""
+      }
+    val contribution =
+      if (isMap) {
+        "@ContributesIntoMap(ConversationViewModelScope::class) @StringKey(\"decoration\")"
+      } else {
+        "@ContributesIntoSet(ConversationViewModelScope::class)"
+      }
+    val collectionType =
+      if (isMap) {
+        "Map<String, Decoration>"
+      } else {
+        "Set<Decoration>"
+      }
+    val localProvider =
+      if (provideImplementationLocally) {
+        "@Provides fun decoration(): DecorationImpl = DecorationImpl()"
+      } else {
+        ""
+      }
+    val file =
+      myFixture.configureMetroFile(
+        """
+        abstract class ConversationScope
+        abstract class ConversationViewModelScope
+        interface Decoration
+
+        $contribution
+        $implementationExposure
+        @SingleIn(ConversationScope::class)
+        @Inject class DecorationImpl : Decoration
+
+        @GraphExtension(ConversationViewModelScope::class)
+        interface ConversationViewModelGraph {
+          val decorations: $collectionType
+
+          $localProvider
+        }
+
+        @DependencyGraph(ConversationScope::class)
+        interface ConversationGraph {
+          val viewModel: ConversationViewModelGraph
+        }
+        """
+      )
+    val index = refreshedIndex(file)
+    val parent = index.graphs.single { it.name == "ConversationGraph" }
+    val results =
+      project.service<MetroGraphValidationService>().validateWithExtensions(file, parent).map {
+        it.requireCompleted()
+      }
+    assertEquals(2, results.size)
+    val childResult = results.first()
+    val parentResult = results.last()
+    if (!exposeImplementation) {
+      assertEquals(
+        listOf(MetroDiagnosticId.INCOMPATIBLY_SCOPED_BINDINGS),
+        childResult.diagnostics.map { it.id },
+      )
+      assertTrue(parentResult.diagnostics.toString(), parentResult.diagnostics.isEmpty())
+      return
+    }
+    for (result in results) {
+      assertTrue(result.diagnostics.joinToString { it.render() }, result.diagnostics.isEmpty())
+    }
+    val collection =
+      childResult.bindings.asMap().values.filterIsInstance<KaBinding.Multibinding>().single()
+    val elementKey = collection.sourceBindings.single()
+    val childElement = childResult.bindings[elementKey] as KaBinding.Alias
+    assertTrue(childElement.isClassContribution)
+    assertNull(childElement.scope)
+    val implementationKey = checkNotNull(childElement.consumedKey).typeKey
+    if (provideImplementationLocally) {
+      val childImplementation = childResult.bindings[implementationKey] as KaBinding.Provided
+      assertNull(childImplementation.scope)
+      assertSame(
+        file.declarationsIncludingNested().function("decoration"),
+        childImplementation.pointer.element,
+      )
+      assertTrue(childResult.parentReservations.isEmpty())
+      assertNull(parentResult.bindings[implementationKey])
+      assertNull(parentResult.bindings[elementKey])
+      return
+    }
+    val childImplementation = childResult.bindings[implementationKey] as KaBinding.GraphDependency
+    assertTrue(childImplementation.isParentScoped)
+    assertEquals("test.ConversationGraph", childImplementation.ownerKey.renderedType)
+    assertEquals(setOf(implementationKey), childResult.parentReservations.keys)
+    assertNull(parentResult.bindings[elementKey])
+    val parentImplementation = checkNotNull(parentResult.bindings[implementationKey])
+    val implementation = file.declarationsIncludingNested().klass("DecorationImpl")
+    assertSame(implementation, parentImplementation.pointer.element)
+    assertTrue(parentImplementation is KaBinding.ConstructorInjected)
+    assertTrue(parentImplementation.scope in parentResult.graph.scopingAnnotations)
+    if (isMap) {
+      val sourceAlias =
+        index.bindingEntriesAt(implementation).filterIsInstance<KaBinding.Alias>().single()
+      assertNotNull(childElement.mapKeyValue)
+      assertEquals(sourceAlias.mapKeyValue, childElement.mapKeyValue)
+    }
+  }
+
+  /** A provider authored in a child contribution must use a scope supported by the child. */
+  fun testChildContributedModuleProviderWithAncestorScopeStaysLocal() {
+    project.setMetroOptions("generate-contribution-providers" to "true")
+    val result =
+      validate(
+        """
+        abstract class ConversationScope
+        abstract class ConversationViewModelScope
+        interface Decoration
+
+        @ContributesTo(ConversationViewModelScope::class)
+        interface DecorationModule {
+          @Provides @IntoSet @SingleIn(ConversationScope::class)
+          fun decoration(): Decoration = object : Decoration {}
+        }
+
+        @GraphExtension(ConversationViewModelScope::class)
+        interface ConversationViewModelGraph {
+          val decorations: Set<Decoration>
+        }
+
+        @DependencyGraph(ConversationScope::class)
+        interface ConversationGraph {
+          val viewModel: ConversationViewModelGraph
+        }
+        """,
+        graphName = "ConversationViewModelGraph",
+      )
+
+    assertEquals(
+      listOf(MetroDiagnosticId.INCOMPATIBLY_SCOPED_BINDINGS),
+      result.diagnostics.map { it.id },
+    )
   }
 
   fun testSharedMapCollectionViewsReuseSyntheticElements() {

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroMultiModuleResolutionTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroMultiModuleResolutionTest.kt
@@ -966,6 +966,164 @@ class MetroMultiModuleResolutionTest : UsefulTestCase() {
     assertTrue(unrelated.diagnostics.single().render().contains("unrelated"))
   }
 
+  /** Abstract contributed overrides keep their narrowed request in each selected graph. */
+  fun testSelectedContributedAbstractOverridesKeepOnlyEffectiveAccessors() {
+    val apiFile =
+      fixture.addFileToProject(
+        "library/abstractoverrides/api/Accessors.kt",
+        """
+        package abstractoverrides.api
+
+        import dev.zacsweers.metro.*
+
+        interface Value
+        class ConcreteValue : Value
+        @Qualifier annotation class Device
+
+        @ContributesTo(AppScope::class)
+        interface PublicAccessors {
+          fun value(): Value
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    val implementationFile =
+      fixture.addFileToProject(
+        "bridge/abstractoverrides/impl/Accessors.kt",
+        """
+        package abstractoverrides.impl
+
+        import dev.zacsweers.metro.*
+        import abstractoverrides.api.*
+
+        @ContributesTo(AppScope::class)
+        interface QualifiedAccessors : PublicAccessors {
+          @Device override fun value(): ConcreteValue
+        }
+
+        @ContributesTo(AppScope::class, replaces = [QualifiedAccessors::class])
+        interface RemoveOverride
+
+        @ContributesTo(AppScope::class)
+        interface ValueBindings {
+          @Provides @Device fun concreteValue(): ConcreteValue = ConcreteValue()
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    val appFile =
+      fixture.addFileToProject(
+        "app/abstractoverrides/app/Graphs.kt",
+        """
+        package abstractoverrides.app
+
+        import dev.zacsweers.metro.*
+        import abstractoverrides.api.*
+        import abstractoverrides.impl.*
+
+        @DependencyGraph(AppScope::class, excludes = [RemoveOverride::class])
+        interface AppGraph
+
+        @DependencyGraph(
+          AppScope::class,
+          excludes = [QualifiedAccessors::class, RemoveOverride::class],
+        )
+        interface ExcludedGraph
+
+        @DependencyGraph(AppScope::class)
+        interface ReplacedGraph
+
+        @DependencyGraph(AppScope::class, excludes = [RemoveOverride::class])
+        interface UnrelatedGraph {
+          val unrelated: Value
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    val appModule = checkNotNull(ModuleUtilCore.findModuleForPsiElement(appFile))
+    ModuleRootModificationUtil.addDependency(
+      appModule,
+      checkNotNull(ModuleUtilCore.findModuleForPsiElement(implementationFile)),
+    )
+    PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
+    IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
+
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
+    val validation = fixture.project.service<MetroGraphValidationService>()
+    fun context(name: String) = index.contextsFor(index.graphs.single { it.name == name }).single()
+    fun accessors(name: String) =
+      index.accessorsFor(checkNotNull(index.queryContext(context(name))))
+
+    val effectiveAccessor = accessors("AppGraph").single()
+    assertEquals("abstractoverrides.api.ConcreteValue", effectiveAccessor.key.renderedType)
+    assertSame(implementationFile, effectiveAccessor.pointer.element?.containingFile)
+    val completed = validation.validate(appFile, context("AppGraph")).requireCompleted()
+    assertTrue(completed.diagnostics.joinToString { it.render() }, completed.diagnostics.isEmpty())
+
+    for (graphName in listOf("ExcludedGraph", "ReplacedGraph")) {
+      val accessor = accessors(graphName).single()
+      assertSame(apiFile, accessor.pointer.element?.containingFile)
+      val result = validation.validate(appFile, context(graphName)).requireCompleted()
+      assertEquals(listOf(MetroDiagnosticId.MISSING_BINDING), result.diagnostics.map { it.id })
+    }
+
+    assertEquals(2, accessors("UnrelatedGraph").size)
+    val unrelated = validation.validate(appFile, context("UnrelatedGraph")).requireCompleted()
+    assertEquals(listOf(MetroDiagnosticId.MISSING_BINDING), unrelated.diagnostics.map { it.id })
+    assertTrue(unrelated.diagnostics.single().render().contains("unrelated"))
+  }
+
+  /** Written overrides narrow generic inherited accessors before graph validation. */
+  fun testWrittenAbstractCovariantOverrideKeepsEffectiveAccessor() {
+    fixture.addFileToProject(
+      "library/writtenoverrides/api/Accessors.kt",
+      """
+      package writtenoverrides.api
+
+      interface Value
+      class ConcreteValue : Value
+      interface PublicAccessors<T> {
+        val value: T
+      }
+      """
+        .trimIndent(),
+    )
+    val appFile =
+      fixture.addFileToProject(
+        "app/writtenoverrides/app/Graph.kt",
+        """
+        package writtenoverrides.app
+
+        import dev.zacsweers.metro.*
+        import writtenoverrides.api.*
+
+        interface NarrowAccessors : PublicAccessors<Value> {
+          override val value: ConcreteValue
+        }
+
+        @DependencyGraph
+        interface AppGraph : NarrowAccessors {
+          @Provides fun concreteValue(): ConcreteValue = ConcreteValue()
+        }
+        """
+          .trimIndent(),
+      ) as KtFile
+    PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
+    IndexingTestUtil.waitUntilIndexesAreReady(fixture.project)
+
+    val index = fixture.project.service<MetroResolutionService>().awaitIndex(appFile)
+    val context = index.contextsFor(index.graphs.single { it.name == "AppGraph" }).single()
+    val accessor = index.accessorsFor(checkNotNull(index.queryContext(context))).single()
+    assertEquals("writtenoverrides.api.ConcreteValue", accessor.key.renderedType)
+    assertSame(appFile, accessor.pointer.element?.containingFile)
+    val result =
+      fixture.project
+        .service<MetroGraphValidationService>()
+        .validate(appFile, context)
+        .requireCompleted()
+    assertTrue(result.diagnostics.joinToString { it.render() }, result.diagnostics.isEmpty())
+  }
+
   fun testWrittenDefaultOverridesAndOptionalRootsRemainDistinct() {
     fixture.addFileToProject(
       "library/defaultroots/api/Accessors.kt",

--- a/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
+++ b/idea-plugin/src/test/kotlin/dev/zacsweers/metro/idea/MetroResolutionServiceTest.kt
@@ -8394,8 +8394,9 @@ class MetroResolutionServiceTest : BasePlatformTestCase() {
     val child = index.graphEntryAt(declarations.klass("ChildGraph"))!!
     val queryContext = index.queryContext(index.contextsFor(child).single())!!
 
+    // The child owns this request even though the parent binding has a higher rank.
     assertEquals(
-      setOf("ParentService", "ChildService"),
+      setOf("ChildService"),
       index.bindingsFor(accessor, queryContext).mapTo(mutableSetOf()) { it.implementationName },
     )
     assertEquals(


### PR DESCRIPTION
Validation could report duplicate bindings when a nearer parent graph provided the requested type. It could also reject valid scoped bindings in sets and maps and request an inherited accessor's old type after an override.